### PR TITLE
Don't allow freeing the ring while it's in use

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -12,6 +12,7 @@
  (synopsis "OCaml bindings for Linux io_uring")
  (description "Bindings to the Linux io_uring kernel IO interfaces.")
  (depends
+  (ocaml (>= 4.12.0))
   dune-configurator
   (iovec (= :version))
   (lwt (and :with-test (>= 5.0.0)))

--- a/lib/uring/heap.mli
+++ b/lib/uring/heap.mli
@@ -40,3 +40,6 @@ val alloc : 'a t -> 'a -> extra_data:'b -> 'a entry
 val free : 'a t -> ptr -> 'a
 (** [free t p] returns the element referenced by [p] and removes it from the
     heap. Has undefined behaviour if [p] has already been freed. *)
+
+val in_use : 'a t -> int
+(** [in_use t] is the number of entries currently allocated. *)

--- a/uring.opam
+++ b/uring.opam
@@ -9,6 +9,7 @@ homepage: "https://github.com/ocaml-multicore/ocaml-uring"
 bug-reports: "https://github.com/ocaml-multicore/ocaml-uring/issues"
 depends: [
   "dune" {>= "2.7"}
+  "ocaml" {>= "4.12.0"}
   "dune-configurator"
   "iovec" {= version}
   "lwt" {with-test & >= "5.0.0"}


### PR DESCRIPTION
Add the ring to a global set on creation and remove it on exit. This prevents GC'ing buffers that we have passed to the kernel.
Attempting to call `exit` while the ring is in use is now an error.

Also, check for invalid cancel requests before allocating a slot. Otherwise, the slot gets leaked.