### PR TITLE
Remove test dependencies on Bos and Rresult

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -16,7 +16,6 @@
   dune-configurator
   (lwt (and :with-test (>= 5.0.0)))
   (notty (and (>= 0.2.2) :with-test))
-  (bos (and (>= 0.2.0) :with-test))
   (bechamel-notty (and (>= 0.1.0) :with-test))
   (bechamel (and (>= 0.1.0) :with-test))
   (logs (and :with-test (>= 0.5.0)))

--- a/tests/dune
+++ b/tests/dune
@@ -43,7 +43,7 @@
 (executable
  (name cptest)
  (modules cptest)
- (libraries urcp_fixed_lib urcp_lib lwtcp_lib uring bos bechamel notty.unix
+ (libraries urcp_fixed_lib urcp_lib lwtcp_lib uring bechamel notty.unix
    bechamel-notty))
 
 (rule

--- a/uring.opam
+++ b/uring.opam
@@ -15,7 +15,6 @@ depends: [
   "dune-configurator"
   "lwt" {with-test & >= "5.0.0"}
   "notty" {>= "0.2.2" & with-test}
-  "bos" {>= "0.2.0" & with-test}
   "bechamel-notty" {>= "0.1.0" & with-test}
   "bechamel" {>= "0.1.0" & with-test}
   "logs" {with-test & >= "0.5.0"}


### PR DESCRIPTION
We already depend on OCaml >= 4.12, which provides similar functions.