### PR TITLE
Introduce a sketch buffer per Uring

### DIFF
--- a/lib/uring/include/discover.ml
+++ b/lib/uring/include/discover.ml
@@ -2,7 +2,7 @@ module C = Configurator.V1
 
 let () =
   C.main ~name:"discover" (fun c ->
-      C.C_define.import c ~c_flags:["-D_GNU_SOURCE"] ~includes:["fcntl.h"; "poll.h"] C.C_define.Type.[
+      C.C_define.import c ~c_flags:["-D_GNU_SOURCE"] ~includes:["fcntl.h"; "poll.h"; "sys/uio.h"] C.C_define.Type.[
           "POLLIN", Int;
           "POLLOUT", Int;
           "POLLERR", Int;
@@ -29,9 +29,12 @@ let () =
           "O_TMPFILE", Int;
 
           "AT_FDCWD", Int;
+
+          "sizeof(struct iovec)", Int;
         ]
       |> List.map (function
           | name, C.C_define.Value.Int v ->
+            let name = if name = "sizeof(struct iovec)" then "sizeof_iovec" else name in
             Printf.sprintf "let %s = 0x%x" (String.lowercase_ascii name) v
           | _ -> assert false
         )

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -128,7 +128,7 @@ module Sketch = struct
     mutable old_buffers : Cstruct.buffer list;
   }
 
-  type ptr = Cstruct.t
+  type ptr = Cstruct.buffer * int * int
 
   let create_buffer len = Bigarray.(Array1.create char c_layout len)
 

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -155,7 +155,7 @@ module Sketch = struct
     (t.buffer, off, alloc_len)
 
   let _cstruct_of_ptr ((buf, off, len) : ptr) =
-    Cstruct.sub (Cstruct.of_bigarray buf) off (len - off)
+    Cstruct.of_bigarray buf ~off ~len
 
   let release t =
     t.off <- 0;

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -105,6 +105,7 @@ module Open_how = struct
   let v ~open_flags ~perm ~resolve path = make open_flags perm resolve path
 end
 
+(* The C stubs rely on the layout of Cstruct.t, so we just check here that it hasn't changed. *)
 module Check_cstruct : sig
   [@@@warning "-34"]
   type t = private {

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -128,7 +128,7 @@ module Sketch = struct
     mutable old_buffers : Cstruct.buffer list;
   }
 
-  type ptr = Cstruct.buffer * int * int
+  type ptr = Cstruct.t
 
   let create_buffer len = Bigarray.(Array1.create char c_layout len)
 

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -164,7 +164,7 @@ module Sketch = struct
   module Iovec = struct
     external set : ptr -> Cstruct.t list -> unit = "ocaml_uring_set_iovec" [@@noalloc]
 
-    let sizeof = if Sys.word_size = 64 then 16 else 8
+    let sizeof = Config.sizeof_iovec
 
     let alloc t csl =
       let ptr = alloc t (List.length csl * sizeof) in

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -105,36 +105,79 @@ module Open_how = struct
   let v ~open_flags ~perm ~resolve path = make open_flags perm resolve path
 end
 
-module Iovec = struct
-  (* The C stubs rely on the layout of Cstruct.t, so we just check here that it hasn't changed. *)
-  module Check : sig
-    [@@@warning "-34"]
-    type t = private {
-      buffer: (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t;
-      off   : int;
-      len   : int;
-    }
-  end = Cstruct
+module Check_cstruct : sig
+  [@@@warning "-34"]
+  type t = private {
+    buffer: (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t;
+    off   : int;
+    len   : int;
+  }
+end = Cstruct
 
-  type iovec
-  (* A C array of iovecs *)
+(*
+ * A Sketch buffer is an area used to hold objects that remain alive
+ * until the next `Uring.submit`.
+ * For example an `iovec` must be passed to io_uring in `readv` and
+ * `writev`, once we call `Uring.submit` the `iovec` structures are
+ * copied by the kernel and we can release them, which we do.
+ *)
+module Sketch = struct
+  type t = {
+    mutable buffer : Cstruct.buffer;
+    mutable off : int;
+    mutable old_buffers : Cstruct.buffer list;
+  }
 
-  type t = iovec * int * Cstruct.t list
-  (* Note: we don't use the buffers list, but adding them here prevents them from being GC'd. *)
+  type ptr = Cstruct.buffer * int * int
 
-  external make_iovec : Cstruct.t list -> int -> iovec = "ocaml_uring_make_iovec"
+  let create_buffer len = Bigarray.(Array1.create char c_layout len)
 
-  let make buffers =
-    let len = List.length buffers in
-    let iovec = make_iovec buffers len in
-    (iovec, len, buffers)
+  let create len =
+    { buffer = create_buffer len; off = 0; old_buffers = [] }
+
+  let length t = Bigarray.Array1.size_in_bytes t.buffer
+
+  let round a x = (x + (a - 1)) land (lnot (a - 1))
+  let round = round (Sys.word_size / 8)
+
+  let avail t = (length t) - t.off
+
+  let alloc t alloc_len =
+    let alloc_len = round alloc_len in
+    if alloc_len > avail t then begin
+      let new_buffer = create_buffer ((length t) + alloc_len) in
+      t.old_buffers <- t.buffer :: t.old_buffers;
+      t.off <- 0;
+      t.buffer <- new_buffer;
+    end;
+    let off = t.off in
+    t.off <- t.off + alloc_len;
+    (t.buffer, off, alloc_len)
+
+  let _cstruct_of_ptr ((buf, off, len) : ptr) =
+    Cstruct.sub (Cstruct.of_bigarray buf) off (len - off)
+
+  let release t =
+    t.off <- 0;
+    t.old_buffers <- []
+
+  module Iovec = struct
+    external set : ptr -> Cstruct.t list -> unit = "ocaml_uring_set_iovec" [@@noalloc]
+
+    let sizeof = if Sys.word_size = 64 then 16 else 8
+
+    let alloc t csl =
+      let ptr = alloc t (List.length csl * sizeof) in
+      set ptr csl;
+      ptr
+  end
 end
 
 (* Used for the sendmsg/recvmsg calls. Liburing doesn't support sendto/recvfrom at the time of writing. *)
 module Msghdr = struct
   type msghdr
-  type t = msghdr * Sockaddr.t option * Iovec.t
-  external make_msghdr : int -> Unix.file_descr list -> Sockaddr.t option -> Iovec.t-> msghdr = "ocaml_uring_make_msghdr"
+  type t = msghdr * Sockaddr.t option * Cstruct.t list (* `Cstruct.t list` is here only for preventing it being GCed *)
+  external make_msghdr : int -> Unix.file_descr list -> Sockaddr.t option -> msghdr = "ocaml_uring_make_msghdr"
   external get_msghdr_fds : msghdr -> Unix.file_descr list = "ocaml_uring_get_msghdr_fds"
 
   let get_fds (hdr, _, _) = get_msghdr_fds hdr
@@ -142,8 +185,7 @@ module Msghdr = struct
   (* Create a value with space for [n_fds] file descriptors.
      When sending, [fds] is used to fill those slots. When receiving, they can be left blank. *)
   let create_with_addr ~n_fds ~fds ?addr buffs =
-    let iovs = Iovec.make buffs in
-    make_msghdr n_fds fds addr iovs, addr, iovs
+    make_msghdr n_fds fds addr, addr, buffs
 
   let create ?(n_fds=0) ?addr buffs =
     create_with_addr ~n_fds ~fds:[] ?addr buffs
@@ -160,6 +202,7 @@ module Uring = struct
   external unregister_buffers : t -> unit = "ocaml_uring_unregister_buffers"
   external register_bigarray : t ->  Cstruct.buffer -> unit = "ocaml_uring_register_ba"
   external submit : t -> int = "ocaml_uring_submit" [@@noalloc]
+  external sq_ready : t -> int = "ocaml_uring_sq_ready" [@@noalloc]
 
   type id = Heap.ptr
 
@@ -168,8 +211,8 @@ module Uring = struct
   external submit_poll_add : t -> Unix.file_descr -> id -> Poll_mask.t -> bool = "ocaml_uring_submit_poll_add" [@@noalloc]
   external submit_read : t -> Unix.file_descr -> id -> Cstruct.t -> offset -> bool = "ocaml_uring_submit_read" [@@noalloc]
   external submit_write : t -> Unix.file_descr -> id -> Cstruct.t -> offset -> bool = "ocaml_uring_submit_write" [@@noalloc]
-  external submit_readv : t -> Unix.file_descr -> id -> Iovec.t -> offset -> bool = "ocaml_uring_submit_readv" [@@noalloc]
-  external submit_writev : t -> Unix.file_descr -> id -> Iovec.t -> offset -> bool = "ocaml_uring_submit_writev" [@@noalloc]
+  external submit_readv : t -> Unix.file_descr -> id -> Sketch.ptr -> offset -> bool = "ocaml_uring_submit_readv" [@@noalloc]
+  external submit_writev : t -> Unix.file_descr -> id -> Sketch.ptr -> offset -> bool = "ocaml_uring_submit_writev" [@@noalloc]
   external submit_readv_fixed : t -> Unix.file_descr -> id -> Cstruct.buffer -> int -> int -> offset -> bool = "ocaml_uring_submit_readv_fixed_byte" "ocaml_uring_submit_readv_fixed_native" [@@noalloc]
   external submit_writev_fixed : t -> Unix.file_descr -> id -> Cstruct.buffer -> int -> int -> offset -> bool = "ocaml_uring_submit_writev_fixed_byte" "ocaml_uring_submit_writev_fixed_native" [@@noalloc]
   external submit_close : t -> Unix.file_descr -> id -> bool = "ocaml_uring_submit_close" [@@noalloc]
@@ -178,8 +221,8 @@ module Uring = struct
   external submit_accept : t -> id -> Unix.file_descr -> Sockaddr.t -> bool = "ocaml_uring_submit_accept" [@@noalloc]
   external submit_cancel : t -> id -> id -> bool = "ocaml_uring_submit_cancel" [@@noalloc]
   external submit_openat2 : t -> id -> Unix.file_descr -> Open_how.t -> bool = "ocaml_uring_submit_openat2" [@@noalloc]
-  external submit_send_msg : t -> id -> Unix.file_descr -> Msghdr.t -> bool = "ocaml_uring_submit_send_msg" [@@noalloc]
-  external submit_recv_msg : t -> id -> Unix.file_descr -> Msghdr.t -> bool = "ocaml_uring_submit_recv_msg" [@@noalloc]
+  external submit_send_msg : t -> id -> Unix.file_descr -> Msghdr.t -> Sketch.ptr -> bool = "ocaml_uring_submit_send_msg" [@@noalloc]
+  external submit_recv_msg : t -> id -> Unix.file_descr -> Msghdr.t -> Sketch.ptr -> bool = "ocaml_uring_submit_recv_msg" [@@noalloc]
 
   type cqe_option = private
     | Cqe_none
@@ -198,8 +241,10 @@ type 'a t = {
   uring: Uring.t;
   mutable fixed_iobuf: Cstruct.buffer;
   data : 'a Heap.t;
+  sketch : Sketch.t;
   queue_depth: int;
   mutable dirty: bool; (* has outstanding requests that need to be submitted *)
+  polling : bool;
 }
 
 module Generic_ring = struct
@@ -243,7 +288,9 @@ let create ?polling_timeout ~queue_depth () =
   let data = Heap.create queue_depth in
   let id = object end in
   let fixed_iobuf = Cstruct.empty.buffer in
-  let t = { id; uring; fixed_iobuf; data; dirty=false; queue_depth } in
+  let sketch = Sketch.create 0 in
+  let polling = Option.is_some polling_timeout in
+  let t = { id; uring; sketch; fixed_iobuf; data; dirty=false; queue_depth; polling } in
   register_gc_root t;
   t
 
@@ -306,8 +353,9 @@ let write t ~file_offset fd (buf : Cstruct.t) user_data =
   with_id_full t (fun id -> Uring.submit_write t.uring fd id buf file_offset) user_data ~extra_data:buf
 
 let readv t ~file_offset fd buffers user_data =
-  let iovec = Iovec.make buffers in
-  with_id_full t (fun id -> Uring.submit_readv t.uring fd id iovec file_offset) user_data ~extra_data:iovec
+  with_id_full t (fun id ->
+      let iovec = Sketch.Iovec.alloc t.sketch buffers in
+      Uring.submit_readv t.uring fd id iovec file_offset) user_data ~extra_data:buffers
 
 let read_fixed t ~file_offset fd ~off ~len user_data =
   with_id t (fun id -> Uring.submit_readv_fixed t.uring fd id t.fixed_iobuf off len file_offset) user_data
@@ -326,8 +374,9 @@ let write_chunk ?len t ~file_offset fd chunk user_data =
   with_id t (fun id -> Uring.submit_writev_fixed t.uring fd id t.fixed_iobuf off len file_offset) user_data
 
 let writev t ~file_offset fd buffers user_data =
-  let iovec = Iovec.make buffers in
-  with_id_full t (fun id -> Uring.submit_writev t.uring fd id iovec file_offset) user_data ~extra_data:iovec
+  with_id_full t (fun id ->
+      let iovec = Sketch.Iovec.alloc t.sketch buffers in
+      Uring.submit_writev t.uring fd id iovec file_offset) user_data ~extra_data:buffers
 
 let poll_add t fd poll_mask user_data =
   with_id t (fun id -> Uring.submit_poll_add t.uring fd id poll_mask) user_data
@@ -349,21 +398,34 @@ let send_msg ?(fds=[]) ?dst t fd buffers user_data =
   let addr = Option.map Sockaddr.of_unix dst in
   let n_fds = List.length fds in
   let msghdr = Msghdr.create_with_addr ~n_fds ~fds ?addr buffers in
-  with_id_full t (fun id -> Uring.submit_send_msg t.uring id fd msghdr) user_data ~extra_data:msghdr
+  (* NOTE: `msghdr` references `buffers`, so it's enough for `extra_data` *)
+  with_id_full t (fun id ->
+      let iovec = Sketch.Iovec.alloc t.sketch buffers in
+      Uring.submit_send_msg t.uring id fd msghdr iovec) user_data ~extra_data:msghdr
 
 let recv_msg t fd msghdr user_data =
-  with_id_full t (fun id -> Uring.submit_recv_msg t.uring id fd msghdr) user_data ~extra_data:msghdr
+  let _, _, buffers = msghdr in
+  (* NOTE: `msghdr` references `buffers`, so it's enough for `extra_data` *)
+  with_id_full t (fun id ->
+      let iovec = Sketch.Iovec.alloc t.sketch buffers in
+      Uring.submit_recv_msg t.uring id fd msghdr iovec) user_data ~extra_data:msghdr
 
 let cancel t job user_data =
   ignore (Heap.ptr job : Uring.id);  (* Check it's still valid *)
   with_id t (fun id -> Uring.submit_cancel t.uring id (Heap.ptr job)) user_data
 
 let submit t =
-  if t.dirty then begin
-    t.dirty <- false;
-    Uring.submit t.uring
-  end else
-    0
+  let v =
+    if t.dirty then begin
+      t.dirty <- false;
+      Uring.submit t.uring
+    end else
+      0
+  in
+  (* We really just need to test if SQEs were consumed in polling mode *)
+  if not t.polling || (Uring.sq_ready t.uring = 0) then
+    Sketch.release t.sketch;
+  v
 
 type 'a completion_option =
   | None

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -226,14 +226,14 @@ module Msghdr : sig
   type t
 
   val create : ?n_fds:int -> ?addr:Sockaddr.t -> Cstruct.t list -> t
-  (** [create buffs] makes a new [msghdr] using the [buffs] 
+  (** [create buffs] makes a new [msghdr] using the [buffs]
       for the underlying [iovec].
       @param addr The remote address.
                   Use {!Sockaddr.create} to create a dummy address that will be filled when data is received.
       @param n_fds Reserve space to receive this many FDs (default 0) *)
 
   val get_fds : t -> Unix.file_descr list
-end 
+end
 
 val send_msg : ?fds:Unix.file_descr list -> ?dst:Unix.sockaddr -> 'a t -> Unix.file_descr -> Cstruct.t list -> 'a -> 'a job option
 (** [send_msg t fd buffs d] will submit a [sendmsg(2)] request. The [Msghdr] will be constructed
@@ -242,7 +242,7 @@ val send_msg : ?fds:Unix.file_descr list -> ?dst:Unix.sockaddr -> 'a t -> Unix.f
     @param fds Extra file descriptors to attach to the message. *)
 
 val recv_msg : 'a t -> Unix.file_descr -> Msghdr.t -> 'a -> 'a job option
-(** [recv_msg t fd msghdr d] will submit a [recvmsg(2)] request. If the request is 
+(** [recv_msg t fd msghdr d] will submit a [recvmsg(2)] request. If the request is
     successful then the [msghdr] will contain the sender address and the data received. *)
 
 (** {2 Submitting operations} *)

--- a/tests/main.md
+++ b/tests/main.md
@@ -712,9 +712,7 @@ val w2 : Unix.file_descr = <abstr>
 
 ## Sketch allocation
 ```ocaml
-let ldup n x =
-	let rec loop n' l = if n' = n then l else loop (succ n') (x :: l) in
-	loop 0 []
+let ldup n x = List.init n (Fun.const x)
 ```
 ```ocaml
 # let t : unit Uring.t = Uring.create ~queue_depth:4 ();;

--- a/tests/main.md
+++ b/tests/main.md
@@ -726,19 +726,25 @@ val b : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 1}
 - : unit Uring.job option = Some <abstr>
 # Uring.submit t;;
 - : int = 1
+# consume t;;
+- : unit * int = ((), 1)
+
+# Uring.readv t fd (ldup 7 b) () ~file_offset:Int63.zero;;
+- : unit Uring.job option = Some <abstr>
+# Uring.submit t;;
+- : int = 1
+# consume t;;
+- : unit * int = ((), 7)
 
 # Uring.readv t fd (ldup 1000 b) () ~file_offset:Int63.zero;;
 - : unit Uring.job option = Some <abstr>
 # Uring.submit t;;
 - : int = 1
+# consume t;;
+- : unit * int = ((), 11)
 
-# Uring.readv t fd (ldup 10000 b) () ~file_offset:Int63.zero;;
-- : unit Uring.job option = Some <abstr>
-# Uring.submit t;;
-- : int = 1
-
-# Uring.readv t fd (ldup 100000 b) () ~file_offset:Int63.zero;;
-- : unit Uring.job option = Some <abstr>
-# Uring.submit t;;
-- : int = 1
+# Unix.close fd;;
+- : unit = ()
+# Uring.exit t;;
+- : unit = ()
 ```


### PR DESCRIPTION
The main motivation of this change is to avoid having one malloc per packet in
readv(2) and writev(2).

Before this, everytime we needed an iovec structure we would malloc it outside
the heap, then fill it up and set up the GC collect it.

Often we only need those structures on the window between the
`Uring.submit_writev` and `Uring.submit`, once the submit is done, the kernel has
already copied the arguments and we don't need it anymore. In the old code the
iovec would end up being held until atleast the CQEvent, this is not a big deal,
but mallocing per syscall kinda is.

The sketch buffer is a linear area that is reset at every `Uring.submit`, so we
can stash all these temporary things there and forget.  The area is allocated
from C code so it looks transparent to ocaml code, this makes it easier to
remember a free operation in case we have to abort the syscall because another
resource starved (like running out of SQEs). We could argue that this is a bit
too much and we should just expect the application to issue a Submit at
some point, but leaking is sloppy behavior at the very least.

The buffer size is always 8 byte aligned, and every allocation will be
aligned to its own machine word size, this is more of a safe guard to guarantee
we could run on a strict aligned machine, and also to gain some cycles as
unaligned access are still slower on x86 and and arm.

The `main.md` test ends up testing the word size to make sure allocations fail
and succeed when they should, but since we have to hard code the output, it will
be different in 32bit mode and main.md will fail here:
```
val sizeof_iovec : int = 16
```

I chose 16KB for the default size, which might be a bit overkill as we will
probably never need more than a few KB (one iovec is 2 pointers). At any rate I
tried to make the API usable enough for other structures, like `__kernel_timeout` that
another PR#59 wants.