### PR TITLE
Re-implement the user_data heap

### DIFF
--- a/bench/.ocamlformat
+++ b/bench/.ocamlformat
@@ -1,0 +1,4 @@
+enable
+profile = conventional
+break-infix = fit-or-vertical
+module-item-spacing = compact

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -1,7 +1,7 @@
 open Bechamel
 
 let noop_run queue_depth =
-  let t = Uring.create ~queue_depth ~default:(-1) () in
+  let t = Uring.create ~queue_depth () in
   Staged.stage (fun () ->
       for i = 1 to queue_depth do
         let r = Uring.noop t i in
@@ -10,7 +10,7 @@ let noop_run queue_depth =
       let submitted = Uring.submit t in
       assert (submitted = queue_depth);
       for _ = 1 to queue_depth do
-        ignore (Uring.wait t : _ option)
+        ignore (Uring.wait t : _ Uring.completion_option)
       done)
 
 let suite =

--- a/lib/uring/heap.ml
+++ b/lib/uring/heap.ml
@@ -1,0 +1,78 @@
+let ( = ) : int -> int -> bool = ( = )
+let ( <> ) : int -> int -> bool = ( <> )
+
+type ptr = int
+let null_ptr = -1
+let is_null x = x = null_ptr
+
+(* Free-list allocator *)
+type 'a t =
+  { data: 'a array
+  (* Pool of potentially-empty data slots. Invariant: an unfreed pointer [p]
+     into this array is valid if one of the following holds:
+
+     1. [is_null free_head];
+     2. [not (is_null free_head)
+         && free_head <> p
+         && is_null free_tail_relation.(p)].
+
+     Either all slots are occupied (1), or there's at least one free slot and
+     [p] is not one of them (2). *)
+  ; mutable free_head: ptr
+  ; free_tail_relation: ptr array
+  (* A linked list of free blocks, with [free_head] being the first element and
+     [free_tail_relation] mapping each free slot [p] to the next one (or
+     [null_ptr] if [p] is either not free or is the final slot).
+
+     Invariant: for all [p : ptr], either [is_null p] or [0 <= p < length]. The
+     user sees non-null pointers only. *)
+  ; max_size: int
+  }
+
+let create : type a. int -> a t =
+ fun n ->
+  if n < 0 || n > Sys.max_array_length then invalid_arg "Heap.create" ;
+  (* Every slot is free, and all but the last have a free successor. *)
+  let free_head = if n = 0 then null_ptr else 0 in
+  let free_tail_relation = Array.init n succ in
+  if n > 0 then free_tail_relation.(n - 1) <- null_ptr;
+  let data =
+    (* See invariants on {!t}, which ensure this data is never read. *)
+    Array.make n (Obj.magic `invalid : a)
+  in
+  { data; free_head; free_tail_relation; max_size = n }
+
+exception No_space
+
+let alloc t a =
+  let ptr = t.free_head in
+  if is_null ptr then raise No_space;
+  let next_head = t.free_tail_relation.(ptr) in
+  Array.unsafe_set t.free_tail_relation ptr null_ptr;
+  Array.unsafe_set t.data ptr a;
+  t.free_head <- next_head;
+  ptr
+
+let free : type a. a t -> ptr -> a =
+ fun t ptr ->
+  let () =
+    assert (not (is_null ptr)) (* [alloc] returns only valid pointers. *);
+    if ptr >= t.max_size then invalid_arg "Heap.free: invalid pointer";
+    let next_free = Array.unsafe_get t.free_tail_relation ptr in
+
+    if is_null t.free_head then
+      (* No free slots, so [ptr] is valid in [t.data]. Case (1) above. *)
+      assert (is_null next_free)
+
+    else if t.free_head <> ptr && is_null next_free then
+      (* One or more free slots, and [ptr] isn't one of them. Case (2) above. *)
+      Array.unsafe_set t.free_tail_relation ptr t.free_head
+
+    else invalid_arg "Heap.free: pointer already freed"
+  in
+  t.free_head <- ptr;
+  let datum = Array.unsafe_get t.data ptr in
+  (* Zero the freed slot. Since this value is now inaccessible (with [ptr] is
+      in the free list) we might as well let it be GCed. *)
+  Array.unsafe_set t.data ptr (Obj.magic `invalid : a);
+  datum

--- a/lib/uring/heap.ml
+++ b/lib/uring/heap.ml
@@ -2,77 +2,75 @@ let ( = ) : int -> int -> bool = ( = )
 let ( <> ) : int -> int -> bool = ( <> )
 
 type ptr = int
-let null_ptr = -1
-let is_null x = x = null_ptr
+let slot_taken = -1
+let free_list_nil = -2
 
 (* Free-list allocator *)
 type 'a t =
   { data: 'a array
   (* Pool of potentially-empty data slots. Invariant: an unfreed pointer [p]
-     into this array is valid if one of the following holds:
-
-     1. [is_null free_head];
-     2. [not (is_null free_head)
-         && free_head <> p
-         && is_null free_tail_relation.(p)].
-
-     Either all slots are occupied (1), or there's at least one free slot and
-     [p] is not one of them (2). *)
+     into this array is valid iff [free_tail_relation.(p) = slot_taken]. *)
   ; mutable free_head: ptr
   ; free_tail_relation: ptr array
-  (* A linked list of free blocks, with [free_head] being the first element and
-     [free_tail_relation] mapping each free slot [p] to the next one (or
-     [null_ptr] if [p] is either not free or is the final slot).
+  (* A linked list of pointers to free slots, with [free_head] being the first
+     element and [free_tail_relation] mapping each free slot to the next one.
+     Each entry [x] signals a state of the corresponding [data.(x)] slot:
 
-     Invariant: for all [p : ptr], either [is_null p] or [0 <= p < length]. The
-     user sees non-null pointers only. *)
-  ; max_size: int
+     - [x = slot_taken]: the data slot is taken;
+     - [x = free_list_nil]: the data slot is free, and is last to be allocated;
+     - [0 <= x < length]: the data slot is free, and will be allocated before
+       [free_tail_relation.(x)].
+
+     The user is given only pointers [p] such that [free_tail_relation.(p) =
+     slot_taken]. *)
+  ; length: int
   }
 
 let create : type a. int -> a t =
  fun n ->
   if n < 0 || n > Sys.max_array_length then invalid_arg "Heap.create" ;
   (* Every slot is free, and all but the last have a free successor. *)
-  let free_head = if n = 0 then null_ptr else 0 in
+  let free_head = if n = 0 then free_list_nil else 0 in
   let free_tail_relation = Array.init n succ in
-  if n > 0 then free_tail_relation.(n - 1) <- null_ptr;
+  if n > 0 then free_tail_relation.(n - 1) <- free_list_nil;
   let data =
-    (* See invariants on {!t}, which ensure this data is never read. *)
+    (* No slot in [free_tail_relation] is [slot_taken], so initial data is
+       inaccessible. *)
     Array.make n (Obj.magic `invalid : a)
   in
-  { data; free_head; free_tail_relation; max_size = n }
+  { data; free_head; free_tail_relation; length = n }
 
 exception No_space
 
 let alloc t a =
   let ptr = t.free_head in
-  if is_null ptr then raise No_space;
-  let next_head = t.free_tail_relation.(ptr) in
-  Array.unsafe_set t.free_tail_relation ptr null_ptr;
+  if ptr = free_list_nil then raise No_space;
   Array.unsafe_set t.data ptr a;
-  t.free_head <- next_head;
+
+  (* Drop [ptr] from the free list. *)
+  let tail = Array.unsafe_get t.free_tail_relation ptr in
+  Array.unsafe_set t.free_tail_relation ptr slot_taken;
+  t.free_head <- tail;
+
   ptr
 
 let free : type a. a t -> ptr -> a =
  fun t ptr ->
-  let () =
-    assert (not (is_null ptr)) (* [alloc] returns only valid pointers. *);
-    if ptr >= t.max_size then invalid_arg "Heap.free: invalid pointer";
-    let next_free = Array.unsafe_get t.free_tail_relation ptr in
+  assert (ptr >= 0) (* [alloc] returns only valid pointers. *);
+  if ptr >= t.length then Fmt.invalid_arg "Heap.free: invalid pointer %d" ptr;
+  let slot_state = Array.unsafe_get t.free_tail_relation ptr in
+  if slot_state <> slot_taken then invalid_arg "Heap.free: pointer already freed";
 
-    if is_null t.free_head then
-      (* No free slots, so [ptr] is valid in [t.data]. Case (1) above. *)
-      assert (is_null next_free)
-
-    else if t.free_head <> ptr && is_null next_free then
-      (* One or more free slots, and [ptr] isn't one of them. Case (2) above. *)
-      Array.unsafe_set t.free_tail_relation ptr t.free_head
-
-    else invalid_arg "Heap.free: pointer already freed"
-  in
-  t.free_head <- ptr;
+  (* [t.free_tail_relation.(ptr) = slot_taken], so [t.data.(ptr)] is valid. *)
   let datum = Array.unsafe_get t.data ptr in
-  (* Zero the freed slot. Since this value is now inaccessible (with [ptr] is
-      in the free list) we might as well let it be GCed. *)
+
+  (* Cons [ptr] to the free-list. *)
+  Array.unsafe_set t.free_tail_relation ptr t.free_head;
+  t.free_head <- ptr;
+
+  (* We've marked this slot as free, so [t.data.(ptr)] is inaccessible. We zero
+     it to allow it to be GC-ed. *)
+  assert (t.free_tail_relation.(ptr) <> slot_taken);
   Array.unsafe_set t.data ptr (Obj.magic `invalid : a);
+
   datum

--- a/lib/uring/heap.ml
+++ b/lib/uring/heap.ml
@@ -1,3 +1,19 @@
+(*
+ * Copyright (c) 2021 Craig Ferguson <me@craigfe.io>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
 let ( = ) : int -> int -> bool = ( = )
 let ( <> ) : int -> int -> bool = ( <> )
 

--- a/lib/uring/heap.mli
+++ b/lib/uring/heap.mli
@@ -1,0 +1,18 @@
+type 'a t
+(** A bounded heap of values of type ['a]. *)
+
+val create : int -> _ t
+(** [create n] is a heap that holds at most [n] elements. *)
+
+type ptr = private int
+(** A pointer to an element in a heap. *)
+
+exception No_space
+
+val alloc : 'a t -> 'a -> ptr
+(** [alloc t a] adds the value [a] to [t] and returns a pointer to that value,
+    or raises {!No_space} if no space exists in [t]. *)
+
+val free : 'a t -> ptr -> 'a
+(** [free t p] returns the element referenced by [p] and removes it from the
+    heap. Has undefined behaviour if [p] has already been freed. *)

--- a/lib/uring/heap.mli
+++ b/lib/uring/heap.mli
@@ -1,3 +1,19 @@
+(*
+ * Copyright (c) 2021 Craig Ferguson <me@craigfe.io>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
 type 'a t
 (** A bounded heap of values of type ['a]. *)
 

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -60,6 +60,7 @@ module Uring = struct
   type cqe_option = private
     | Cqe_none
     | Cqe_some of { user_data_id : id; res: int }
+  [@@ocaml.warning "-37" (* Avoids "Unused constructor" warning on OCaml <= 4.09. *)]
 
   external wait_cqe : t -> cqe_option = "ocaml_uring_wait_cqe"
   external wait_cqe_timeout : float -> t -> cqe_option = "ocaml_uring_wait_cqe_timeout"

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -133,7 +133,7 @@ let submit t =
   end else
     0
 
- type 'a completion_option =
+type 'a completion_option =
   | None
   | Some of { result: int; data: 'a }
 

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -14,8 +14,12 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Int63 = Optint.Int63
+module Private = struct
+  module Heap = Heap
+end
+
 module Region = Region
+module Int63 = Optint.Int63
 
 module Poll_mask = struct
   type t = int
@@ -42,7 +46,7 @@ module Uring = struct
   external register_bigarray : t ->  Iovec.Buffer.t -> unit = "ocaml_uring_register_ba"
   external submit : t -> int = "ocaml_uring_submit"
 
-  type id = int
+  type id = Heap.ptr
   type offset = Optint.Int63.t
   external submit_nop : t -> id -> bool = "ocaml_uring_submit_nop" [@@noalloc]
   external submit_poll_add : t -> Unix.file_descr -> id -> Poll_mask.t -> bool = "ocaml_uring_submit_poll_add" [@@noalloc]
@@ -62,24 +66,22 @@ end
 type 'a t = {
   uring: Uring.t;
   mutable fixed_iobuf: Iovec.Buffer.t;
-  mutable id_freelist: int list;
-  user_data: 'a array;
+  user_data : 'a Heap.t;
   queue_depth: int;
   mutable dirty: bool; (* has outstanding requests that need to be submitted *)
 }
 
 let default_iobuf_len = 1024 * 1024 (* 1MB *)
 
-let create ?(fixed_buf_len=default_iobuf_len) ~queue_depth ~default () =
+let create ?(fixed_buf_len=default_iobuf_len) ~queue_depth () =
   if queue_depth < 1 then Fmt.invalid_arg "Non-positive queue depth: %d" queue_depth;
   let uring = Uring.create queue_depth in
   (* TODO posix memalign this to page *)
   let fixed_iobuf = Iovec.Buffer.create fixed_buf_len in
   Uring.register_bigarray uring fixed_iobuf;
   Gc.finalise Uring.exit uring;
-  let id_freelist = List.init queue_depth (fun i -> i) in
-  let user_data = Array.init queue_depth (fun _ -> default) in
-  { uring; fixed_iobuf; id_freelist; user_data; dirty=false; queue_depth }
+  let user_data = Heap.create queue_depth in
+  { uring; fixed_iobuf; user_data; dirty=false; queue_depth }
 
 let realloc t iobuf =
   Uring.unregister_bigarray t.uring;
@@ -88,23 +90,14 @@ let realloc t iobuf =
 
 let exit {uring;_} = Uring.exit uring
 
-let get_id t =
-  match t.id_freelist with
-  | [] -> raise Not_found
-  | hd::tl -> t.id_freelist <- tl; hd
-
-let put_id t v =
-  t.id_freelist <- v :: t.id_freelist
-
-let with_id t fn user_data =
-  match get_id t with
-  | id ->
-     if fn id then begin
-       t.dirty <- true;
-       t.user_data.(id) <- user_data;
-       true
-     end else false
-  | exception Not_found -> false
+let with_id : type a. a t -> (Heap.ptr -> bool) -> a -> bool =
+ fun t fn datum ->
+  match Heap.alloc t.user_data datum with
+  | exception Heap.No_space -> false
+  | ptr ->
+     let has_space = fn ptr in
+     if has_space then t.dirty <- true else ignore (Heap.free t.user_data ptr : a);
+     has_space
 
 let noop t user_data =
   with_id t (fun id -> Uring.submit_nop t.uring id) user_data
@@ -142,16 +135,15 @@ type 'a completion_option =
 let errno_is_retry = function -62 | -11 | -4 -> true |_ -> false
 
 let fn_on_ring fn t =
-   let id, res = fn t.uring in
-   match id, res with
+   let (id : Heap.ptr), res = fn t.uring in
+   match (id :> int), res with
    | -1, res when errno_is_retry res ->
      None
    | -1, res when res < 0 ->
      failwith ("wait error " ^ (string_of_int res))
      (* TODO switch to unixsupport.h to raise Unix_error *)
-   | id, res ->
-     let data = t.user_data.(id) in
-     put_id t id;
+   | _, res ->
+     let data = Heap.free t.user_data id in
      Some { result = res; data }
 
 let peek t = fn_on_ring Uring.peek_cqe t

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -24,11 +24,11 @@ module Region = Region
 type 'a t
 (** ['a t] is a reference to an Io_uring structure. *)
 
-val create : ?fixed_buf_len:int -> queue_depth:int -> default:'a -> unit -> 'a t
-(** [create ?fixed_buf_len ~queue_depth ~default] will return a fresh
-    Io_uring structure [t].  Each [t] has associated with it a fixed region of
-    memory that is used for the "fixed buffer" mode of io_uring to avoid data
-    copying between userspace and the kernel. *)
+val create : ?fixed_buf_len:int -> queue_depth:int -> unit -> 'a t
+(** [create ?fixed_buf_len ~queue_depth] will return a fresh Io_uring structure
+    [t]. Each [t] has associated with it a fixed region of memory that is used
+    for the "fixed buffer" mode of io_uring to avoid data copying between
+    userspace and the kernel. *)
 
 val queue_depth : 'a t -> int
 (** [queue_depth t] returns the total number of submission slots for the uring [t] *)
@@ -127,3 +127,6 @@ val peek : 'a t -> 'a completion_option
 val error_of_errno : int -> Unix.error
 (** [error_of_errno e] converts the error code [abs e] to a Unix error type. *)
 
+module Private : sig
+  module Heap = Heap
+end

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -234,7 +234,7 @@ value ocaml_uring_submit(value v_uring)
 static value Val_cqe_some(value id, value res) {
   CAMLparam2(id, res);
   CAMLlocal1(some);
-  some = caml_alloc(3, 0);
+  some = caml_alloc(2, 0);
   Store_field(some, 0, id);
   Store_field(some, 1, res);
   CAMLreturn(some);

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -26,6 +26,7 @@
 #include <caml/mlvalues.h>
 #include <caml/signals.h>
 #include <caml/unixsupport.h>
+#include <errno.h>
 #include <string.h>
 #include <poll.h>
 
@@ -228,6 +229,17 @@ value ocaml_uring_submit(value v_uring)
   CAMLreturn(Val_int(num));
 }
 
+#define Val_cqe_none Val_int(0)
+
+static value Val_cqe_some(value id, value res) {
+  CAMLparam2(id, res);
+  CAMLlocal1(some);
+  some = caml_alloc(3, 0);
+  Store_field(some, 0, id);
+  Store_field(some, 1, res);
+  CAMLreturn(some);
+}
+
 value ocaml_uring_wait_cqe_timeout(value v_timeout, value v_uring)
 {
   CAMLparam2(v_uring, v_timeout);
@@ -243,17 +255,16 @@ value ocaml_uring_wait_cqe_timeout(value v_timeout, value v_uring)
   dprintf("cqe: waiting, timeout %fs\n", timeout);
   res = io_uring_wait_cqe_timeout(ring, &cqe, &t);
   if (res < 0) {
-    v_ret = caml_alloc(2, 0);
-    Store_field(v_ret, 0, Val_int(-1));
-    Store_field(v_ret, 1, Val_int(res));
+    if (res == -EAGAIN || res == -EINTR || res == -ETIME) {
+      CAMLreturn(Val_cqe_none);
+    } else {
+      unix_error(-res, "io_uring_wait_cqe_timeout", Nothing);
+    }
   } else {
     id = (long)io_uring_cqe_get_data(cqe);
     io_uring_cqe_seen(ring, cqe);
-    v_ret = caml_alloc(2, 0);
-    Store_field(v_ret, 0, Val_int(id));
-    Store_field(v_ret, 1, Val_int(cqe->res));
+    CAMLreturn(Val_cqe_some(Val_int(id), Val_int(cqe->res)));
   }
-  CAMLreturn(v_ret);
 }
 
 value ocaml_uring_wait_cqe(value v_uring)
@@ -267,17 +278,16 @@ value ocaml_uring_wait_cqe(value v_uring)
   dprintf("cqe: waiting\n");
   res = io_uring_wait_cqe(ring, &cqe);
   if (res < 0) {
-    v_ret = caml_alloc(2, 0);
-    Store_field(v_ret, 0, Val_int(-1));
-    Store_field(v_ret, 1, Val_int(res));
+    if (res == -EAGAIN || res == -EINTR) {
+      CAMLreturn(Val_cqe_none);
+    } else {
+      unix_error(-res, "io_uring_wait_cqe", Nothing);
+    }
   } else {
     id = (long)io_uring_cqe_get_data(cqe);
     io_uring_cqe_seen(ring, cqe);
-    v_ret = caml_alloc(2, 0);
-    Store_field(v_ret, 0, Val_int(id));
-    Store_field(v_ret, 1, Val_int(cqe->res));
+    CAMLreturn(Val_cqe_some(Val_int(id), Val_int(cqe->res)));
   }
-  CAMLreturn(v_ret);
 }
 
 value ocaml_uring_peek_cqe(value v_uring)
@@ -291,17 +301,16 @@ value ocaml_uring_peek_cqe(value v_uring)
   dprintf("cqe: peeking\n");
   res = io_uring_peek_cqe(ring, &cqe);
   if (res < 0) {
-    v_ret = caml_alloc(2, 0);
-    Store_field(v_ret, 0, Val_int(-1));
-    Store_field(v_ret, 1, Val_int(res));
+    if (res == -EAGAIN || res == -EINTR) {
+      CAMLreturn(Val_cqe_none);
+    } else {
+      unix_error(-res, "io_uring_peek_cqe", Nothing);
+    }
   } else {
     id = (long)io_uring_cqe_get_data(cqe);
     io_uring_cqe_seen(ring, cqe);
-    v_ret = caml_alloc(2, 0);
-    Store_field(v_ret, 0, Val_int(id));
-    Store_field(v_ret, 1, Val_int(cqe->res));
+    CAMLreturn(Val_cqe_some(Val_int(id), Val_int(cqe->res)));
   }
-  CAMLreturn(v_ret);
 }
 
 // Allocates

--- a/tests/main.ml
+++ b/tests/main.ml
@@ -1,8 +1,68 @@
 module Int63 = Optint.Int63
 
 let assert_      ~__POS__ = Alcotest.(check ~pos:__POS__ bool) "" true
+let check_raises ~__POS__ = Alcotest.check_raises ~pos:__POS__ ""
 let check_int    ~__POS__ ~expected = Alcotest.(check ~pos:__POS__ int) "" expected
 let check_string ~__POS__ ~expected = Alcotest.(check ~pos:__POS__ string) "" expected
+
+module Heap = struct
+  module Heap = Uring.Private.Heap
+
+  let test_basic () =
+    let t = Heap.create 10 in
+    let p1 = Heap.alloc t 1 in
+    let p2 = Heap.alloc t 2 in
+    check_int ~__POS__ ~expected:2 (Heap.free t p2);
+    check_int ~__POS__ ~expected:1 (Heap.free t p1)
+
+  let test_double_free () =
+    let () =
+      (* Double free in an empty heap *)
+      let t = Heap.create 1 in
+      let p = Heap.alloc t 1 in
+      check_int ~__POS__ ~expected:1 (Heap.free t p);
+      check_raises ~__POS__ (Invalid_argument "Heap.free: pointer already freed")
+        (fun () -> ignore (Heap.free t p))
+    in
+    let () =
+      (* Double free in a non-empty heap *)
+      let t = Heap.create 2 in
+      let p = Heap.alloc t 1 in
+      let _ = Heap.alloc t 2 in
+      check_int ~__POS__ ~expected:1 (Heap.free t p);
+      check_raises ~__POS__ (Invalid_argument "Heap.free: pointer already freed")
+        (fun () -> ignore (Heap.free t p))
+    in
+    ()
+
+  let test_out_of_space () =
+    let check_raises_no_space ~__POS__:pos f =
+      Alcotest.check_raises ~pos "" Heap.No_space (fun () -> ignore (f ()))
+    in
+    let () =
+      let t = Heap.create 0 in
+      (* 1 > 0 *)
+      check_raises_no_space ~__POS__ (fun () -> Heap.alloc t ())
+    in
+    let () =
+      let t = Heap.create 2 in
+      let _ : Heap.ptr = Heap.alloc t () in
+      let _ : Heap.ptr = Heap.alloc t () in
+      (* 3 > 2 *)
+      check_raises_no_space ~__POS__ (fun () -> Heap.alloc t ())
+    in
+    let () =
+      let t = Heap.create 3 in
+      let p1 = Heap.alloc t 1 in
+      let _ : Heap.ptr = Heap.alloc t 2 in
+      check_int ~__POS__ ~expected:1 (Heap.free t p1);
+      let _ : Heap.ptr = Heap.alloc t 3 in
+      let _ : Heap.ptr = Heap.alloc t 4 in
+      (* 2 - 1 + 2 > 3 *)
+      check_raises_no_space ~__POS__ (fun () -> Heap.alloc t 5);
+    in
+    ()
+end
 
 module Test_data = struct
   let path = "output_file.txt"
@@ -25,12 +85,12 @@ let rec consume t =
   | None -> consume t
 
 let test_invalid_queue_depth () =
-  Alcotest.check_raises "" (Invalid_argument "Non-positive queue depth: 0")
-    (fun () -> ignore (Uring.create ~queue_depth:0 ~default:() ()))
+  check_raises ~__POS__ (Invalid_argument "Non-positive queue depth: 0")
+    (fun () -> ignore (Uring.create ~queue_depth:0 ()))
 
 let test_noop () =
   let queue_depth = 5 in
-  let t = Uring.create ~queue_depth ~default:0 () in
+  let t = Uring.create ~queue_depth () in
 
   for i = 1 to queue_depth do
     assert_ ~__POS__ (Uring.noop t i);
@@ -45,7 +105,7 @@ let test_noop () =
   done
 
 let test_read () =
-  let t = Uring.create ~queue_depth:1 ~default:`Unused () in
+  let t = Uring.create ~queue_depth:1 () in
   Test_data.with_fd @@ fun fd ->
 
   let off = 3 in
@@ -63,7 +123,7 @@ let test_read () =
     (Bigstringaf.substring fbuf ~off ~len)
 
 let test_readv () =
-  let t = Uring.create ~queue_depth:1 ~default:`Unused () in
+  let t = Uring.create ~queue_depth:1 () in
   Test_data.with_fd @@ fun fd ->
 
   let b1_len = 3 and b2_len = 7 in
@@ -83,10 +143,17 @@ let test_readv () =
 let () =
   Test_data.setup ();
   let tc name f = Alcotest.test_case name `Quick f in
-  Alcotest.run __FILE__ [ "uring", [
+  Alcotest.run __FILE__ [
+    "heap", [
+      tc "" Heap.test_basic;
+      tc "double_free" Heap.test_double_free;
+      tc "out_of_space" Heap.test_out_of_space;
+    ];
+    "uring", [
       tc "invalid_queue_depth" test_invalid_queue_depth;
       tc "noop" test_noop;
       tc "read" test_read;
       tc "readv" test_readv;
-    ] ]
+    ];
+  ]
 

--- a/tests/main.ml
+++ b/tests/main.ml
@@ -37,7 +37,8 @@ module Heap = struct
         else
           let data = Random.int 5000 in
           let ptr = Heap.alloc t data in
-          Hashtbl.replace reference ptr data;
+          assert_ ~__POS__ (not (Hashtbl.mem reference ptr));
+          Hashtbl.add reference ptr data;
           incr currently_allocated
       | false ->
         let (k, v) = random_hashtbl_elt reference in

--- a/tests/poll_add.ml
+++ b/tests/poll_add.ml
@@ -3,7 +3,7 @@ let () =
   Logs.set_reporter (Logs_fmt.reporter ())
 
 let () =
-  let t = Uring.create ~queue_depth:1 ~default:() () in
+  let t = Uring.create ~queue_depth:1 () in
   let readable, writable = Unix.pipe () in
   let r = Uring.poll_add t readable Uring.Poll_mask.(pollin + pollerr) () in assert(r);
   let res = Uring.submit t in

--- a/tests/urcat.ml
+++ b/tests/urcat.ml
@@ -43,6 +43,6 @@ let submit_read_request fname uring =
 
 let () =
    let fname = Sys.argv.(1) in
-   let uring = Uring.create ~queue_depth:1 ~default:Iovec.empty () in
+   let uring = Uring.create ~queue_depth:1 () in
    submit_read_request fname uring;
    get_completion_and_print uring

--- a/tests/urcp_fixed_lib.ml
+++ b/tests/urcp_fixed_lib.ml
@@ -38,8 +38,6 @@ type req = {
 let pp_req ppf {op; len; off; fixed_off; fileoff; t; _ } =
   Fmt.pf ppf "[%s fileoff %a len %d off %d fixedoff %d] [%a]" (match op with |`R -> "r" |`W -> "w") Int63.pp fileoff len off fixed_off pp t
 
-let empty_req t = { op=`R; fixed_off=0; len=0; off=0; fileoff=Int63.zero; t}
-
 (* Perform a complete read into bufs. *)
 let queue_read uring t len =
   let fixed_off = Queue.pop t.freelist in
@@ -160,7 +158,7 @@ let run_cp block_size queue_depth infile outfile () =
    let t = { freelist; block_size; insize; offset=Int63.zero; reads=0; writes=0; write_left=insize; read_left=insize; infd; outfd } in
    Logs.debug (fun l -> l "starting: %a bs=%d qd=%d" pp t block_size queue_depth);
    let fixed_buf_len = queue_depth * block_size in
-   let uring = Uring.create ~fixed_buf_len ~queue_depth ~default:(empty_req t) () in
+   let uring = Uring.create ~fixed_buf_len ~queue_depth () in
    copy_file uring t;
    Unix.close infd;
    Unix.close outfd;

--- a/tests/urcp_lib.ml
+++ b/tests/urcp_lib.ml
@@ -37,8 +37,6 @@ type req = {
 let pp_req ppf {op; len; off; fileoff; t; _ } =
   Fmt.pf ppf "[%s fileoff %a len %d off %d] [%a]" (match op with |`R -> "r" |`W -> "w") Int63.pp fileoff len off pp t
 
-let empty_req t = { op=`R; iov=Iovec.empty; len=0; off=0; fileoff=Int63.zero; t}
-
 (* Perform a complete read into bufs. *)
 let queue_read uring t len =
   let ba = Iovec.Buffer.create len in
@@ -158,7 +156,7 @@ let run_cp block_size queue_depth infile outfile () =
    let insize = get_file_size infd in
    let t = { block_size; insize; offset=Int63.zero; reads=0; writes=0; write_left=insize; read_left=insize; infd; outfd } in
    Logs.debug (fun l -> l "starting: %a bs=%d qd=%d" pp t block_size queue_depth);
-   let uring = Uring.create ~queue_depth ~default:(empty_req t) () in
+   let uring = Uring.create ~queue_depth () in
    copy_file uring t;
    Unix.close infd;
    Unix.close outfd;


### PR DESCRIPTION
In benchmarking Uring + Index, I noticed that large buffers were being held hostage by the `user_data` array, which doesn't drop user data after it has been returned.

This PR replaces the existing free-list allocator with one that doesn't leak memory. Fortunately, the approach used to avoid memory leaks also ensures that it's safe to not require dummy user data when first constructing a uring, so we can get rid of that.