### PR TITLE
Add poll_add to wait for an FD to become ready

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+all:
+	dune build @check @runtest

--- a/dune-project
+++ b/dune-project
@@ -6,14 +6,13 @@
 (license ISC)
 (authors "Anil Madhavapeddy" "Sadiq Jaffer")
 (maintainers "anil@recoil.org")
-(package
- (name iovec)
- (synopsis "POSIX IO vectors"))
+(package (name iovec) (synopsis "POSIX IO vectors"))
 (package
  (name uring)
  (synopsis "OCaml bindings for Linux io_uring")
  (description "Bindings to the Linux io_uring kernel IO interfaces.")
  (depends
+  dune-configurator
   (lwt (>= 5.0.0))
   (notty (and (>= 0.2.2) :with-test))
   (bos (and (>= 0.2.0) :with-test))

--- a/lib/uring/dune
+++ b/lib/uring/dune
@@ -12,6 +12,10 @@
   (extra_deps include/liburing/compat.h)))
 
 (rule
+ (targets config.ml)
+ (action (run ./include/discover.exe)))
+
+(rule
  (deps
   (source_tree %{project_root}/vendor/liburing))
  (targets liburing.a dlluring.so barrier.h compat.h io_uring.h liburing.h)

--- a/lib/uring/include/discover.ml
+++ b/lib/uring/include/discover.ml
@@ -1,0 +1,17 @@
+module C = Configurator.V1
+
+let () =
+  C.main ~name:"discover" (fun c ->
+      C.C_define.import c ~includes:["poll.h"] C.C_define.Type.[
+          "POLLIN", Int;
+          "POLLOUT", Int;
+          "POLLERR", Int;
+          "POLLHUP", Int;
+        ]
+      |> List.map (function
+          | name, C.C_define.Value.Int v ->
+            Printf.sprintf "let %s = 0x%x" (String.lowercase_ascii name) v
+          | _ -> assert false
+        )
+      |> C.Flags.write_lines "config.ml"
+    )

--- a/lib/uring/include/dune
+++ b/lib/uring/include/dune
@@ -1,1 +1,6 @@
 (copy_files %{project_root}/vendor/liburing/src/include/liburing.h)
+
+(executable
+ (name discover)
+ (modules discover)
+ (libraries dune-configurator))

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -36,6 +36,27 @@ val queue_depth : 'a t -> int
 val exit : 'a t -> unit
 (** [exit t] will shut down the uring [t]. Any subsequent requests will fail. *)
 
+module Poll_mask : sig
+  type t = private int
+
+  val pollin  : t
+  val pollout : t
+  val pollerr : t
+  val pollhup : t
+
+  val of_int : int -> t
+  
+  val ( + ) : t -> t -> t
+  (** [a + b] is the union of the sets. *)
+
+  val mem : t -> t -> bool
+  (** [mem x flags] is [true] iff [x] is a subset of [flags]. *)
+end
+
+val poll_add : 'a t -> Unix.file_descr -> Poll_mask.t -> 'a -> bool
+(** [poll_add t fd mask d] will submit a [poll(2)] request to uring [t].
+    It completes and returns [d] when an event in [mask] is ready on [fd]. *)
+
 val readv : 'a t -> ?offset:int -> Unix.file_descr -> Iovec.t -> 'a -> bool
 (** [readv t ?offset fd iov d] will submit a [readv(2)] request to uring [t].
     It reads from absolute file [offset] on the [fd] file descriptor and writes

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -15,6 +15,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <endian.h>	/* liburing.h needs this for __BYTE_ORDER */
 #include <liburing.h>
 #include <caml/alloc.h>
 #include <caml/bigarray.h>
@@ -26,6 +27,7 @@
 #include <caml/signals.h>
 #include <caml/unixsupport.h>
 #include <string.h>
+#include <poll.h>
 
 #undef URING_DEBUG
 #ifdef URING_DEBUG
@@ -96,6 +98,19 @@ value ocaml_uring_exit(value v_uring) {
     Ring_val(v_uring) = NULL;
   }
   CAMLreturn(Val_unit);
+}
+
+value
+ocaml_uring_submit_poll_add(value v_uring, value v_fd, value v_id, value v_poll_mask) {
+  CAMLparam1(v_uring);
+  int poll_mask = Int_val(v_poll_mask);
+  struct io_uring *ring = Ring_val(v_uring);
+  struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
+  if (!sqe) CAMLreturn(Val_false);
+  dprintf("submit_poll_add: fd:%d mask:%x\n", Int_val(v_fd), poll_mask);
+  io_uring_prep_poll_add(sqe, Int_val(v_fd), poll_mask);
+  io_uring_sqe_set_data(sqe, (void *)(uintptr_t)Int_val(v_id)); /* TODO sort out cast */
+  CAMLreturn(Val_true);
 }
 
 value

--- a/tests/dune
+++ b/tests/dune
@@ -41,6 +41,11 @@
  (libraries bigstringaf unix uring alcotest))
 
 (executable
+ (name poll_add)
+ (modules poll_add)
+ (libraries unix uring alcotest logs logs.fmt))
+
+(executable
  (name cptest)
  (modules cptest)
  (libraries urcp_fixed_lib urcp_lib lwtcp_lib uring bos bechamel notty.unix
@@ -51,6 +56,11 @@
  (package uring)
  (deps test.txt)
  (action (run ./basic_file_read.exe)))
+
+(rule
+ (alias runtest)
+ (package uring)
+ (action (run ./poll_add.exe)))
 
 (rule
  (alias runbenchmark)

--- a/tests/poll_add.ml
+++ b/tests/poll_add.ml
@@ -1,0 +1,20 @@
+let () =
+  Logs.set_level (Some Logs.Debug);
+  Logs.set_reporter (Logs_fmt.reporter ())
+
+let () =
+  let t = Uring.create ~queue_depth:1 ~default:() () in
+  let readable, writable = Unix.pipe () in
+  let r = Uring.poll_add t readable Uring.Poll_mask.(pollin + pollerr) () in assert(r);
+  let res = Uring.submit t in
+  Printf.eprintf "submitted %d\n%!" res;
+  let sent = Unix.write writable (Bytes.of_string "!") 0 1 in
+  assert (sent = 1);
+  let rec retry () =
+    match Uring.wait t with
+    | None -> retry ()
+    | Some v -> v
+  in
+  let (), res = retry () in
+  Printf.eprintf "poll_add: %x\n%!" res;
+  ()

--- a/uring.opam
+++ b/uring.opam
@@ -9,6 +9,7 @@ homepage: "https://github.com/ocaml-multicore/ocaml-uring"
 bug-reports: "https://github.com/ocaml-multicore/ocaml-uring/issues"
 depends: [
   "dune" {>= "2.7"}
+  "dune-configurator"
   "lwt" {>= "5.0.0"}
   "notty" {>= "0.2.2" & with-test}
   "bos" {>= "0.2.0" & with-test}


### PR DESCRIPTION
This should make it easier to migrate to uring, since unsupported operations can be handled by waiting for the FD to become ready and then performing a normal syscall.