### PR TITLE
Allow clock to be configured in Uring.wait

### DIFF
--- a/lib/uring/include/discover.ml
+++ b/lib/uring/include/discover.ml
@@ -2,7 +2,9 @@ module C = Configurator.V1
 
 let () =
   C.main ~name:"discover" (fun c ->
-      C.C_define.import c ~c_flags:["-D_GNU_SOURCE"] ~includes:["fcntl.h"; "poll.h"; "sys/uio.h"] C.C_define.Type.[
+    C.C_define.import c ~c_flags:["-D_GNU_SOURCE"]
+      ~includes:["fcntl.h"; "poll.h"; "sys/uio.h"; "linux/time_types.h"]
+      C.C_define.Type.[
           "POLLIN", Int;
           "POLLOUT", Int;
           "POLLERR", Int;
@@ -31,10 +33,16 @@ let () =
           "AT_FDCWD", Int;
 
           "sizeof(struct iovec)", Int;
+          "sizeof(struct __kernel_timespec)", Int;
         ]
       |> List.map (function
           | name, C.C_define.Value.Int v ->
-            let name = if name = "sizeof(struct iovec)" then "sizeof_iovec" else name in
+            let name = 
+              match name with
+              | "sizeof(struct iovec)" -> "sizeof_iovec"
+              | "sizeof(struct __kernel_timespec)" -> "sizeof_kernel_timespec"
+              | nm -> nm 
+            in
             Printf.sprintf "let %s = 0x%x" (String.lowercase_ascii name) v
           | _ -> assert false
         )

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -209,7 +209,7 @@ module Uring = struct
 
   type offset = Optint.Int63.t
   external submit_nop : t -> id -> bool = "ocaml_uring_submit_nop" [@@noalloc]
-  external submit_timeout : t -> id -> Sketch.ptr -> [`Boottime | `Realtime] -> [`Relative | `Absolute] -> bool = "ocaml_uring_submit_timeout" [@@noalloc]
+  external submit_timeout : t -> id -> Sketch.ptr -> [`Boottime | `Realtime] -> bool -> bool = "ocaml_uring_submit_timeout" [@@noalloc]
   external submit_poll_add : t -> Unix.file_descr -> id -> Poll_mask.t -> bool = "ocaml_uring_submit_poll_add" [@@noalloc]
   external submit_read : t -> Unix.file_descr -> id -> Cstruct.t -> offset -> bool = "ocaml_uring_submit_read" [@@noalloc]
   external submit_write : t -> Unix.file_descr -> id -> Cstruct.t -> offset -> bool = "ocaml_uring_submit_write" [@@noalloc]
@@ -337,10 +337,10 @@ let noop t user_data =
 
 external set_timespec: Sketch.ptr -> int64 -> unit = "ocaml_uring_set_timespec" [@@noalloc]
 
-let timeout ?(rel = `Relative) t clock timeout_ns user_data =
+let timeout ?(absolute = false) t clock timeout_ns user_data =
   let timespec_ptr = Sketch.alloc t.sketch Config.sizeof_kernel_timespec in
   set_timespec timespec_ptr timeout_ns;
-  with_id t (fun id -> Uring.submit_timeout t.uring id timespec_ptr clock rel) user_data
+  with_id t (fun id -> Uring.submit_timeout t.uring id timespec_ptr clock absolute) user_data
 
 let at_fdcwd : Unix.file_descr = Obj.magic Config.at_fdcwd
 

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -209,6 +209,7 @@ module Uring = struct
 
   type offset = Optint.Int63.t
   external submit_nop : t -> id -> bool = "ocaml_uring_submit_nop" [@@noalloc]
+  external submit_timeout : t -> id -> [`Clock_mono | `Clock_sys | `Clock_default ] -> int64 -> bool = "ocaml_uring_submit_timeout"
   external submit_poll_add : t -> Unix.file_descr -> id -> Poll_mask.t -> bool = "ocaml_uring_submit_poll_add" [@@noalloc]
   external submit_read : t -> Unix.file_descr -> id -> Cstruct.t -> offset -> bool = "ocaml_uring_submit_read" [@@noalloc]
   external submit_write : t -> Unix.file_descr -> id -> Cstruct.t -> offset -> bool = "ocaml_uring_submit_write" [@@noalloc]
@@ -333,6 +334,9 @@ let with_id t fn a = with_id_full t fn a ~extra_data:()
 
 let noop t user_data =
   with_id t (fun id -> Uring.submit_nop t.uring id) user_data
+
+let timeout t ?(clock=`Clock_default) timeout_ns user_data =
+  with_id t (fun id -> Uring.submit_timeout t.uring id clock timeout_ns) user_data
 
 let at_fdcwd : Unix.file_descr = Obj.magic Config.at_fdcwd
 

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -194,6 +194,8 @@ end
 
 type 'a job = 'a Heap.entry
 
+type clock = Boottime | Realtime
+
 module Uring = struct
   type t
 
@@ -209,7 +211,7 @@ module Uring = struct
 
   type offset = Optint.Int63.t
   external submit_nop : t -> id -> bool = "ocaml_uring_submit_nop" [@@noalloc]
-  external submit_timeout : t -> id -> Sketch.ptr -> [`Boottime | `Realtime] -> bool -> bool = "ocaml_uring_submit_timeout" [@@noalloc]
+  external submit_timeout : t -> id -> Sketch.ptr -> clock -> bool -> bool = "ocaml_uring_submit_timeout" [@@noalloc]
   external submit_poll_add : t -> Unix.file_descr -> id -> Poll_mask.t -> bool = "ocaml_uring_submit_poll_add" [@@noalloc]
   external submit_read : t -> Unix.file_descr -> id -> Cstruct.t -> offset -> bool = "ocaml_uring_submit_read" [@@noalloc]
   external submit_write : t -> Unix.file_descr -> id -> Cstruct.t -> offset -> bool = "ocaml_uring_submit_write" [@@noalloc]

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -209,7 +209,7 @@ module Uring = struct
 
   type offset = Optint.Int63.t
   external submit_nop : t -> id -> bool = "ocaml_uring_submit_nop" [@@noalloc]
-  external submit_timeout : t -> id -> [`Boottime | `Realtime ] -> int64 -> bool = "ocaml_uring_submit_timeout" [@@noalloc]
+  external submit_timeout : t -> id -> Sketch.ptr -> [`Boottime | `Realtime ] -> bool = "ocaml_uring_submit_timeout" [@@noalloc]
   external submit_poll_add : t -> Unix.file_descr -> id -> Poll_mask.t -> bool = "ocaml_uring_submit_poll_add" [@@noalloc]
   external submit_read : t -> Unix.file_descr -> id -> Cstruct.t -> offset -> bool = "ocaml_uring_submit_read" [@@noalloc]
   external submit_write : t -> Unix.file_descr -> id -> Cstruct.t -> offset -> bool = "ocaml_uring_submit_write" [@@noalloc]
@@ -335,8 +335,12 @@ let with_id t fn a = with_id_full t fn a ~extra_data:()
 let noop t user_data =
   with_id t (fun id -> Uring.submit_nop t.uring id) user_data
 
+external set_timespec: Sketch.ptr -> int64 -> unit = "ocaml_uring_set_timespec" [@@noalloc]
+
 let timeout t clock timeout_ns user_data =
-  with_id t (fun id -> Uring.submit_timeout t.uring id clock timeout_ns) user_data
+  let ptr = Sketch.alloc t.sketch Config.sizeof_kernel_timespec in
+  set_timespec ptr timeout_ns;
+  with_id t (fun id -> Uring.submit_timeout t.uring id ptr clock) user_data
 
 let at_fdcwd : Unix.file_descr = Obj.magic Config.at_fdcwd
 

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -209,7 +209,7 @@ module Uring = struct
 
   type offset = Optint.Int63.t
   external submit_nop : t -> id -> bool = "ocaml_uring_submit_nop" [@@noalloc]
-  external submit_timeout : t -> id -> Sketch.ptr -> [`Boottime | `Realtime ] -> bool = "ocaml_uring_submit_timeout" [@@noalloc]
+  external submit_timeout : t -> id -> Sketch.ptr -> [`Boottime | `Realtime] -> [`Relative | `Absolute] -> bool = "ocaml_uring_submit_timeout" [@@noalloc]
   external submit_poll_add : t -> Unix.file_descr -> id -> Poll_mask.t -> bool = "ocaml_uring_submit_poll_add" [@@noalloc]
   external submit_read : t -> Unix.file_descr -> id -> Cstruct.t -> offset -> bool = "ocaml_uring_submit_read" [@@noalloc]
   external submit_write : t -> Unix.file_descr -> id -> Cstruct.t -> offset -> bool = "ocaml_uring_submit_write" [@@noalloc]
@@ -337,10 +337,10 @@ let noop t user_data =
 
 external set_timespec: Sketch.ptr -> int64 -> unit = "ocaml_uring_set_timespec" [@@noalloc]
 
-let timeout t clock timeout_ns user_data =
-  let ptr = Sketch.alloc t.sketch Config.sizeof_kernel_timespec in
-  set_timespec ptr timeout_ns;
-  with_id t (fun id -> Uring.submit_timeout t.uring id ptr clock) user_data
+let timeout ?(rel = `Relative) t clock timeout_ns user_data =
+  let timespec_ptr = Sketch.alloc t.sketch Config.sizeof_kernel_timespec in
+  set_timespec timespec_ptr timeout_ns;
+  with_id t (fun id -> Uring.submit_timeout t.uring id timespec_ptr clock rel) user_data
 
 let at_fdcwd : Unix.file_descr = Obj.magic Config.at_fdcwd
 

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -209,7 +209,7 @@ module Uring = struct
 
   type offset = Optint.Int63.t
   external submit_nop : t -> id -> bool = "ocaml_uring_submit_nop" [@@noalloc]
-  external submit_timeout : t -> id -> [`Clock_mono | `Clock_sys | `Clock_default ] -> int64 -> bool = "ocaml_uring_submit_timeout"
+  external submit_timeout : t -> id -> [`Boottime | `Realtime ] -> int64 -> bool = "ocaml_uring_submit_timeout" [@@noalloc]
   external submit_poll_add : t -> Unix.file_descr -> id -> Poll_mask.t -> bool = "ocaml_uring_submit_poll_add" [@@noalloc]
   external submit_read : t -> Unix.file_descr -> id -> Cstruct.t -> offset -> bool = "ocaml_uring_submit_read" [@@noalloc]
   external submit_write : t -> Unix.file_descr -> id -> Cstruct.t -> offset -> bool = "ocaml_uring_submit_write" [@@noalloc]
@@ -335,7 +335,7 @@ let with_id t fn a = with_id_full t fn a ~extra_data:()
 let noop t user_data =
   with_id t (fun id -> Uring.submit_nop t.uring id) user_data
 
-let timeout t ?(clock=`Clock_default) timeout_ns user_data =
+let timeout t clock timeout_ns user_data =
   with_id t (fun id -> Uring.submit_timeout t.uring id clock timeout_ns) user_data
 
 let at_fdcwd : Unix.file_descr = Obj.magic Config.at_fdcwd

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -67,11 +67,14 @@ val noop : 'a t -> 'a -> 'a job option
 (** [noop t d] submits a no-op operation to uring [t]. The user data [d] will be
     returned by {!wait} or {!peek} upon completion. *)
 
-val timeout: ?absolute:bool -> 'a t -> [`Boottime | `Realtime] -> int64 -> 'a -> 'a job option
-(** [timeout t clock ns d] submits a timeout request to uring [t].
+(** {2 Timeout} *)
 
-    [clock] [`Boottime] and [`Realtime] represents OS clocks CLOCK_BOOTTIME and CLOCK_REALTIME 
-    respectively.
+type clock = Boottime | Realtime
+(** Represents Linux clocks. [Boottime] and [Realtime] represents OS clocks CLOCK_BOOTTIME
+    and CLOCK_REALTIME respectively. *)
+
+val timeout: ?absolute:bool -> 'a t -> clock -> int64 -> 'a -> 'a job option
+(** [timeout t clock ns d] submits a timeout request to uring [t].
 
     [absolute] denotes how [clock] and [ns] relate to one another. Default value is [false]
 

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -67,13 +67,13 @@ val noop : 'a t -> 'a -> 'a job option
 (** [noop t d] submits a no-op operation to uring [t]. The user data [d] will be
     returned by {!wait} or {!peek} upon completion. *)
 
-val timeout: ?rel:[`Relative | `Absolute] -> 'a t -> [`Boottime | `Realtime] -> int64 -> 'a -> 'a job option
+val timeout: ?absolute:bool -> 'a t -> [`Boottime | `Realtime] -> int64 -> 'a -> 'a job option
 (** [timeout t clock ns d] submits a timeout request to uring [t].
 
     [clock] [`Boottime] and [`Realtime] represents OS clocks CLOCK_BOOTTIME and CLOCK_REALTIME 
     respectively.
 
-    [rel] denotes how [clock] and [ns] relates to one another. Default value is [`Relative]
+    [absolute] denotes how [clock] and [ns] relate to one another. Default value is [false]
 
     [ns] is the timeout time in nanoseconds *)
 

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -67,6 +67,14 @@ val noop : 'a t -> 'a -> 'a job option
 (** [noop t d] submits a no-op operation to uring [t]. The user data [d] will be
     returned by {!wait} or {!peek} upon completion. *)
 
+val timeout: 'a t -> ?clock:[`Clock_mono | `Clock_sys | `Clock_default] -> int64 -> 'a -> 'a job option
+(** [timeout t d clock ns] submits a timeout request to uring [t].
+
+    [clock] [`Clock_default] represents the default clock used by uring, [`Clock_mono] represents 
+    CLOCK_BOOTTIME and [`Clock_sys] represents CLOCK_REALTIME.
+
+    [ns] is the the timeout time in nanoseconds *)
+
 module type FLAGS = sig
   type t = private int
   (** A set of flags. *)

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -67,13 +67,15 @@ val noop : 'a t -> 'a -> 'a job option
 (** [noop t d] submits a no-op operation to uring [t]. The user data [d] will be
     returned by {!wait} or {!peek} upon completion. *)
 
-val timeout: 'a t -> [`Boottime | `Realtime] -> int64 -> 'a -> 'a job option
+val timeout: ?rel:[`Relative | `Absolute] -> 'a t -> [`Boottime | `Realtime] -> int64 -> 'a -> 'a job option
 (** [timeout t clock ns d] submits a timeout request to uring [t].
 
-    [clock] [`Boottime] and [`Realtime] represents CLOCK_BOOTTIME and
-    CLOCK_REALTIME respectively.
+    [clock] [`Boottime] and [`Realtime] represents OS clocks CLOCK_BOOTTIME and CLOCK_REALTIME 
+    respectively.
 
-    [ns] is the the timeout time in nanoseconds *)
+    [rel] denotes how [clock] and [ns] relates to one another. Default value is [`Relative]
+
+    [ns] is the timeout time in nanoseconds *)
 
 module type FLAGS = sig
   type t = private int

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -67,11 +67,11 @@ val noop : 'a t -> 'a -> 'a job option
 (** [noop t d] submits a no-op operation to uring [t]. The user data [d] will be
     returned by {!wait} or {!peek} upon completion. *)
 
-val timeout: 'a t -> ?clock:[`Clock_mono | `Clock_sys | `Clock_default] -> int64 -> 'a -> 'a job option
-(** [timeout t d clock ns] submits a timeout request to uring [t].
+val timeout: 'a t -> [`Boottime | `Realtime] -> int64 -> 'a -> 'a job option
+(** [timeout t clock ns d] submits a timeout request to uring [t].
 
-    [clock] [`Clock_default] represents the default clock used by uring, [`Clock_mono] represents 
-    CLOCK_BOOTTIME and [`Clock_sys] represents CLOCK_REALTIME.
+    [clock] [`Boottime] and [`Realtime] represents CLOCK_BOOTTIME and
+    CLOCK_REALTIME respectively.
 
     [ns] is the the timeout time in nanoseconds *)
 

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -33,7 +33,6 @@
 #include <string.h>
 #include <poll.h>
 #include <sys/uio.h>
-#include <stdint.h>
 
 #undef URING_DEBUG
 #ifdef URING_DEBUG

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -157,21 +157,24 @@ ocaml_uring_set_timespec(value v_sketch_ptr, value v_timeout)
 }
 
 value /* noalloc */
-ocaml_uring_submit_timeout(value v_uring, value v_id, value v_sketch_ptr, value v_clock)
+ocaml_uring_submit_timeout(value v_uring, value v_id, value v_sketch_ptr, value v_clock, value v_rel)
 {
   struct __kernel_timespec *t = Sketch_ptr_val(v_sketch_ptr);
   struct io_uring* ring = Ring_val(v_uring);
   struct io_uring_sqe* sqe;
-  int clock;
+  int flags;
 
   if (v_clock == caml_hash_variant("Boottime"))
-    clock = IORING_TIMEOUT_BOOTTIME;
+    flags = IORING_TIMEOUT_BOOTTIME;
   else
-    clock = IORING_TIMEOUT_REALTIME;
+    flags = IORING_TIMEOUT_REALTIME;
+
+  if(v_rel == caml_hash_variant("Absolute"))
+    flags |= IORING_TIMEOUT_ABS;
 
   sqe = io_uring_get_sqe(ring);
   if (!sqe) return Val_false;
-  io_uring_prep_timeout(sqe, t, 0, clock);
+  io_uring_prep_timeout(sqe, t, 0, flags);
   io_uring_sqe_set_data(sqe, (void *)Long_val(v_id));
   return Val_true;
 }

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -157,7 +157,7 @@ ocaml_uring_set_timespec(value v_sketch_ptr, value v_timeout)
 }
 
 value /* noalloc */
-ocaml_uring_submit_timeout(value v_uring, value v_id, value v_sketch_ptr, value v_clock, value v_rel)
+ocaml_uring_submit_timeout(value v_uring, value v_id, value v_sketch_ptr, value v_clock, value v_absolute)
 {
   struct __kernel_timespec *t = Sketch_ptr_val(v_sketch_ptr);
   struct io_uring* ring = Ring_val(v_uring);
@@ -169,7 +169,7 @@ ocaml_uring_submit_timeout(value v_uring, value v_id, value v_sketch_ptr, value 
   else
     flags = IORING_TIMEOUT_REALTIME;
 
-  if(v_rel == caml_hash_variant("Absolute"))
+  if(Bool_val(v_absolute))
     flags |= IORING_TIMEOUT_ABS;
 
   sqe = io_uring_get_sqe(ring);

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -156,6 +156,8 @@ ocaml_uring_set_timespec(value v_sketch_ptr, value v_timeout)
   t->tv_nsec = Int64_val(v_timeout);
 }
 
+#define Val_boottime Val_int(0)
+
 value /* noalloc */
 ocaml_uring_submit_timeout(value v_uring, value v_id, value v_sketch_ptr, value v_clock, value v_absolute)
 {
@@ -164,7 +166,7 @@ ocaml_uring_submit_timeout(value v_uring, value v_id, value v_sketch_ptr, value 
   struct io_uring_sqe* sqe;
   int flags;
 
-  if (v_clock == caml_hash_variant("Boottime"))
+  if (v_clock == Val_boottime)
     flags = IORING_TIMEOUT_BOOTTIME;
   else
     flags = IORING_TIMEOUT_REALTIME;

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -33,6 +33,7 @@
 #include <string.h>
 #include <poll.h>
 #include <sys/uio.h>
+#include <stdint.h>
 
 #undef URING_DEBUG
 #ifdef URING_DEBUG
@@ -144,6 +145,40 @@ value /* noalloc */
 ocaml_uring_sq_ready(value v_uring) {
   struct io_uring *ring = Ring_val(v_uring);
   return (Int_val(io_uring_sq_ready(ring)));
+}
+
+value ocaml_uring_submit_timeout(value v_uring, value v_id, value v_clock, value v_timeout)
+{
+  CAMLparam4(v_uring, v_id, v_clock, v_timeout);
+  struct __kernel_timespec t;
+  struct io_uring* ring = Ring_val(v_uring);
+  struct io_uring_sqe* sqe;
+  int res, clock;
+
+  if (v_clock == caml_hash_variant("Clock_mono"))
+    clock = IORING_TIMEOUT_BOOTTIME;
+  else if (v_clock == caml_hash_variant("Clock_sys"))
+    clock = IORING_TIMEOUT_REALTIME;
+  else
+    clock = 0;
+
+  t.tv_sec = 0;
+  t.tv_nsec = Int64_val(v_timeout);
+
+  sqe = io_uring_get_sqe(ring);
+  if(!sqe) {
+    res = io_uring_submit(ring);
+    if (res < 0)
+      CAMLreturn(Val_false);
+
+    sqe = io_uring_get_sqe(ring);
+    if(!sqe)
+      CAMLreturn(Val_false);
+  }
+  io_uring_prep_timeout(sqe, &t, 0, clock);
+  io_uring_sqe_set_data(sqe, (void *)Long_val(v_id));
+  sqe->user_data = LIBURING_UDATA_TIMEOUT;
+  CAMLreturn(Val_true);
 }
 
 struct open_how_data {

--- a/tests/main.md
+++ b/tests/main.md
@@ -771,7 +771,7 @@ val timeout : int = -62
     ((Unix.gettimeofday () +. 0.01) *. 1e9)
     |> Int64.of_float
   in
-  Uring.timeout ~rel:`Absolute t `Realtime ns `Timeout;;
+  Uring.timeout ~absolute:true t `Realtime ns `Timeout;;
 - : [ `Timeout ] Uring.job option = Some <abstr>
 
 # let `Timeout, timeout = consume t;;

--- a/tests/main.md
+++ b/tests/main.md
@@ -757,8 +757,8 @@ Timeout should return (-ETIME). This is defined in https://github.com/torvalds/l
 # let t = Uring.create ~queue_depth:1 ();;
 val t : '_weak13 Uring.t = <abstr>
 
-# let ns = Int64.(mul 10L 1_000_000L) in
-  Uring.timeout t `Realtime ns `Timeout;;
+# let ns1 = Int64.(mul 10L 1_000_000L) in
+  Uring.(timeout t Boottime ns1 `Timeout);;
 - : _[> `Timeout ] Uring.job option = Some <abstr>
 
 # Uring.submit t;;
@@ -771,7 +771,14 @@ val timeout : int = -62
     ((Unix.gettimeofday () +. 0.01) *. 1e9)
     |> Int64.of_float
   in
-  Uring.timeout ~absolute:true t `Realtime ns `Timeout;;
+  Uring.(timeout ~absolute:true t Realtime ns `Timeout);;
+- : [ `Timeout ] Uring.job option = Some <abstr>
+
+# let `Timeout, timeout = consume t;;
+val timeout : int = -62
+
+# let ns1 = Int64.(mul 10L 1_000_000L) in
+  Uring.(timeout ~absolute:true t Boottime ns1 `Timeout);;
 - : [ `Timeout ] Uring.job option = Some <abstr>
 
 # let `Timeout, timeout = consume t;;

--- a/tests/main.md
+++ b/tests/main.md
@@ -757,12 +757,22 @@ Timeout should return (-ETIME). This is defined in https://github.com/torvalds/l
 # let t = Uring.create ~queue_depth:1 ();;
 val t : '_weak13 Uring.t = <abstr>
 
-# let ns = Int64.(mul 1L 1_000_000_000L) in
+# let ns = Int64.(mul 10L 1_000_000L) in
   Uring.timeout t `Realtime ns `Timeout;;
 - : _[> `Timeout ] Uring.job option = Some <abstr>
 
 # Uring.submit t;;
 - : int = 1
+
+# let `Timeout, timeout = consume t;;
+val timeout : int = -62
+
+# let ns = 
+    ((Unix.gettimeofday () +. 0.01) *. 1e9)
+    |> Int64.of_float
+  in
+  Uring.timeout ~rel:`Absolute t `Realtime ns `Timeout;;
+- : [ `Timeout ] Uring.job option = Some <abstr>
 
 # let `Timeout, timeout = consume t;;
 val timeout : int = -62

--- a/tests/main.md
+++ b/tests/main.md
@@ -748,3 +748,25 @@ val b : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 1}
 # Uring.exit t;;
 - : unit = ()
 ```
+
+## Timeout
+
+Timeout should return (-ETIME). This is defined in https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/errno.h#L45
+
+```ocaml
+# let t = Uring.create ~queue_depth:1 ();;
+val t : '_weak13 Uring.t = <abstr>
+
+# let ns = Int64.(mul 1L 1_000_000_000L) in
+  Uring.timeout t `Realtime ns `Timeout;;
+- : _[> `Timeout ] Uring.job option = Some <abstr>
+
+# Uring.submit t;;
+- : int = 1
+
+# let `Timeout, timeout = consume t;;
+val timeout : int = -62
+
+# Uring.exit t;;
+- : unit = ()
+```


### PR DESCRIPTION
This PR allows specifying clocks for timeout (as timeout is relative to a clock) when waiting for `cqe` events; specifically `Uring.wait` now accepts clock argument along with the `timeout` value in nanoseconds.

Summary:
- Changes timeout from seconds to nanoseconds (float -> int64)
- Add `Clock_mono`, `Clock_sys` ~~and `Clock_default` to `Uring.wait`~~

Required by https://github.com/ocaml-multicore/eio/pull/249