### PR TITLE
Readwrite

### DIFF
--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -166,6 +166,8 @@ module Uring = struct
   type offset = Optint.Int63.t
   external submit_nop : t -> id -> bool = "ocaml_uring_submit_nop" [@@noalloc]
   external submit_poll_add : t -> Unix.file_descr -> id -> Poll_mask.t -> bool = "ocaml_uring_submit_poll_add" [@@noalloc]
+  external submit_read : t -> Unix.file_descr -> id -> Cstruct.t -> offset -> bool = "ocaml_uring_submit_read" [@@noalloc]
+  external submit_write : t -> Unix.file_descr -> id -> Cstruct.t -> offset -> bool = "ocaml_uring_submit_write" [@@noalloc]
   external submit_readv : t -> Unix.file_descr -> id -> Iovec.t -> offset -> bool = "ocaml_uring_submit_readv" [@@noalloc]
   external submit_writev : t -> Unix.file_descr -> id -> Iovec.t -> offset -> bool = "ocaml_uring_submit_writev" [@@noalloc]
   external submit_readv_fixed : t -> Unix.file_descr -> id -> Cstruct.buffer -> int -> int -> offset -> bool = "ocaml_uring_submit_readv_fixed_byte" "ocaml_uring_submit_readv_fixed_native" [@@noalloc]
@@ -296,6 +298,12 @@ let openat2 t ~access ~flags ~perm ~resolve ?(fd=at_fdcwd) path user_data =
   in
   let open_how = Open_how.v ~open_flags ~perm ~resolve path in
   with_id_full t (fun id -> Uring.submit_openat2 t.uring id fd open_how) user_data ~extra_data:open_how
+
+let read t ~file_offset fd (buf : Cstruct.t) user_data =
+  with_id_full t (fun id -> Uring.submit_read t.uring fd id buf file_offset) user_data ~extra_data:buf
+
+let write t ~file_offset fd (buf : Cstruct.t) user_data =
+  with_id_full t (fun id -> Uring.submit_write t.uring fd id buf file_offset) user_data ~extra_data:buf
 
 let readv t ~file_offset fd buffers user_data =
   let iovec = Iovec.make buffers in

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -149,6 +149,18 @@ type offset := Optint.Int63.t
 (** For files, give the absolute offset, or use [Optint.Int63.minus_one] for the current position.
     For sockets, use an offset of [Optint.Int63.zero] ([minus_one] is not allowed here). *)
 
+val read : 'a t -> file_offset:offset -> Unix.file_descr -> Cstruct.t -> 'a -> 'a job option
+(** [read t ~file_offset fd buf d] will submit a [read(2)] request to uring [t].
+    It reads from absolute [file_offset] on the [fd] file descriptor and writes
+    the results into the memory pointed to by [buf].  The user data [d] will
+    be returned by {!wait} or {!peek} upon completion. *)
+
+val write : 'a t -> file_offset:offset -> Unix.file_descr -> Cstruct.t -> 'a -> 'a job option
+(** [write t ~file_offset fd buf d] will submit a [write(2)] request to uring [t].
+    It writes to absolute [file_offset] on the [fd] file descriptor from the
+    the memory pointed to by [buf].  The user data [d] will be returned by
+    {!wait} or {!peek} upon completion. *)
+
 val readv : 'a t -> file_offset:offset -> Unix.file_descr -> Cstruct.t list -> 'a -> 'a job option
 (** [readv t ~file_offset fd iov d] will submit a [readv(2)] request to uring [t].
     It reads from absolute [file_offset] on the [fd] file descriptor and writes

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -342,36 +342,34 @@ ocaml_uring_submit_writev_fixed_byte(value* values, int argc) {
 
 value /* noalloc */
 ocaml_uring_submit_read(value v_uring, value v_fd, value v_id, value v_cstruct, value v_fileoff) {
-  CAMLparam3(v_uring, v_cstruct, v_fileoff);
   struct io_uring *ring = Ring_val(v_uring);
   struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
   value v_ba = Field(v_cstruct, 0);
   value v_off = Field(v_cstruct, 1);
   value v_len = Field(v_cstruct, 2);
   void *buf = Caml_ba_data_val(v_ba) + Long_val(v_off);
-  if (!sqe) CAMLreturn(Val_false);
+  if (!sqe) return (Val_false);
   dprintf("submit_read: fd %d buff %p len %zd fileoff %d\n",
 	  Int_val(v_fd), buf, Long_val(v_len), Int63_val(v_fileoff));
   io_uring_prep_read(sqe, Int_val(v_fd), buf, Long_val(v_len), Int63_val(v_fileoff));
   io_uring_sqe_set_data(sqe, (void *)Long_val(v_id));
-  CAMLreturn(Val_true);
+  return (Val_true);
 }
 
-value
+value /* noalloc */
 ocaml_uring_submit_write(value v_uring, value v_fd, value v_id, value v_cstruct, value v_fileoff) {
-  CAMLparam3(v_uring, v_cstruct, v_fileoff);
   struct io_uring *ring = Ring_val(v_uring);
   struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
   value v_ba = Field(v_cstruct, 0);
   value v_off = Field(v_cstruct, 1);
   value v_len = Field(v_cstruct, 2);
   void *buf = Caml_ba_data_val(v_ba) + Long_val(v_off);
-  if (!sqe) CAMLreturn(Val_false);
+  if (!sqe) return (Val_false);
   dprintf("submit_write: fd %d buff %p len %zd fileoff %d\n",
 	  Int_val(v_fd), buf, Long_val(v_len), Int63_val(v_fileoff));
   io_uring_prep_write(sqe, Int_val(v_fd), buf, Long_val(v_len), Int63_val(v_fileoff));
   io_uring_sqe_set_data(sqe, (void *)Long_val(v_id));
-  CAMLreturn(Val_true);
+  return (Val_true);
 }
 
 value /* noalloc */

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -341,6 +341,40 @@ ocaml_uring_submit_writev_fixed_byte(value* values, int argc) {
 }
 
 value /* noalloc */
+ocaml_uring_submit_read(value v_uring, value v_fd, value v_id, value v_cstruct, value v_fileoff) {
+  CAMLparam3(v_uring, v_cstruct, v_fileoff);
+  struct io_uring *ring = Ring_val(v_uring);
+  struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
+  value v_ba = Field(v_cstruct, 0);
+  value v_off = Field(v_cstruct, 1);
+  value v_len = Field(v_cstruct, 2);
+  void *buf = Caml_ba_data_val(v_ba) + Long_val(v_off);
+  if (!sqe) CAMLreturn(Val_false);
+  dprintf("submit_read: fd %d buff %p len %zd fileoff %d\n",
+	  Int_val(v_fd), buf, Long_val(v_len), Int63_val(v_fileoff));
+  io_uring_prep_read(sqe, Int_val(v_fd), buf, Long_val(v_len), Int63_val(v_fileoff));
+  io_uring_sqe_set_data(sqe, (void *)Long_val(v_id));
+  CAMLreturn(Val_true);
+}
+
+value
+ocaml_uring_submit_write(value v_uring, value v_fd, value v_id, value v_cstruct, value v_fileoff) {
+  CAMLparam3(v_uring, v_cstruct, v_fileoff);
+  struct io_uring *ring = Ring_val(v_uring);
+  struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
+  value v_ba = Field(v_cstruct, 0);
+  value v_off = Field(v_cstruct, 1);
+  value v_len = Field(v_cstruct, 2);
+  void *buf = Caml_ba_data_val(v_ba) + Long_val(v_off);
+  if (!sqe) CAMLreturn(Val_false);
+  dprintf("submit_write: fd %d buff %p len %zd fileoff %d\n",
+	  Int_val(v_fd), buf, Long_val(v_len), Int63_val(v_fileoff));
+  io_uring_prep_write(sqe, Int_val(v_fd), buf, Long_val(v_len), Int63_val(v_fileoff));
+  io_uring_sqe_set_data(sqe, (void *)Long_val(v_id));
+  CAMLreturn(Val_true);
+}
+
+value /* noalloc */
 ocaml_uring_submit_splice(value v_uring, value v_id, value v_fd_in, value v_fd_out, value v_nbytes) {
   struct io_uring *ring = Ring_val(v_uring);
   struct io_uring_sqe *sqe = io_uring_get_sqe(ring);

--- a/tests/main.md
+++ b/tests/main.md
@@ -343,18 +343,20 @@ val b2_len : int = 7
 # let b1 = Cstruct.create b1_len and b2 = Cstruct.create b2_len;;
 val b1 : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 3}
 val b2 : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 7}
+
 # Uring.read t fd b1 `Read ~file_offset:Int63.minus_one;;
 - : [ `Read ] Uring.job option = Some <abstr>
-# Uring.read t fd b2 `Read ~file_offset:Int63.minus_one;;
-- : [ `Read ] Uring.job option = Some <abstr>
-
 # Uring.submit t;;
-- : int = 2
-
+- : int = 1
 # let `Read, read = consume t;;
 val read : int = 3
 # Cstruct.to_string b1;;
 - : string = "A t"
+
+# Uring.read t fd b2 `Read ~file_offset:Int63.minus_one;;
+- : [ `Read ] Uring.job option = Some <abstr>
+# Uring.submit t;;
+- : int = 1
 # let `Read, read = consume t;;
 val read : int = 7
 # Cstruct.to_string b2;;
@@ -379,15 +381,16 @@ val w : Unix.file_descr = <abstr>
 
 # Uring.write t w wb `Write ~file_offset:Int63.minus_one;;
 - : [ `Read | `Write ] Uring.job option = Some <abstr>
-# Uring.read t r rb `Read ~file_offset:Int63.minus_one;;
-- : [ `Read | `Write ] Uring.job option = Some <abstr>
-
 # Uring.submit t;;
-- : int = 2
-
+- : int = 1
 # let v, read = consume t;;
 val v : [ `Read | `Write ] = `Write
 val read : int = 5
+
+# Uring.read t r rb `Read ~file_offset:Int63.minus_one;;
+- : [ `Read | `Write ] Uring.job option = Some <abstr>
+# Uring.submit t;;
+- : int = 1
 # let v, read = consume t;;
 val v : [ `Read | `Write ] = `Read
 val read : int = 5

--- a/tests/main.md
+++ b/tests/main.md
@@ -332,8 +332,8 @@ val len : int = 5
 Reading with read:
 
 ```ocaml
-# let t = Uring.create ~queue_depth:2 ();;
-val t : '_weak6 Uring.t = <abstr>
+# let t : [`Read] Uring.t = Uring.create ~queue_depth:2 ();;
+val t : [ `Read ] Uring.t = <abstr>
 
 # let fd = Unix.openfile Test_data.path [ O_RDONLY ] 0;;
 val fd : Unix.file_descr = <abstr>
@@ -344,9 +344,9 @@ val b2_len : int = 7
 val b1 : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 3}
 val b2 : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 7}
 # Uring.read t fd b1 `Read ~file_offset:Int63.minus_one;;
-- : _[> `Read ] Uring.job option = Some <abstr>
+- : [ `Read ] Uring.job option = Some <abstr>
 # Uring.read t fd b2 `Read ~file_offset:Int63.minus_one;;
-- : _[> `Read ] Uring.job option = Some <abstr>
+- : [ `Read ] Uring.job option = Some <abstr>
 
 # Uring.submit t;;
 - : int = 2
@@ -367,8 +367,8 @@ val read : int = 7
 Writing with write:
 
 ```ocaml
-# let t = Uring.create ~queue_depth:2 ();;
-val t : '_weak7 Uring.t = <abstr>
+# let t : [`Read | `Write] Uring.t =  Uring.create ~queue_depth:2 ();;
+val t : [ `Read | `Write ] Uring.t = <abstr>
 
 # let rb = Cstruct.create 10 and wb = Cstruct.of_string "Hello";;
 val rb : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 10}
@@ -378,18 +378,18 @@ val r : Unix.file_descr = <abstr>
 val w : Unix.file_descr = <abstr>
 
 # Uring.write t w wb `Write ~file_offset:Int63.minus_one;;
-- : _[> `Write ] Uring.job option = Some <abstr>
+- : [ `Read | `Write ] Uring.job option = Some <abstr>
 # Uring.read t r rb `Read ~file_offset:Int63.minus_one;;
-- : _[> `Read | `Write ] Uring.job option = Some <abstr>
+- : [ `Read | `Write ] Uring.job option = Some <abstr>
 
 # Uring.submit t;;
 - : int = 2
 
 # let v, read = consume t;;
-val v : _[> `Read | `Write ] = `Write
+val v : [ `Read | `Write ] = `Write
 val read : int = 5
 # let v, read = consume t;;
-val v : _[> `Read | `Write ] = `Read
+val v : [ `Read | `Write ] = `Read
 val read : int = 5
 
 # let rb = Cstruct.sub rb 0 5;;
@@ -407,7 +407,7 @@ Reading with readv:
 
 ```ocaml
 # let t = Uring.create ~queue_depth:1 ();;
-val t : '_weak8 Uring.t = <abstr>
+val t : '_weak6 Uring.t = <abstr>
 
 # let fd = Unix.openfile Test_data.path [ O_RDONLY ] 0;;
 val fd : Unix.file_descr = <abstr>
@@ -461,7 +461,7 @@ val b : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 25}
 
 ```ocaml
 # let t = Uring.create ~queue_depth:1 ();;
-val t : '_weak9 Uring.t = <abstr>
+val t : '_weak7 Uring.t = <abstr>
 
 # let fbuf = set_fixed_buffer t 64;;
 val fbuf :
@@ -506,7 +506,7 @@ Ask to read from a pipe (with no data available), then cancel it.
 exception Multiple of Unix.error list
 
 # let t = Uring.create ~queue_depth:5 ();;
-val t : '_weak10 Uring.t = <abstr>
+val t : '_weak8 Uring.t = <abstr>
 
 # set_fixed_buffer t 1024;;
 - : (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t =
@@ -549,7 +549,7 @@ By the time we cancel, the request has already succeeded (we just didn't process
 
 ```ocaml
 # let t = Uring.create ~queue_depth:5 ();;
-val t : '_weak11 Uring.t = <abstr>
+val t : '_weak9 Uring.t = <abstr>
 # set_fixed_buffer t 102;;
 - : (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t =
 <abstr>
@@ -596,7 +596,7 @@ By the time we cancel, we already knew the operation was over:
 
 ```ocaml
 # let t = Uring.create ~queue_depth:5 ();;
-val t : '_weak12 Uring.t = <abstr>
+val t : '_weak10 Uring.t = <abstr>
 # set_fixed_buffer t 1024;;
 - : (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t =
 <abstr>
@@ -626,7 +626,7 @@ We can't exit the ring while an operation is still pending:
 
 ```ocaml
 # let t = Uring.create ~queue_depth:1 ();;
-val t : '_weak13 Uring.t = <abstr>
+val t : '_weak11 Uring.t = <abstr>
 # set_fixed_buffer t 1024;;
 - : (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t =
 <abstr>
@@ -661,7 +661,7 @@ But we can once it's complete:
 val r : Unix.file_descr = <abstr>
 val w : Unix.file_descr = <abstr>
 # let t = Uring.create ~queue_depth:2 ();;
-val t : '_weak14 Uring.t = <abstr>
+val t : '_weak12 Uring.t = <abstr>
 # let a, b = Unix.(socketpair PF_UNIX SOCK_STREAM 0);;
 val a : Unix.file_descr = <abstr>
 val b : Unix.file_descr = <abstr>


### PR DESCRIPTION
    Implement Uring.read and Uring.write

    These are simple wrappers for read(2) and write(2) that use a Cstruct.t.
    This avoids the extra allocations done by readv(2) and writev(2) as we currently
    need to do one malloc per readv(2)/writev(2).

    It's also more natural for most applications that only have a single buffer to
    read/write.

+++

    YACI - Yet Another Cat Implementation

    Wrote this to make sure I realize what was going on in Uring and to be able to
    properly test a new allocator for writev/readv, as a bonus I've used to make
    sure read and write work.

    The current urcat is a bit limited and this works a bit more like a normal cat.