### PR TITLE
Switch file offsets to use 63-bit integers

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -22,4 +22,5 @@
   cmdliner
   (fmt (>= 0.8.4))
   bigstringaf
+  (optint (>= 0.1.0))
   (alcotest (and (>= 1.4.0) :with-test))))

--- a/lib/uring/dune
+++ b/lib/uring/dune
@@ -2,7 +2,7 @@
  (name uring)
  (public_name uring)
  (foreign_archives uring)
- (libraries bigstringaf iovec fmt)
+ (libraries bigstringaf iovec fmt optint)
  (foreign_stubs
   (language c)
   (flags

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -71,26 +71,28 @@ val poll_add : 'a t -> Unix.file_descr -> Poll_mask.t -> 'a -> bool
 (** [poll_add t fd mask d] will submit a [poll(2)] request to uring [t].
     It completes and returns [d] when an event in [mask] is ready on [fd]. *)
 
-val readv : 'a t -> ?offset:int -> Unix.file_descr -> Iovec.t -> 'a -> bool
+type offset := Optint.Int63.t
+
+val readv : 'a t -> ?offset:offset -> Unix.file_descr -> Iovec.t -> 'a -> bool
 (** [readv t ?offset fd iov d] will submit a [readv(2)] request to uring [t].
     It reads from absolute file [offset] on the [fd] file descriptor and writes
     the results into the memory pointed to by [iov].  The user data [d] will
     be returned by {!wait} or {!peek} upon completion. *)
 
-val writev : 'a t -> ?offset:int -> Unix.file_descr -> Iovec.t -> 'a -> bool
+val writev : 'a t -> ?offset:offset -> Unix.file_descr -> Iovec.t -> 'a -> bool
 (** [writev t ?offset fd iov d] will submit a [writev(2)] request to uring [t].
     It writes to absolute file [offset] on the [fd] file descriptor from the
     the memory pointed to by [iov].  The user data [d] will be returned by
     {!wait} or {!peek} upon completion. *)
 
-val read : 'a t -> ?file_offset:int -> Unix.file_descr -> int -> int -> 'a -> bool
+val read : 'a t -> ?file_offset:offset -> Unix.file_descr -> int -> int -> 'a -> bool
 (** [read t ?file_offset fd off d] will submit a [read(2)] request to uring [t].
     It read from absolute [file_offset] on the [fd] file descriptor and writes
     the results into the fixed memory buffer associated with uring [t] at offset
     [off]. TODO: replace [off] with {!Region.chunk} instead?
     The user data [d] will be returned by {!wait} or {!peek} upon completion. *)
 
-val write : 'a t -> ?file_offset:int -> Unix.file_descr -> int -> int -> 'a -> bool
+val write : 'a t -> ?file_offset:offset -> Unix.file_descr -> int -> int -> 'a -> bool
 (** [write t ?file_offset fd off d] will submit a [write(2)] request to uring [t].
     It writes into absolute [file_offset] on the [fd] file descriptor from
     the fixed memory buffer associated with uring [t] at offset [off].

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -36,6 +36,13 @@
 #define dprintf(fmt, ...) ((void)0)
 #endif
 
+// TODO: this belongs in Optint
+#ifdef ARCH_SIXTYFOUR
+#define Int63_val(v) Long_val(v)
+#else
+#define Int63_val(v) (Int64_val(v)) >> 1
+#endif
+
 #define Ring_val(v) *((struct io_uring**)Data_custom_val(v))
 
 static struct custom_operations ring_ops = {
@@ -144,8 +151,8 @@ ocaml_uring_submit_readv(value v_uring, value v_fd, value v_id, value v_iov, val
   int len = Wosize_val(Field(v_iov, 1));
   struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
   if (!sqe) CAMLreturn(Val_false);
-  dprintf("submit_readv: %d ents len[0] %lu off %d\n", len, iovs[0].iov_len, Int_val(v_off));
-  io_uring_prep_readv(sqe, Int_val(v_fd), iovs, len, Int_val(v_off));
+  dprintf("submit_readv: %d ents len[0] %lu off %d\n", len, iovs[0].iov_len, Int63_val(v_off));
+  io_uring_prep_readv(sqe, Int_val(v_fd), iovs, len, Int63_val(v_off));
   io_uring_sqe_set_data(sqe, (void *)(uintptr_t)Int_val(v_id)); /* TODO sort out cast */
   CAMLreturn(Val_true);
 }
@@ -158,8 +165,8 @@ ocaml_uring_submit_writev(value v_uring, value v_fd, value v_id, value v_iov, va
   int len = Wosize_val(Field(v_iov, 1));
   struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
   if (!sqe) CAMLreturn(Val_false);
-  dprintf("submit_writev: %d ents len[0] %lu off %d\n", len, iovs[0].iov_len, Int_val(v_off));
-  io_uring_prep_writev(sqe, Int_val(v_fd), iovs, len, Int_val(v_off));
+  dprintf("submit_writev: %d ents len[0] %lu off %d\n", len, iovs[0].iov_len, Int63_val(v_off));
+  io_uring_prep_writev(sqe, Int_val(v_fd), iovs, len, Int63_val(v_off));
   io_uring_sqe_set_data(sqe, (void *)(uintptr_t)Int_val(v_id)); /* TODO sort out cast */
   CAMLreturn(Val_true);
 }
@@ -170,8 +177,8 @@ ocaml_uring_submit_readv_fixed_native(value v_uring, value v_fd, value v_id, val
   struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
   void *buf = Caml_ba_data_val(v_ba) + Long_val(v_off);
   if (!sqe) return Val_false;
-  dprintf("submit_readv_fixed: buf %p off %d len %d fileoff %d", buf, Int_val(v_off), Int_val(v_len), Int_val(v_fileoff));
-  io_uring_prep_read_fixed(sqe, Int_val(v_fd), buf, Int_val(v_len), Int_val(v_fileoff), 0);
+  dprintf("submit_readv_fixed: buf %p off %d len %d fileoff %d", buf, Int_val(v_off), Int_val(v_len), Int63_val(v_fileoff));
+  io_uring_prep_read_fixed(sqe, Int_val(v_fd), buf, Int_val(v_len), Int63_val(v_fileoff), 0);
   io_uring_sqe_set_data(sqe, (void *)(uintptr_t)Int_val(v_id)); /* TODO sort out cast */
   return Val_true;
 }
@@ -195,8 +202,8 @@ ocaml_uring_submit_writev_fixed_native(value v_uring, value v_fd, value v_id, va
   void *buf = Caml_ba_data_val(v_ba) + Long_val(v_off);
   if (!sqe)
     return Val_false;
-  dprintf("submit_writev_fixed: buf %p off %d len %d fileoff %d", buf, Int_val(v_off), Int_val(v_len), Int_val(v_fileoff));
-  io_uring_prep_write_fixed(sqe, Int_val(v_fd), buf, Int_val(v_len), Int_val(v_fileoff), 0);
+  dprintf("submit_writev_fixed: buf %p off %d len %d fileoff %d", buf, Int_val(v_off), Int_val(v_len), Int63_val(v_fileoff));
+  io_uring_prep_write_fixed(sqe, Int_val(v_fd), buf, Int_val(v_len), Int63_val(v_fileoff), 0);
   io_uring_sqe_set_data(sqe, (void *)(uintptr_t)Int_val(v_id)); /* TODO sort out cast */
   return Val_true;
 }

--- a/tests/dune
+++ b/tests/dune
@@ -2,7 +2,7 @@
  (name main)
  (modules main)
  (package uring)
- (libraries bigstringaf unix uring alcotest))
+ (libraries bigstringaf unix uring alcotest optint))
 
 (library
  (name urcp_lib)

--- a/tests/main.ml
+++ b/tests/main.ml
@@ -1,3 +1,5 @@
+module Int63 = Optint.Int63
+
 let assert_      ~__POS__ = Alcotest.(check ~pos:__POS__ bool) "" true
 let check_int    ~__POS__ ~expected = Alcotest.(check ~pos:__POS__ int) "" expected
 let check_string ~__POS__ ~expected = Alcotest.(check ~pos:__POS__ string) "" expected
@@ -48,7 +50,7 @@ let test_read () =
 
   let off = 3 in
   let len = 5 in
-  let file_offset = 2 in
+  let file_offset = Int63.of_int 2 in
   assert_   ~__POS__ (Uring.read t ~file_offset fd off len `Read);
   check_int ~__POS__ (Uring.submit t) ~expected:1;
 

--- a/uring.opam
+++ b/uring.opam
@@ -19,6 +19,7 @@ depends: [
   "cmdliner"
   "fmt" {>= "0.8.4"}
   "bigstringaf"
+  "optint" {>= "0.1.0"}
   "alcotest" {>= "1.4.0" & with-test}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Enables support for files larger than 4GB on 32-bit machines.