### PR TITLE
Fix test_cancel

### DIFF
--- a/tests/poll_add.ml
+++ b/tests/poll_add.ml
@@ -17,4 +17,4 @@ let () =
   in
   let res = retry () in
   Printf.eprintf "poll_add: %x\n%!" res;
-  ()
+  Uring.exit t


### PR DESCRIPTION
Occasionally, the read is busy when we try to cancel, giving different results.