### PR TITLE
Update benchmark to new API

### DIFF
--- a/bench/main.ml
+++ b/bench/main.ml
@@ -10,7 +10,7 @@ let noop_run queue_depth =
       let submitted = Uring.submit t in
       assert (submitted = queue_depth);
       for _ = 1 to queue_depth do
-        ignore (Uring.wait t : _ option)
+        ignore (Uring.wait t : _ Uring.completion_option)
       done)
 
 let suite =


### PR DESCRIPTION
This should fix CI, which is now failing due to the stricter check in https://github.com/ocurrent/ocaml-ci/pull/338.