### PR TITLE
Enable CI

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,7 @@
 (lang dune 2.7)
 (name uring)
 (generate_opam_files true)
+(formatting disabled)
 (source (github ocaml-multicore/ocaml-uring))
 (license ISC)
 (authors "Anil Madhavapeddy" "Sadiq Jaffer")

--- a/tests/dune
+++ b/tests/dune
@@ -43,5 +43,10 @@
 
 (rule
  (alias runtest)
+ (deps test.txt)
+ (action (run ./basic_file_read.exe)))
+
+(rule
+ (alias runbenchmark)
  (deps urcp.exe)
  (action (run ./cptest.exe ./urcp.exe)))

--- a/tests/test.txt
+++ b/tests/test.txt
@@ -1,0 +1,1 @@
+A test file

--- a/uring.opam
+++ b/uring.opam
@@ -36,3 +36,6 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/ocaml-uring.git"
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+]


### PR DESCRIPTION
I moved the benchmarks to `@runbenchmarks` (as they're very slow and don't need to run on each commit, I think), and used `basic_file_read` instead as the test. The CI machines were failing with `Unix.Unix_error(Unix.ENOMEM, "io_uring_register_buffers", "")`, which I fixed by increasing the locked-memory limit on the CI machines.