### PR TITLE
Use caml_enter_blocking_section when waiting

### DIFF
--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -472,7 +472,9 @@ value ocaml_uring_wait_cqe_timeout(value v_timeout, value v_uring)
   struct io_uring_cqe *cqe;
   int res;
   dprintf("cqe: waiting, timeout %fs\n", timeout);
+  caml_enter_blocking_section();
   res = io_uring_wait_cqe_timeout(ring, &cqe, &t);
+  caml_leave_blocking_section();
   if (res < 0) {
     if (res == -EAGAIN || res == -EINTR || res == -ETIME) {
       CAMLreturn(Val_cqe_none);
@@ -495,7 +497,9 @@ value ocaml_uring_wait_cqe(value v_uring)
   struct io_uring_cqe *cqe;
   int res;
   dprintf("cqe: waiting\n");
+  caml_enter_blocking_section();
   res = io_uring_wait_cqe(ring, &cqe);
+  caml_leave_blocking_section();
   if (res < 0) {
     if (res == -EAGAIN || res == -EINTR) {
       CAMLreturn(Val_cqe_none);

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -462,7 +462,6 @@ static value Val_cqe_some(value id, value res) {
 value ocaml_uring_wait_cqe_timeout(value v_timeout, value v_uring)
 {
   CAMLparam2(v_uring, v_timeout);
-  CAMLlocal1(v_ret);
   double timeout = Double_val(v_timeout);
   struct __kernel_timespec t;
   t.tv_sec = (time_t) timeout;
@@ -491,7 +490,6 @@ value ocaml_uring_wait_cqe_timeout(value v_timeout, value v_uring)
 value ocaml_uring_wait_cqe(value v_uring)
 {
   CAMLparam1(v_uring);
-  CAMLlocal1(v_ret);
   long id;
   struct io_uring *ring = Ring_val(v_uring);
   struct io_uring_cqe *cqe;
@@ -516,7 +514,6 @@ value ocaml_uring_wait_cqe(value v_uring)
 value ocaml_uring_peek_cqe(value v_uring)
 {
   CAMLparam1(v_uring);
-  CAMLlocal1(v_ret);
   long id;
   struct io_uring *ring = Ring_val(v_uring);
   struct io_uring_cqe *cqe;


### PR DESCRIPTION
This allows other threads to run while we're waiting and, on multicore, allows GC to happen while waiting.