### PR TITLE
Don't install test executables

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -14,12 +14,12 @@
  (depends
   dune-configurator
   (iovec (= :version))
-  (lwt (>= 5.0.0))
+  (lwt (and :with-test (>= 5.0.0)))
   (notty (and (>= 0.2.2) :with-test))
   (bos (and (>= 0.2.0) :with-test))
   (bechamel-notty (and (>= 0.1.0) :with-test))
   (bechamel (and (>= 0.1.0) :with-test))
-  (logs (>= 0.5.0))
+  (logs (and :with-test (>= 0.5.0)))
   cmdliner
   (fmt (>= 0.8.4))
   bigstringaf

--- a/tests/dune
+++ b/tests/dune
@@ -22,23 +22,17 @@
 (executable
  (name urcat)
  (modules urcat)
- (public_name urcat)
- (package uring)
  (libraries bigstringaf unix uring))
 
 (executable
  (name urcp)
  (modules urcp)
- (public_name urcp)
- (package uring)
  (libraries cmdliner logs.cli logs.fmt fmt.tty fmt.cli urcp_fixed_lib
    urcp_lib))
 
 (executable
  (name lwtcp)
  (modules lwtcp)
- (public_name lwtcp)
- (package uring)
  (libraries cmdliner logs.cli logs.fmt fmt.tty fmt.cli lwtcp_lib))
 
 (executable

--- a/uring.opam
+++ b/uring.opam
@@ -11,12 +11,12 @@ depends: [
   "dune" {>= "2.7"}
   "dune-configurator"
   "iovec" {= version}
-  "lwt" {>= "5.0.0"}
+  "lwt" {with-test & >= "5.0.0"}
   "notty" {>= "0.2.2" & with-test}
   "bos" {>= "0.2.0" & with-test}
   "bechamel-notty" {>= "0.1.0" & with-test}
   "bechamel" {>= "0.1.0" & with-test}
-  "logs" {>= "0.5.0"}
+  "logs" {with-test & >= "0.5.0"}
   "cmdliner"
   "fmt" {>= "0.8.4"}
   "bigstringaf"


### PR DESCRIPTION
They don't seem very useful, and pull in a dependency on Lwt.

@avsm were these installed for a reason?