### PR TITLE
Add splice and fix default offets for read/write

### DIFF
--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -51,6 +51,7 @@ module Uring = struct
   external submit_readv_fixed : t -> Unix.file_descr -> id -> Iovec.Buffer.t -> int -> int -> offset -> bool = "ocaml_uring_submit_readv_fixed_byte" "ocaml_uring_submit_readv_fixed_native" [@@noalloc]
   external submit_writev_fixed : t -> Unix.file_descr -> id -> Iovec.Buffer.t -> int -> int -> offset -> bool = "ocaml_uring_submit_writev_fixed_byte" "ocaml_uring_submit_writev_fixed_native" [@@noalloc]
   external submit_close : t -> Unix.file_descr -> id -> bool = "ocaml_uring_submit_close" [@@noalloc]
+  external submit_splice : t -> id -> Unix.file_descr -> Unix.file_descr -> int -> bool = "ocaml_uring_submit_splice" [@@noalloc]
 
   external wait_cqe : t -> id * int = "ocaml_uring_wait_cqe"
   external wait_cqe_timeout : float -> t -> id * int = "ocaml_uring_wait_cqe_timeout"
@@ -126,6 +127,9 @@ let poll_add t fd poll_mask user_data =
 
 let close t fd user_data =
   with_id t (fun id -> Uring.submit_close t.uring fd id) user_data
+
+let splice t ~src ~dst ~len user_data =
+  with_id t (fun id -> Uring.submit_splice t.uring id src dst len) user_data
 
 let submit t =
   if t.dirty then begin

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -110,16 +110,16 @@ let with_id t fn user_data =
 let noop t user_data =
   with_id t (fun id -> Uring.submit_nop t.uring id) user_data
 
-let readv t ?(offset=Int63.zero) fd iovec user_data =
+let readv t ?(offset=Int63.minus_one) fd iovec user_data =
   with_id t (fun id -> Uring.submit_readv t.uring fd id iovec offset) user_data
 
-let read t ?(file_offset=Int63.zero) fd off len user_data =
+let read t ?(file_offset=Int63.minus_one) fd off len user_data =
   with_id t (fun id -> Uring.submit_readv_fixed t.uring fd id t.fixed_iobuf off len file_offset) user_data
 
-let write t ?(file_offset=Int63.zero) fd off len user_data =
+let write t ?(file_offset=Int63.minus_one) fd off len user_data =
   with_id t (fun id -> Uring.submit_writev_fixed t.uring fd id t.fixed_iobuf off len file_offset) user_data
 
-let writev t ?(offset=Int63.zero) fd iovec user_data =
+let writev t ?(offset=Int63.minus_one) fd iovec user_data =
   with_id t (fun id -> Uring.submit_writev t.uring fd id iovec offset) user_data
 
 let poll_add t fd poll_mask user_data =

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -99,6 +99,11 @@ val write : 'a t -> ?file_offset:offset -> Unix.file_descr -> int -> int -> 'a -
     TODO: replace [off] with {!Region.chunk} instead?
     The user data [d] will be returned by {!wait} or {!peek} upon completion. *)
 
+val splice : 'a t -> src:Unix.file_descr -> dst:Unix.file_descr -> len:int -> 'a -> bool
+(** [splice t ~src ~dst ~len d] will submit a request to copy [len] bytes from [src] to [dst].
+    The operation returns the number of bytes transferred, or 0 for end-of-input.
+    The result is [EINVAL] if the file descriptors don't support splicing. *)
+
 val close : 'a t -> Unix.file_descr -> 'a -> bool
 
 (** {2 Submitting operations} *)

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -220,6 +220,20 @@ ocaml_uring_submit_writev_fixed_byte(value* values, int argc) {
 			  values[6]);
 }
 
+value
+ocaml_uring_submit_splice(value v_uring, value v_id, value v_fd_in, value v_fd_out, value v_nbytes) {
+  CAMLparam1(v_uring);
+  struct io_uring *ring = Ring_val(v_uring);
+  struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
+  if (!sqe) CAMLreturn(Val_false);
+  io_uring_prep_splice(sqe,
+		       Int_val(v_fd_in), (int64_t) -1,
+		       Int_val(v_fd_out), (int64_t) -1,
+		       Int_val(v_nbytes), 0);
+  io_uring_sqe_set_data(sqe, (void *)(uintptr_t)Int_val(v_id)); /* TODO sort out cast */
+  CAMLreturn(Val_true);
+}
+
 value ocaml_uring_submit(value v_uring)
 {
   CAMLparam1(v_uring);


### PR DESCRIPTION
This allows copying between some types of FD more efficiently.

This PR also modifies the existing read/write operations so that if you don't specify an offset then it uses (and updates) the current file position. Otherwise, reading from a file just keeps returning the start!