### PR TITLE
Allow clock to be configured in Uring.wait_cqe (no mdx)

### DIFF
--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -214,14 +214,14 @@ module Msghdr : sig
   type t
 
   val create : ?n_fds:int -> ?addr:Sockaddr.t -> Cstruct.t list -> t
-  (** [create buffs] makes a new [msghdr] using the [buffs] 
+  (** [create buffs] makes a new [msghdr] using the [buffs]
       for the underlying [iovec].
       @param addr The remote address.
                   Use {!Sockaddr.create} to create a dummy address that will be filled when data is received.
       @param n_fds Reserve space to receive this many FDs (default 0) *)
 
   val get_fds : t -> Unix.file_descr list
-end 
+end
 
 val send_msg : ?fds:Unix.file_descr list -> ?dst:Unix.sockaddr -> 'a t -> Unix.file_descr -> Cstruct.t list -> 'a -> 'a job option
 (** [send_msg t fd buffs d] will submit a [sendmsg(2)] request. The [Msghdr] will be constructed
@@ -230,7 +230,7 @@ val send_msg : ?fds:Unix.file_descr list -> ?dst:Unix.sockaddr -> 'a t -> Unix.f
     @param fds Extra file descriptors to attach to the message. *)
 
 val recv_msg : 'a t -> Unix.file_descr -> Msghdr.t -> 'a -> 'a job option
-(** [recv_msg t fd msghdr d] will submit a [recvmsg(2)] request. If the request is 
+(** [recv_msg t fd msghdr d] will submit a [recvmsg(2)] request. If the request is
     successful then the [msghdr] will contain the sender address and the data received. *)
 
 (** {2 Submitting operations} *)
@@ -248,9 +248,9 @@ type 'a completion_option =
     occurred. [Some] contains both the user data attached to the completed
     request and the integer syscall result. *)
 
-val wait : ?timeout:float -> 'a t -> 'a completion_option
-(** [wait ?timeout t] will block indefinitely (the default) or for [timeout]
-    seconds for any outstanding events to complete on uring [t]. Events should
+val wait : ?clock:[`Clock_mono | `Clock_sys | `Clock_default] -> ?timeout:int64 -> 'a t -> 'a completion_option
+(** [wait ?clock ?timeout t] will block indefinitely (the default) or for [timeout]
+    nanoseconds for any outstanding events to complete on uring [t]. Events should
     have been queued via {!submit} previously to this call. *)
 
 val peek : 'a t -> 'a completion_option

--- a/tests/main.ml
+++ b/tests/main.ml
@@ -115,7 +115,8 @@ module Test_data = struct
 end
 
 let rec consume t =
-  match Uring.wait ~timeout:1. t with
+  let timeout = Int64.of_float (1. *. 1e9) in
+  match Uring.wait ~timeout t with
   | Some { data; result } -> (data, result)
   | None -> consume t
 


### PR DESCRIPTION
This is an alternate PR to https://github.com/ocaml-multicore/ocaml-uring/pull/59. I am opening the PR to determine if `dune runtest` fail as when using mdx vs when not using mdx (i.e. alcotest and this PR). 