### PR TITLE
Allow sending and receiving FDs using SCM_RIGHTS

### DIFF
--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -202,24 +202,25 @@ val cancel : 'a t -> 'a job -> 'a -> 'a job option
 module Msghdr : sig
   type t
 
-  val create : Cstruct.t list -> t
+  val create : ?n_fds:int -> ?addr:Sockaddr.t -> Cstruct.t list -> t
   (** [create buffs] makes a new [msghdr] using the [buffs] 
-      for the underlying [iovec]. A dummy socket address is used
-      and will be filled when data is received.*)
+      for the underlying [iovec].
+      @param addr The remote address.
+                  Use {!Sockaddr.create} to create a dummy address that will be filled when data is received.
+      @param n_fds Reserve space to receive this many FDs (default 0) *)
 
-  val get_sockaddr : t -> Sockaddr.t
-  (** [get_sockaddr t] gets the socket address from [t]. When used
-      with {!recv_msg} the socket will only be the sender address once the message
-      is received, until then the address will be a dummy address. *)
+  val get_fds : t -> Unix.file_descr list
 end 
 
-val send_msg : 'a t -> Unix.file_descr -> Unix.sockaddr -> Cstruct.t list -> 'a -> 'a job option
-(** [send_msg t fd addr buffs d] will submit a [sendmsg(2)] request. The [Msghdr] will be constructed
-    from the address ([addr]) and the buffers ([buffs]). *)
+val send_msg : ?fds:Unix.file_descr list -> ?dst:Unix.sockaddr -> 'a t -> Unix.file_descr -> Cstruct.t list -> 'a -> 'a job option
+(** [send_msg t fd buffs d] will submit a [sendmsg(2)] request. The [Msghdr] will be constructed
+    from the FDs ([fds]), address ([dst]) and buffers ([buffs]).
+    @param dst Destination address.
+    @param fds Extra file descriptors to attach to the message. *)
 
 val recv_msg : 'a t -> Unix.file_descr -> Msghdr.t -> 'a -> 'a job option
 (** [recv_msg t fd msghdr d] will submit a [recvmsg(2)] request. If the request is 
-    successful then the [msghdr] will contain the sender address and the data sent. *)
+    successful then the [msghdr] will contain the sender address and the data received. *)
 
 (** {2 Submitting operations} *)
 

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -27,6 +27,7 @@
 #include <caml/signals.h>
 #include <caml/unixsupport.h>
 #include <caml/socketaddr.h>
+#include <sys/socket.h>
 #include <errno.h>
 #include <string.h>
 #include <poll.h>
@@ -423,28 +424,88 @@ static struct custom_operations msghdr_ops = {
   custom_fixed_length_default
 };
 
+struct msghdr_with_cmsg {
+  struct msghdr msg;
+  struct cmsghdr cmsg;
+};
+
 // v_sockaddr and v_iov must not be freed before the msghdr as it contains pointers to them
 value
-ocaml_uring_make_msghdr(value v_sockaddr, value v_iov) {
-  CAMLparam2(v_sockaddr, v_iov);
+ocaml_uring_make_msghdr(value v_n_fds, value v_fds, value v_sockaddr_opt, value v_iov) {
+  CAMLparam3(v_fds, v_sockaddr_opt, v_iov);
   CAMLlocal1(v);
   struct msghdr *msg;
   struct iovec *iovs = Iovec_val(Field(v_iov, 0));
   int iovs_len = Int_val(Field(v_iov, 1));
+  int n_fds = Int_val(v_n_fds);
+  int cmsg_offset, controllen, total_size;
+  cmsg_offset = sizeof(struct msghdr_with_cmsg) - sizeof(struct cmsghdr);
+  controllen = n_fds > 0 ? CMSG_SPACE(sizeof(int) * n_fds) : 0;
+  total_size = cmsg_offset + controllen;
+  //dprintf("using %d bytes to hold %d FDs\n", total_size, n_fds);
   // Allocate a pointer on the OCaml heap for the msghdr
-  v = caml_alloc_custom_mem(&msghdr_ops, sizeof(struct msghdr *), sizeof(struct msghdr));
+  v = caml_alloc_custom_mem(&msghdr_ops, sizeof(struct msghdr *), total_size);
   Msghdr_val(v) = NULL;
-  msg = (struct msghdr *) caml_stat_alloc(sizeof(struct msghdr));
-  // The msghdr must zero-ed to avoid unwanted errors
-  memset(msg, 0, sizeof(struct msghdr));
+  msg = (struct msghdr *) caml_stat_alloc(total_size);
+  // The msghdr and cmsghdr must zero-ed to avoid unwanted errors
+  memset(msg, 0, total_size);
   Msghdr_val(v) = msg;
-  struct sock_addr_data *addr = Sock_addr_val(v_sockaddr);
-  // Store the address and iovec data in the message
-  msg->msg_name = &(addr->sock_addr_addr);
-  msg->msg_namelen = sizeof(addr->sock_addr_addr);
+  if (Is_some(v_sockaddr_opt)) {
+    struct sock_addr_data *addr = Sock_addr_val(Some_val(v_sockaddr_opt));
+    // Store the address and iovec data in the message
+    msg->msg_name = &(addr->sock_addr_addr);
+    msg->msg_namelen = sizeof(addr->sock_addr_addr);
+  } else {
+    msg->msg_name = NULL;
+  }
   msg->msg_iov = iovs;
   msg->msg_iovlen = iovs_len;
+  // Add the FDs to the message
+  if (n_fds > 0) {
+    int i;
+    struct cmsghdr *cm;
+    msg->msg_control = &(((struct msghdr_with_cmsg *) msg)->cmsg);
+    msg->msg_controllen = controllen;
+    if (Is_block(v_fds)) {
+      cm = CMSG_FIRSTHDR(msg);
+      cm->cmsg_level = SOL_SOCKET;
+      cm->cmsg_type = SCM_RIGHTS;
+      cm->cmsg_len = CMSG_LEN(n_fds * sizeof(int));
+      for (i = 0; i < n_fds; i++) {
+	int fd = -1;
+	if (Is_block(v_fds)) {
+	  fd = Int_val(Field(v_fds, 0));
+	  v_fds = Field(v_fds, 1);
+	}
+	((int *)CMSG_DATA(cm))[i] = fd;
+      }
+    }
+  }
   CAMLreturn(v);
+}
+
+value
+ocaml_uring_get_msghdr_fds(value v_msghdr) {
+  CAMLparam1(v_msghdr);
+  CAMLlocal2(v_list, v_cons);
+  struct msghdr *msg = Msghdr_val(v_msghdr);
+  struct cmsghdr *cm;
+  v_list = Val_int(0);
+  for (cm = CMSG_FIRSTHDR(msg); cm; cm = CMSG_NXTHDR(msg, cm)) {
+    if (cm->cmsg_level == SOL_SOCKET && cm->cmsg_type == SCM_RIGHTS) {
+      int *fds = (int *) CMSG_DATA(cm);
+      int n_fds = (cm->cmsg_len - CMSG_LEN(0)) / sizeof(int);
+      int i;
+      for (i = n_fds - 1; i >= 0; i--) {
+	int fd = Val_int(fds[i]);
+	value v_cons = caml_alloc_tuple(2);
+	Store_field(v_cons, 0, fd);
+	Store_field(v_cons, 1, v_list);
+	v_list = v_cons;
+      }
+    }
+  }
+  CAMLreturn(v_list);
 }
 
 // v_sockaddr must not be GC'd while the call is in progress


### PR DESCRIPTION
This also makes the target address in `send_msg` optional. It's not needed for connected sockets.