### PR TITLE
Add an io_uring probe function

### DIFF
--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -137,6 +137,7 @@ module Uring = struct
 
   external create : int -> int option -> t = "ocaml_uring_setup"
   external exit : t -> unit = "ocaml_uring_exit"
+  external probe : unit -> bool = "ocaml_uring_probe"
 
   external unregister_buffers : t -> unit = "ocaml_uring_unregister_buffers"
   external register_bigarray : t ->  Cstruct.buffer -> unit = "ocaml_uring_register_ba"
@@ -243,6 +244,8 @@ let exit t =
   ensure_idle t "exit";
   Uring.exit t.uring;
   unregister_gc_root t
+
+let probe = Uring.probe
 
 let with_id_full : type a. a t -> (Heap.ptr -> bool) -> a -> extra_data:'b -> a job option =
  fun t fn datum ~extra_data ->

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -50,6 +50,10 @@ val exit : 'a t -> unit
 (** [exit t] will shut down the uring [t]. Any subsequent requests will fail.
     @raise Invalid_argument if there are any requests in progress *)
 
+val probe : unit -> bool
+(** [probe ()] checks whether or not the necessary io_uring operations are available.
+    The function returns [true] if all are available and [false] otherwise. *)
+
 (** {2 Queueing operations} *)
 
 val noop : 'a t -> 'a -> 'a job option

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -172,6 +172,70 @@ value ocaml_uring_exit(value v_uring) {
   CAMLreturn(Val_unit);
 }
 
+// This list comes from https://github.com/axboe/liburing/blob/918d8061ffdfdf253806a1e8e141c71644e678bd/src/include/liburing/io_uring.h#L109
+// We only check the operations that we use and expose in the bindings.
+static const char *op_strs[] = {
+  "IORING_OP_NOP",
+  "IORING_OP_READV",
+  "IORING_OP_WRITEV",
+  // "IORING_OP_FSYNC",
+  "IORING_OP_READ_FIXED",
+  "IORING_OP_WRITE_FIXED",
+  "IORING_OP_POLL_ADD",
+  "IORING_OP_POLL_REMOVE",
+  // "IORING_OP_SYNC_FILE_RANGE",
+  "IORING_OP_SENDMSG",
+  "IORING_OP_RECVMSG",
+  "IORING_OP_TIMEOUT",
+  "IORING_OP_TIMEOUT_REMOVE",
+  "IORING_OP_ACCEPT",
+  // "IORING_OP_ASYNC_CANCEL",
+  // "IORING_OP_LINK_TIMEOUT",
+  "IORING_OP_CONNECT",
+  // "IORING_OP_FALLOCATE",
+  "IORING_OP_OPENAT",
+  "IORING_OP_CLOSE",
+  // "IORING_OP_FILES_UPDATE",
+  // "IORING_OP_STATX",
+  "IORING_OP_READ",
+  "IORING_OP_WRITE",
+  // "IORING_OP_FADVISE",
+  // "IORING_OP_MADVISE",
+  "IORING_OP_SEND",
+  "IORING_OP_RECV",
+  "IORING_OP_OPENAT2",
+  // "IORING_OP_EPOLL_CTL",
+  "IORING_OP_SPLICE",
+  // "IORING_OP_PROVIDE_BUFFERS",
+  // "IORING_OP_REMOVE_BUFFERS",
+  // "IORING_OP_TEE"
+  // "IORING_OP_SHUTDOWN",
+  // "IORING_OP_RENAMEAT",
+  // "IORING_OP_UNLINKAT",
+  // "IORING_OP_MKDIRAT",
+  // "IORING_OP_SYMLINKAT",
+  // "IORING_OP_LINKAT"
+};
+
+// This probe function is based on https://unixism.net/loti/tutorial/probe_liburing.html
+value
+ocaml_uring_probe(value _v_unit) {
+  CAMLparam0();
+  struct io_uring_probe *probe = io_uring_get_probe();
+  int i = 0;
+  while (op_strs[i]) {
+    if(!io_uring_opcode_supported(probe, i)) {
+      dprintf("IO_uring operation %s is NOT supported\n", op_strs[i]);
+      free(probe);
+      CAMLreturn(Val_false);
+    }
+    dprintf("IO_uring operation %s is supported\n", op_strs[i]);
+    i++;
+  }
+  free(probe);
+  CAMLreturn(Val_true);
+}
+
 value
 ocaml_uring_submit_nop(value v_uring, value v_id) {
   CAMLparam1(v_uring);

--- a/tests/main.ml
+++ b/tests/main.ml
@@ -367,6 +367,7 @@ let test_free_busy () =
   Uring.exit t
 
 let () =
+  if Uring.probe () then () else failwith "Unsupported io_uring operations";
   Test_data.setup ();
   Random.self_init ();
   let tc name f = Alcotest.test_case name `Quick (fun () -> f (); Gc.full_major ()) in


### PR DESCRIPTION
This PR adds a `Uring.probe ()` function that checks the kernel's support for the various io_uring operations that we currently use (I think I got all of them). Hopefully this can help with https://github.com/ocaml-multicore/eio/issues/187 and could be used in `Eio_main` for Linux to check if we can using the io_uring backend before defaulting to libuv.