### PR TITLE
Add connect

### DIFF
--- a/lib/uring/heap.mli
+++ b/lib/uring/heap.mli
@@ -25,9 +25,10 @@ type ptr = private int
 
 exception No_space
 
-val alloc : 'a t -> 'a -> ptr
-(** [alloc t a] adds the value [a] to [t] and returns a pointer to that value,
-    or raises {!No_space} if no space exists in [t]. *)
+val alloc : 'a t -> 'a -> extra_data:'b -> ptr
+(** [alloc t a ~extra_data] adds the value [a] to [t] and returns a pointer to that value,
+    or raises {!No_space} if no space exists in [t].
+    @param extra_data Prevent this from being GC'd until [free] is called. *)
 
 val free : 'a t -> ptr -> 'a
 (** [free t p] returns the element referenced by [p] and removes it from the

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -48,6 +48,10 @@ module Uring = struct
   external submit : t -> int = "ocaml_uring_submit"
 
   type id = Heap.ptr
+
+  type sockaddr
+  external make_sockaddr : Unix.sockaddr -> sockaddr = "ocaml_uring_make_sockaddr"
+
   type offset = Optint.Int63.t
   external submit_nop : t -> id -> bool = "ocaml_uring_submit_nop" [@@noalloc]
   external submit_poll_add : t -> Unix.file_descr -> id -> Poll_mask.t -> bool = "ocaml_uring_submit_poll_add" [@@noalloc]
@@ -57,6 +61,7 @@ module Uring = struct
   external submit_writev_fixed : t -> Unix.file_descr -> id -> Iovec.Buffer.t -> int -> int -> offset -> bool = "ocaml_uring_submit_writev_fixed_byte" "ocaml_uring_submit_writev_fixed_native" [@@noalloc]
   external submit_close : t -> Unix.file_descr -> id -> bool = "ocaml_uring_submit_close" [@@noalloc]
   external submit_splice : t -> id -> Unix.file_descr -> Unix.file_descr -> int -> bool = "ocaml_uring_submit_splice" [@@noalloc]
+  external submit_connect : t -> id -> Unix.file_descr -> sockaddr -> bool = "ocaml_uring_submit_connect" [@@noalloc]
 
   type cqe_option = private
     | Cqe_none
@@ -97,14 +102,16 @@ let realloc t iobuf =
 
 let exit {uring;_} = Uring.exit uring
 
-let with_id : type a. a t -> (Heap.ptr -> bool) -> a -> bool =
- fun t fn datum ->
-  match Heap.alloc t.user_data datum with
+let with_id_full : type a. a t -> (Heap.ptr -> bool) -> a -> extra_data:'b -> bool =
+ fun t fn datum ~extra_data ->
+  match Heap.alloc t.user_data datum ~extra_data with
   | exception Heap.No_space -> false
   | ptr ->
      let has_space = fn ptr in
      if has_space then t.dirty <- true else ignore (Heap.free t.user_data ptr : a);
      has_space
+
+let with_id t fn a = with_id_full t fn a ~extra_data:()
 
 let noop t user_data =
   with_id t (fun id -> Uring.submit_nop t.uring id) user_data
@@ -129,6 +136,10 @@ let close t fd user_data =
 
 let splice t ~src ~dst ~len user_data =
   with_id t (fun id -> Uring.submit_splice t.uring id src dst len) user_data
+
+let connect t fd addr user_data =
+  let addr = Uring.make_sockaddr addr in
+  with_id_full t (fun id -> Uring.submit_connect t.uring id fd addr) user_data ~extra_data:addr
 
 let submit t =
   if t.dirty then begin

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -106,6 +106,9 @@ val splice : 'a t -> src:Unix.file_descr -> dst:Unix.file_descr -> len:int -> 'a
     The operation returns the number of bytes transferred, or 0 for end-of-input.
     The result is [EINVAL] if the file descriptors don't support splicing. *)
 
+val connect : 'a t -> Unix.file_descr -> Unix.sockaddr -> 'a -> bool
+(** [connect t fd addr d] will submit a request to connect [fd] to [addr]. *)
+
 val close : 'a t -> Unix.file_descr -> 'a -> bool
 
 (** {2 Submitting operations} *)

--- a/tests/main.ml
+++ b/tests/main.ml
@@ -6,7 +6,10 @@ let check_int    ~__POS__ ~expected = Alcotest.(check ~pos:__POS__ int) "" expec
 let check_string ~__POS__ ~expected = Alcotest.(check ~pos:__POS__ string) "" expected
 
 module Heap = struct
-  module Heap = Uring.Private.Heap
+  module Heap = struct
+    include Uring.Private.Heap
+    let alloc = alloc ~extra_data:()
+  end
 
   let random_hashtbl_elt tbl =
     let rec inner n acc (seq : _ Seq.t) =


### PR DESCRIPTION
This seems a bit complicated. The problem is that the address is passed as a pointer into application memory, and so must not be GC'd while the request is in progress. So I convert the `Unix.sockaddr` to the C form and store it in a new field I added to @CraigFe's heap so it doesn't get removed until the entry is freed.

Suggestions on better ways of doing it welcome!

(we might have the same problem with the `iovec` arguments)