### PR TITLE
Remove bigstringaf dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -21,6 +21,5 @@
   (logs (and :with-test (>= 0.5.0)))
   cmdliner
   (fmt (>= 0.8.10))
-  bigstringaf
   (optint (>= 0.1.0))
   (alcotest (and (>= 1.4.0) :with-test))))

--- a/lib/uring/dune
+++ b/lib/uring/dune
@@ -2,7 +2,7 @@
  (name uring)
  (public_name uring)
  (foreign_archives uring)
- (libraries bigstringaf cstruct fmt optint unix)
+ (libraries cstruct fmt optint unix)
  (foreign_stubs
   (language c)
   (names uring_stubs)

--- a/lib/uring/region.ml
+++ b/lib/uring/region.ml
@@ -3,7 +3,7 @@
 
 (* TODO turn into a variable length slab allocator *)
 type t = {
-  buf: Bigstringaf.t;
+  buf: Cstruct.buffer;
   block_size: int;
   slots: int;
   freelist: int Queue.t;
@@ -42,10 +42,10 @@ let to_cstruct ?len (t, chunk) =
   Cstruct.of_bigarray ~off:chunk ~len:(length_option t len) t.buf
 
 let to_bigstring ?len (t, chunk) =
-  Bigstringaf.sub t.buf ~off:chunk ~len:(length_option t len)
+  Bigarray.Array1.sub t.buf chunk (length_option t len)
 
 let to_string ?len (t, chunk) =
-  Bigstringaf.substring t.buf ~off:chunk ~len:(length_option t len)
+  Cstruct.to_string (to_cstruct ?len (t, chunk))
 
 let avail {freelist;_} = Queue.length freelist
 

--- a/tests/dune
+++ b/tests/dune
@@ -2,7 +2,7 @@
  (name main)
  (modules main)
  (package uring)
- (libraries bigstringaf unix uring alcotest optint))
+ (libraries unix uring alcotest optint))
 
 (library
  (name urcp_lib)
@@ -22,7 +22,7 @@
 (executable
  (name urcat)
  (modules urcat)
- (libraries bigstringaf unix uring))
+ (libraries unix uring))
 
 (executable
  (name urcp)

--- a/tests/main.ml
+++ b/tests/main.ml
@@ -225,8 +225,8 @@ let test_read () =
   check_int ~__POS__ read ~expected:len;
 
   let fbuf = Uring.buf t in
-  check_string ~__POS__  ~expected:"test "
-    (Bigstringaf.substring fbuf ~off ~len)
+  let got = Cstruct.of_bigarray fbuf ~off ~len in
+  check_string ~__POS__  ~expected:"test " (Cstruct.to_string got)
 
 let test_readv () =
   with_uring ~queue_depth:1 @@ fun t ->

--- a/tests/main.ml
+++ b/tests/main.ml
@@ -123,8 +123,8 @@ let test_invalid_queue_depth () =
   check_raises ~__POS__ (Invalid_argument "Non-positive queue depth: 0")
     (fun () -> ignore (Uring.create ~queue_depth:0 ()))
 
-let with_uring ?fixed_buf_len ~queue_depth fn =
-  let t = Uring.create ?fixed_buf_len ~queue_depth () in
+let with_uring ?(fixed_buf_len=1024) ~queue_depth fn =
+  let t = Uring.create ~fixed_buf_len ~queue_depth () in
   fn t;
   Uring.exit t  (* Only free if there wasn't an error *)
 

--- a/uring.opam
+++ b/uring.opam
@@ -20,7 +20,6 @@ depends: [
   "logs" {with-test & >= "0.5.0"}
   "cmdliner"
   "fmt" {>= "0.8.10"}
-  "bigstringaf"
   "optint" {>= "0.1.0"}
   "alcotest" {>= "1.4.0" & with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
We now depend on cstruct, which provides the same functions.