### PR TITLE
Make file offset non-optional

### DIFF
--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -110,17 +110,17 @@ let with_id t fn user_data =
 let noop t user_data =
   with_id t (fun id -> Uring.submit_nop t.uring id) user_data
 
-let readv t ?(offset=Int63.minus_one) fd iovec user_data =
-  with_id t (fun id -> Uring.submit_readv t.uring fd id iovec offset) user_data
+let readv t ~file_offset fd iovec user_data =
+  with_id t (fun id -> Uring.submit_readv t.uring fd id iovec file_offset) user_data
 
-let read t ?(file_offset=Int63.minus_one) fd off len user_data =
+let read t ~file_offset fd off len user_data =
   with_id t (fun id -> Uring.submit_readv_fixed t.uring fd id t.fixed_iobuf off len file_offset) user_data
 
-let write t ?(file_offset=Int63.minus_one) fd off len user_data =
+let write t ~file_offset fd off len user_data =
   with_id t (fun id -> Uring.submit_writev_fixed t.uring fd id t.fixed_iobuf off len file_offset) user_data
 
-let writev t ?(offset=Int63.minus_one) fd iovec user_data =
-  with_id t (fun id -> Uring.submit_writev t.uring fd id iovec offset) user_data
+let writev t ~file_offset fd iovec user_data =
+  with_id t (fun id -> Uring.submit_writev t.uring fd id iovec file_offset) user_data
 
 let poll_add t fd poll_mask user_data =
   with_id t (fun id -> Uring.submit_poll_add t.uring fd id poll_mask) user_data

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -72,28 +72,30 @@ val poll_add : 'a t -> Unix.file_descr -> Poll_mask.t -> 'a -> bool
     It completes and returns [d] when an event in [mask] is ready on [fd]. *)
 
 type offset := Optint.Int63.t
+(** For files, give the absolute offset, or use [Optint.Int63.minus_one] for the current position.
+    For sockets, use an offset of [Optint.Int63.zero] ([minus_one] is not allowed here). *)
 
-val readv : 'a t -> ?offset:offset -> Unix.file_descr -> Iovec.t -> 'a -> bool
-(** [readv t ?offset fd iov d] will submit a [readv(2)] request to uring [t].
-    It reads from absolute file [offset] on the [fd] file descriptor and writes
+val readv : 'a t -> file_offset:offset -> Unix.file_descr -> Iovec.t -> 'a -> bool
+(** [readv t ~file_offset fd iov d] will submit a [readv(2)] request to uring [t].
+    It reads from absolute [file_offset] on the [fd] file descriptor and writes
     the results into the memory pointed to by [iov].  The user data [d] will
     be returned by {!wait} or {!peek} upon completion. *)
 
-val writev : 'a t -> ?offset:offset -> Unix.file_descr -> Iovec.t -> 'a -> bool
-(** [writev t ?offset fd iov d] will submit a [writev(2)] request to uring [t].
-    It writes to absolute file [offset] on the [fd] file descriptor from the
+val writev : 'a t -> file_offset:offset -> Unix.file_descr -> Iovec.t -> 'a -> bool
+(** [writev t ~file_offset fd iov d] will submit a [writev(2)] request to uring [t].
+    It writes to absolute [file_offset] on the [fd] file descriptor from the
     the memory pointed to by [iov].  The user data [d] will be returned by
     {!wait} or {!peek} upon completion. *)
 
-val read : 'a t -> ?file_offset:offset -> Unix.file_descr -> int -> int -> 'a -> bool
-(** [read t ?file_offset fd off d] will submit a [read(2)] request to uring [t].
-    It read from absolute [file_offset] on the [fd] file descriptor and writes
+val read : 'a t -> file_offset:offset -> Unix.file_descr -> int -> int -> 'a -> bool
+(** [read t ~file_offset fd off d] will submit a [read(2)] request to uring [t].
+    It reads from absolute [file_offset] on the [fd] file descriptor and writes
     the results into the fixed memory buffer associated with uring [t] at offset
     [off]. TODO: replace [off] with {!Region.chunk} instead?
     The user data [d] will be returned by {!wait} or {!peek} upon completion. *)
 
-val write : 'a t -> ?file_offset:offset -> Unix.file_descr -> int -> int -> 'a -> bool
-(** [write t ?file_offset fd off d] will submit a [write(2)] request to uring [t].
+val write : 'a t -> file_offset:offset -> Unix.file_descr -> int -> int -> 'a -> bool
+(** [write t ~file_offset fd off d] will submit a [write(2)] request to uring [t].
     It writes into absolute [file_offset] on the [fd] file descriptor from
     the fixed memory buffer associated with uring [t] at offset [off].
     TODO: replace [off] with {!Region.chunk} instead?

--- a/tests/main.ml
+++ b/tests/main.ml
@@ -70,7 +70,7 @@ let test_readv () =
   let b1 = Iovec.Buffer.create b1_len and b2 = Iovec.Buffer.create b2_len in
   let iov = Iovec.alloc [| b1; b2 |] in
 
-  assert_   ~__POS__ (Uring.readv t fd iov `Readv);
+  assert_   ~__POS__ (Uring.readv t fd iov `Readv ~file_offset:Int63.zero);
   check_int ~__POS__ (Uring.submit t) ~expected:1;
 
   let token, read = consume t in

--- a/tests/urcat.ml
+++ b/tests/urcat.ml
@@ -36,7 +36,7 @@ let submit_read_request fname uring =
   let blocks = if file_sz mod block_size <> 0 then (file_sz / block_size)+1 else file_sz/block_size in
   let bufs = Array.init blocks (fun _ -> Iovec.Buffer.create block_size) in
   let iov = Iovec.alloc bufs in
-  let _ = Uring.readv uring fd iov (iov :> Iovec.t) in
+  let _ = Uring.readv uring fd iov (iov :> Iovec.t) ~file_offset:Optint.Int63.zero in
   let numreq = Uring.submit uring in
   assert(numreq=1);
   ()


### PR DESCRIPTION
In #17 I changed the default offset to `-1`. That worked for files (and pipes!), but it doesn't work for sockets, which require you to pass `0`. As it seems impossible to provide a default that works everywhere, this PR requires the user to specify the offset in all cases.

Also, rename `offset` to `file_offset` in some places for consistency.