### PR TITLE
dune b: fixes 'dune b'

### DIFF
--- a/lib/uring/dune
+++ b/lib/uring/dune
@@ -23,6 +23,7 @@
     (chdir
      %{project_root}/vendor/liburing
      (progn
+      (run chmod +w src/include/liburing/compat.h)
       (run ./configure)
       (setenv
        CFLAGS


### PR DESCRIPTION
'dune b' fails due to permission issue with 'compat.h'. This commit
fixes the error by setting the write permission for the file.

Sample error:

./configure: line 336: src/include/liburing/compat.h: Permission denied
./configure: line 360: src/include/liburing/compat.h: Permission denied
./configure: line 366: src/include/liburing/compat.h: Permission denied
./configure: line 378: src/include/liburing/compat.h: Permission denied

Signed-off-by: Bikal Lem <gbikal+git@gmail.com>