### PR TITLE
Don't allocate a fixed buffer by default

### DIFF
--- a/tests/main.ml
+++ b/tests/main.ml
@@ -341,7 +341,7 @@ let test_cancel_late () =
   ) else (
     (* This isn't the case we want to test, but it can happen sometimes. *)
     check_int ~__POS__ ~expected:(-125) r_read; (* ECANCELED *)
-    check_int ~__POS__ ~expected:1 r_cancel;    (* Success *)
+    check_int ~__POS__ ~expected:0 r_cancel;    (* Success *)
   );
   Unix.close r
 

--- a/tests/main.ml
+++ b/tests/main.ml
@@ -123,8 +123,8 @@ let test_invalid_queue_depth () =
   check_raises ~__POS__ (Invalid_argument "Non-positive queue depth: 0")
     (fun () -> ignore (Uring.create ~queue_depth:0 ()))
 
-let with_uring ?(fixed_buf_len=1024) ~queue_depth fn =
-  let t = Uring.create ~fixed_buf_len ~queue_depth () in
+let with_uring ~queue_depth fn =
+  let t = Uring.create ~queue_depth () in
   fn t;
   Uring.exit t  (* Only free if there wasn't an error *)
 
@@ -210,10 +210,16 @@ let test_resolve () =
   check_bool ~__POS__ ~expected:true @@ get ~resolve:Uring.Resolve.empty "..";
   check_bool ~__POS__ ~expected:false @@ get ~resolve:Uring.Resolve.beneath ".."
 
+let set_fixed_buffer t size =
+  let fbuf = Bigarray.(Array1.create char c_layout size) in
+  match Uring.set_fixed_buffer t fbuf with
+  | Ok () -> fbuf
+  | Error `ENOMEM -> failwith "Resource limit exceeded"
+
 let test_read () =
   with_uring ~queue_depth:1 @@ fun t ->
+  let fbuf = set_fixed_buffer t 1024 in
   Test_data.with_fd @@ fun fd ->
-
   let off = 3 in
   let len = 5 in
   let file_offset = Int63.of_int 2 in
@@ -224,7 +230,6 @@ let test_read () =
   assert_   ~__POS__ (token = `Read);
   check_int ~__POS__ read ~expected:len;
 
-  let fbuf = Uring.buf t in
   let got = Cstruct.of_bigarray fbuf ~off ~len in
   check_string ~__POS__  ~expected:"test " (Cstruct.to_string got)
 
@@ -261,9 +266,10 @@ let test_readv2 () =
   check_string ~__POS__ ~expected:"Gathered [A te] and [st ]" (Cstruct.to_string b)
 
 let test_region () =
-  with_uring ~queue_depth:1 ~fixed_buf_len:64 @@ fun t ->
+  with_uring ~queue_depth:1 @@ fun t ->
+  let fbuf = set_fixed_buffer t 64 in
   Test_data.with_fd @@ fun fd ->
-  let region = Uring.Region.init (Uring.buf t) 4 ~block_size:16 in
+  let region = Uring.Region.init fbuf 4 ~block_size:16 in
   let chunk = Uring.Region.alloc region in
   assert_some ~__POS__ (Uring.read_chunk t fd chunk `Read ~file_offset:Int63.zero);
   let token, read = consume t in
@@ -283,6 +289,7 @@ let test_region () =
 (* Ask to read from a pipe (with no data available), then cancel it. *)
 let test_cancel () =
   with_uring ~queue_depth:5 @@ fun t ->
+  let _fbuf = set_fixed_buffer t 1024 in
   (* while true do *)
   let r, w = Unix.pipe () in
   let read = Uring.read_fixed t ~file_offset:Int63.zero r ~off:0 ~len:1 `Read |> Option.get in
@@ -313,6 +320,7 @@ let test_cancel () =
 (* By the time we cancel, the request has already succeeded (we just didn't process the reply yet). *)
 let test_cancel_late () =
   with_uring ~queue_depth:5 @@ fun t ->
+  let _fbuf = set_fixed_buffer t 1024 in
   let r = Unix.openfile "/dev/zero" Unix.[O_RDONLY] 0 in
   let read = Uring.read_fixed t ~file_offset:Int63.zero r ~off:0 ~len:1 `Read |> Option.get in
   check_int   ~__POS__ (Uring.submit t) ~expected:1;
@@ -340,6 +348,7 @@ let test_cancel_late () =
 (* By the time we cancel, we already knew the operation was over. *)
 let test_cancel_invalid () =
   with_uring ~queue_depth:5 @@ fun t ->
+  let _fbuf = set_fixed_buffer t 1024 in
   let r = Unix.openfile "/dev/zero" Unix.[O_RDONLY] 0 in
   let read = Uring.read_fixed t ~file_offset:Int63.zero r ~off:0 ~len:1 `Read |> Option.get in
   let token, r_read = consume t in
@@ -353,6 +362,7 @@ let test_cancel_invalid () =
 
 let test_free_busy () =
   let t = Uring.create ~queue_depth:1 () in
+  let _fbuf = set_fixed_buffer t 1024 in
   let r, w = Unix.pipe () in
   Fun.protect ~finally:(fun () -> Unix.close r) @@ fun () ->
   assert_some ~__POS__ (Uring.read_fixed t ~file_offset:Int63.minus_one r ~off:0 ~len:1 `Read);


### PR DESCRIPTION
Instead, let the user call `set_fixed_buffer` manually if they want one. This avoids allocating locked memory by accident, and makes it easy to handle the case of hitting a resource limit.

/cc @avsm