### PR TITLE
Fix remaining TODOs in API

### DIFF
--- a/lib/uring/region.mli
+++ b/lib/uring/region.mli
@@ -37,21 +37,21 @@ type t
       offset in its associated region.  This can be used in IO calls
       involving that memory. *)
 
-  val to_bigstring : ?len:int -> chunk -> Cstruct.buffer
-  (** [to_bigstring ?len chunk] will create a {!Bigarray} into the
-      chunk of memory. Note that this is a zero-copy view into the
-      underlying region [t] and so the [chunk] should not be freed
-      until this Bigarray reference is no longer used.
+  val to_cstruct : ?len:int -> chunk -> Cstruct.t
+  (** [to_cstruct chunk] is a cstruct of [chunk]'s slice of the region.
+      Note that this is a zero-copy view into the underlying region [t]
+      and so [chunk] should not be freed until this cstruct is no longer used.
+      @param len Use only the first [len] bytes of [chunk]. *)
 
-      If [len] is specified then the returned view is of that size,
-      and otherwise it defaults to [block_size]. *)
+  val to_bigstring : ?len:int -> chunk -> Cstruct.buffer
+  (** [to_bigstring] is like {!to_cstruct}, but creates a {!Bigarray}.
+      Note that this is a zero-copy view into the underlying region [t]
+      and so [chunk] should not be freed until this Bigarray reference is no longer used.
+      @param len Use only the first [len] bytes of [chunk]. *)
 
   val to_string : ?len:int -> chunk -> string
-  (** [to_string ?len chunk] will return a copy of the [chunk]
-      as an OCaml string.
-
-      If [len] is specified then the returned view is of that size,
-      and otherwise it defaults to [block_size]. *)
+  (** [to_string ?len chunk] will return a copy of [chunk] as an OCaml string.
+      @param len Use only the first [len] bytes of [chunk]. *)
 
   val avail : t -> int
   (** [avail t] is the number of free chunks of memory remaining

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -40,10 +40,12 @@ val buf : 'a t -> Cstruct.buffer
 
 val realloc : 'a t -> Cstruct.buffer -> unit
 (** [realloc t buf] will replace the internal fixed buffer associated with
-    uring [t] with a fresh one. TODO: specify semantics of outstanding requests. *)
+    uring [t] with a fresh one.
+    @raise Invalid_argument if there are any requests in progress *)
 
 val exit : 'a t -> unit
-(** [exit t] will shut down the uring [t]. Any subsequent requests will fail. *)
+(** [exit t] will shut down the uring [t]. Any subsequent requests will fail.
+    @raise Invalid_argument if there are any requests in progress *)
 
 (** {2 Queueing operations} *)
 

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -83,6 +83,7 @@ value ocaml_uring_setup(value entries) {
   }
 }
 
+// Note that the ring must be idle when calling this.
 value ocaml_uring_register_ba(value v_uring, value v_ba) {
   CAMLparam2(v_uring, v_ba);
   struct io_uring *ring = Ring_val(v_uring);

--- a/tests/main.ml
+++ b/tests/main.ml
@@ -317,7 +317,7 @@ let test_free_busy () =
   assert_some ~__POS__ (Uring.read t ~file_offset:Int63.minus_one r 0 1 `Read);
   check_int   ~__POS__ (Uring.submit t) ~expected:1;
   check_raises ~__POS__
-    (Invalid_argument "Can't free ring; 1 request(s) still active!")
+    (Invalid_argument "exit: 1 request(s) still active!")
     (fun () -> Uring.exit t);
   Unix.close w;
   let token, r_read = consume t in
@@ -349,4 +349,3 @@ let () =
       tc "free_busy" test_free_busy;
     ];
   ]
-

--- a/tests/main.ml
+++ b/tests/main.ml
@@ -123,8 +123,8 @@ let test_invalid_queue_depth () =
   check_raises ~__POS__ (Invalid_argument "Non-positive queue depth: 0")
     (fun () -> ignore (Uring.create ~queue_depth:0 ()))
 
-let with_uring ~queue_depth fn =
-  let t = Uring.create ~queue_depth () in
+let with_uring ?fixed_buf_len ~queue_depth fn =
+  let t = Uring.create ?fixed_buf_len ~queue_depth () in
   fn t;
   Uring.exit t  (* Only free if there wasn't an error *)
 
@@ -217,7 +217,7 @@ let test_read () =
   let off = 3 in
   let len = 5 in
   let file_offset = Int63.of_int 2 in
-  assert_some ~__POS__ (Uring.read t ~file_offset fd off len `Read);
+  assert_some ~__POS__ (Uring.read_fixed t ~file_offset fd ~off ~len `Read);
   check_int   ~__POS__ (Uring.submit t) ~expected:1;
 
   let token, read = consume t in
@@ -246,12 +246,32 @@ let test_readv () =
   check_string ~__POS__ ~expected:"est fil" (Cstruct.to_string b2);
   ()
 
+let test_region () =
+  with_uring ~queue_depth:1 ~fixed_buf_len:64 @@ fun t ->
+  Test_data.with_fd @@ fun fd ->
+  let region = Uring.Region.init (Uring.buf t) 4 ~block_size:16 in
+  let chunk = Uring.Region.alloc region in
+  assert_some ~__POS__ (Uring.read_chunk t fd chunk `Read ~file_offset:Int63.zero);
+  let token, read = consume t in
+  assert_      ~__POS__ (token = `Read);
+  check_int    ~__POS__ ~expected:11 read;
+  check_string ~__POS__ ~expected:"A test file" (Uring.Region.to_string ~len:read chunk);
+  check_raises ~__POS__
+    (Invalid_argument "to_cstruct: requested length 17 > block size 16")
+    (fun () -> Uring.read_chunk ~len:17 t fd chunk `Read ~file_offset:Int63.zero |> ignore);
+  with_uring ~queue_depth:1 (fun t2 ->
+    check_raises ~__POS__
+      (Invalid_argument "Chunk does not belong to ring!")
+      (fun () -> Uring.read_chunk ~len:16 t2 fd chunk `Read ~file_offset:Int63.zero |> ignore);
+    );
+  ()
+
 (* Ask to read from a pipe (with no data available), then cancel it. *)
 let test_cancel () =
   with_uring ~queue_depth:5 @@ fun t ->
   (* while true do *)
   let r, w = Unix.pipe () in
-  let read = Uring.read t ~file_offset:Int63.zero r 0 1 `Read |> Option.get in
+  let read = Uring.read_fixed t ~file_offset:Int63.zero r ~off:0 ~len:1 `Read |> Option.get in
   assert_some ~__POS__ (Uring.cancel t read `Cancel);
   check_int   ~__POS__ (Uring.submit t) ~expected:2;
   let t1, r1 = consume t in
@@ -280,7 +300,7 @@ let test_cancel () =
 let test_cancel_late () =
   with_uring ~queue_depth:5 @@ fun t ->
   let r = Unix.openfile "/dev/zero" Unix.[O_RDONLY] 0 in
-  let read = Uring.read t ~file_offset:Int63.zero r 0 1 `Read |> Option.get in
+  let read = Uring.read_fixed t ~file_offset:Int63.zero r ~off:0 ~len:1 `Read |> Option.get in
   check_int   ~__POS__ (Uring.submit t) ~expected:1;
   assert_some ~__POS__ (Uring.cancel t read `Cancel);
   check_int   ~__POS__ (Uring.submit t) ~expected:1;
@@ -300,7 +320,7 @@ let test_cancel_late () =
 let test_cancel_invalid () =
   with_uring ~queue_depth:5 @@ fun t ->
   let r = Unix.openfile "/dev/zero" Unix.[O_RDONLY] 0 in
-  let read = Uring.read t ~file_offset:Int63.zero r 0 1 `Read |> Option.get in
+  let read = Uring.read_fixed t ~file_offset:Int63.zero r ~off:0 ~len:1 `Read |> Option.get in
   let token, r_read = consume t in
   assert_   ~__POS__ (token = `Read);
   check_int ~__POS__ ~expected:1    r_read;   (* Success *)
@@ -314,7 +334,7 @@ let test_free_busy () =
   let t = Uring.create ~queue_depth:1 () in
   let r, w = Unix.pipe () in
   Fun.protect ~finally:(fun () -> Unix.close r) @@ fun () ->
-  assert_some ~__POS__ (Uring.read t ~file_offset:Int63.minus_one r 0 1 `Read);
+  assert_some ~__POS__ (Uring.read_fixed t ~file_offset:Int63.minus_one r ~off:0 ~len:1 `Read);
   check_int   ~__POS__ (Uring.submit t) ~expected:1;
   check_raises ~__POS__
     (Invalid_argument "exit: 1 request(s) still active!")
@@ -343,6 +363,7 @@ let () =
       tc "resolve" test_resolve;
       tc "read" test_read;
       tc "readv" test_readv;
+      tc "region" test_region;
       tc "cancel" test_cancel;
       tc "cancel_late" test_cancel_late;
       tc "cancel_invalid" test_cancel_invalid;


### PR DESCRIPTION
- Rename `read` to `read_fixed` and provide a new `read_chunk` for the common case of reading into a chunk.
- Same thing for `write`.
- Add `Region.to_cstruct` as a faster alternative to creating a sub-bigarray.
- Raise an exception if the user asks for a chunk slice larger than the chunk, rather than taking the smaller size.
- Require the ring to be idle to reallocate the fixed buffer.