### PR TITLE
Use a more structured completion return type

### DIFF
--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -132,6 +132,10 @@ let submit t =
   end else
     0
 
+type 'a completion_option =
+  | None
+  | Some of { result: int; data: 'a }
+
 (* TODO use unixsupport.h *)
 let errno_is_retry = function -62 | -11 | -4 -> true |_ -> false
 
@@ -146,7 +150,7 @@ let fn_on_ring fn t =
    | id, res ->
      let data = t.user_data.(id) in
      put_id t id;
-     Some (data, res)
+     Some { result = res; data }
 
 let peek t = fn_on_ring Uring.peek_cqe t
 let wait ?timeout t =

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -106,17 +106,21 @@ val submit : 'a t -> int
     to the kernel. Their results can subsequently be retrieved using {!wait}
     or {!peek}. *)
 
-val wait : ?timeout:float -> 'a t -> ('a * int) option
-(** [wait ?timeout t] will block indefinitely (the default) or for [timeout]
-    seconds for any outstanding events to complete on uring [t].  Events should
-    have been queued via {!submit} previously to this call.
-    It returns the user data associated with the original request and the 
-    integer syscall result. TODO: replace int res with a GADT of the request type. *)
+type 'a completion_option =
+  | None
+  | Some of { result: int; data: 'a } (**)
+(** The type of results of calling {!wait} and {!peek}. [None] denotes that
+    either there were no completions in the queue or an interrupt / timeout
+    occurred. [Some] contains both the user data attached to the completed
+    request and the integer syscall result. *)
 
-val peek : 'a t -> ('a * int) option
-(** [peek t] looks for completed requests on the uring [t] without blocking.
-    It returns the user data associated with the original request and the 
-    integer syscall result. TODO: replace int res with a GADT of the request type. *)
+val wait : ?timeout:float -> 'a t -> 'a completion_option
+(** [wait ?timeout t] will block indefinitely (the default) or for [timeout]
+    seconds for any outstanding events to complete on uring [t]. Events should
+    have been queued via {!submit} previously to this call. *)
+
+val peek : 'a t -> 'a completion_option
+(** [peek t] looks for completed requests on the uring [t] without blocking. *)
 
 val error_of_errno : int -> Unix.error
 (** [error_of_errno e] converts the error code [abs e] to a Unix error type. *)

--- a/tests/main.ml
+++ b/tests/main.ml
@@ -19,7 +19,7 @@ end
 
 let rec consume t =
   match Uring.wait ~timeout:1. t with
-  | Some v -> v
+  | Some { data; result } -> (data, result)
   | None -> consume t
 
 let test_invalid_queue_depth () =

--- a/tests/poll_add.ml
+++ b/tests/poll_add.ml
@@ -13,8 +13,8 @@ let () =
   let rec retry () =
     match Uring.wait t with
     | None -> retry ()
-    | Some v -> v
+    | Some { result; _ } -> result
   in
-  let (), res = retry () in
+  let res = retry () in
   Printf.eprintf "poll_add: %x\n%!" res;
   ()

--- a/tests/urcat.ml
+++ b/tests/urcat.ml
@@ -9,7 +9,11 @@ let get_file_size fd =
 (* TODO make this work with ST_ISBLK *)
 
 let get_completion_and_print uring =
-  let iov, len = match Uring.wait uring with Some v -> v | None -> failwith "retry" in
+  let iov, len =
+    match Uring.wait uring with
+    | Some { data; result } -> (data, result)
+    | None -> failwith "retry"
+  in
   let bufs = Iovec.buffers iov in
   let remaining = ref len in
   Printf.eprintf "%d bytes read\n%!" len;

--- a/tests/urcp_fixed_lib.ml
+++ b/tests/urcp_fixed_lib.ml
@@ -138,8 +138,8 @@ let copy_file uring t =
         let check_q = if !got_completion then Uring.peek uring else Uring.wait uring  in
         match check_q with
         |None -> Logs.debug (fun l -> l "completions: retry so finishing loop")
-        |Some (req, res) ->  
-          handle_completion uring req res;
+        |Some { data; result } ->
+          handle_completion uring data result;
           got_completion := true;
           handle_completions ();
       end

--- a/tests/urcp_lib.ml
+++ b/tests/urcp_lib.ml
@@ -139,8 +139,8 @@ let copy_file uring t =
         let check_q = if !got_completion then Uring.peek uring else Uring.wait uring  in
         match check_q with
         |None -> Logs.debug (fun l -> l "completions: retry so finishing loop")
-        |Some (req, res) ->  
-          handle_completion uring req res;
+        |Some { data; result } ->
+          handle_completion uring data result;
           got_completion := true;
           handle_completions ();
       end


### PR DESCRIPTION
The current `(int * 'a) option` return type is a bit error-prone (and allocates an extra pair of words we probably don't need). Perhaps there are better names than "result" and "data" for these components?