### PR TITLE
Add a readv benchmark and fix sketch buffer GC

### DIFF
--- a/bench/dune
+++ b/bench/dune
@@ -1,3 +1,9 @@
 (executable
  (name main)
+ (modules main)
  (libraries uring bechamel bechamel-notty notty.unix))
+
+(executable
+ (name readv)
+ (modules readv)
+ (libraries uring))

--- a/bench/readv.ml
+++ b/bench/readv.ml
@@ -1,0 +1,61 @@
+(* This benchmark uses [Uring.readv] to read from /dev/zero in a loop.
+   This is intended to stress the sketch buffer. *)
+
+let buffer_size = 100   (* Use a small buffer to stress the system more *)
+let n_concurrent = 16   (* How many requests to have active at once *)
+let n_iters = 1_000_000 (* How many times to accept and resubmit *)
+
+let got = ref 0
+
+let rec wait t handle =
+  match Uring.peek t with
+  | Some { result; data = buf } -> handle result buf
+  | None ->
+    match Uring.wait t with
+    | None -> wait t handle
+    | Some { result; data = buf } -> handle result buf
+
+let run_bechmark ~polling_timeout fd =
+  got := 0;
+  (* For polling mode, [queue_depth] needs to be slightly larger than [n_concurrent] or submission
+     occasionally fails for some reason. *)
+  let t = Uring.create ?polling_timeout ~queue_depth:(n_concurrent * 2) () in
+  (* We start by submitting [n_concurrent] reads. *)
+  for _ = 1 to n_concurrent do
+    let buf = Cstruct.create buffer_size in
+    let _job : _ Uring.job = Uring.readv t fd [buf] ~file_offset:Optint.Int63.zero [buf] |> Option.get in
+    ()
+  done;
+  assert (Uring.submit t = n_concurrent);
+  (* Then we wait for reads to complete. Each time a read returns, we immediately submit another. *)
+  let t0 = Unix.gettimeofday () in
+  for _ = 1 to n_iters do
+    wait t (fun result bufs ->
+        if result < 0 then (
+          raise (Unix.Unix_error (Uring.error_of_errno result, "readv", ""))
+        ) else (
+          got := !got + result;
+          let _job : _ Uring.job = Uring.readv t fd bufs ~file_offset:Optint.Int63.zero bufs |> Option.get in
+          ()
+        )
+      )
+  done;
+  let t1 = Unix.gettimeofday () in
+  let time = t1 -. t0 in
+  let got = float !got /. (1024. *. 1024.)  in
+  let polling = polling_timeout <> None in
+  Printf.printf "Read %.2f MB in %.2f seconds (%.2f MB/second) # buffer_size=%d, polling=%b\n%!"
+    got time (got /. time) buffer_size polling;
+  (* Finally, drain the remaining reads and shut down the ring. *)
+  for _ = 1 to n_concurrent do
+    wait t (fun _result _buf -> ())
+  done;
+  Uring.exit t
+
+let () =
+  let fd = Unix.openfile "/dev/zero" Unix.[O_RDONLY] 0 in
+  run_bechmark fd ~polling_timeout:None;
+  run_bechmark fd ~polling_timeout:(Some 1000);
+  run_bechmark fd ~polling_timeout:None;
+  run_bechmark fd ~polling_timeout:(Some 1000);
+  Unix.close fd

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -148,6 +148,7 @@ module Sketch = struct
     if alloc_len > avail t then begin
       let new_buffer = create_buffer ((length t) + alloc_len) in
       t.old_buffers <- t.buffer :: t.old_buffers;
+      (* Printf.printf "len t.old_buffers = %d\n%!" (List.length t.old_buffers); *)
       t.off <- 0;
       t.buffer <- new_buffer;
     end;
@@ -288,7 +289,7 @@ let create ?polling_timeout ~queue_depth () =
   let data = Heap.create queue_depth in
   let id = object end in
   let fixed_iobuf = Cstruct.empty.buffer in
-  let sketch = Sketch.create 0 in
+  let sketch = Sketch.create 4096 in
   let t = { id; uring; sketch; fixed_iobuf; data; dirty=false; queue_depth } in
   register_gc_root t;
   t
@@ -413,6 +414,13 @@ let cancel t job user_data =
   ignore (Heap.ptr job : Uring.id);  (* Check it's still valid *)
   with_id t (fun id -> Uring.submit_cancel t.uring id (Heap.ptr job)) user_data
 
+(* Free stale entries in the sketch buffer, if possible.
+   This isn't quite right: a busy system might never have 0 unsubmitted entries.
+   We should probably track how many requests need to be submitted before each
+   of [t.sketch.old_buffers] can be released, but this will do for now. *)
+let gc_sketch t =
+  if Uring.sq_ready t.uring = 0 then Sketch.release t.sketch
+
 let submit t =
   let v =
     if t.dirty then begin
@@ -421,8 +429,10 @@ let submit t =
     end else
       0
   in
-  if Uring.sq_ready t.uring = 0 then
-    Sketch.release t.sketch;
+  (* In non-polling mode, we will almost always be able to free the sketch buffer here.
+     However, in polling mode it's unlikely the entries have been consumed by the kernel yet,
+     and we must rely on other GC points. *)
+  gc_sketch t;
   v
 
 type 'a completion_option =
@@ -436,12 +446,20 @@ let fn_on_ring fn t =
     let data = Heap.free t.data user_data_id in
     Some { result = res; data }
 
-let peek t = fn_on_ring Uring.peek_cqe t
+let peek t =
+  gc_sketch t;
+  fn_on_ring Uring.peek_cqe t
 
 let wait ?timeout t =
-  match timeout with
-  | None -> fn_on_ring Uring.wait_cqe t
-  | Some timeout -> fn_on_ring (Uring.wait_cqe_timeout timeout) t
+  let r =
+    match timeout with
+    | None -> fn_on_ring Uring.wait_cqe t
+    | Some timeout -> fn_on_ring (Uring.wait_cqe_timeout timeout) t
+  in
+  (* In polling mode, this is a good time to GC the sketch buffer, because the
+     kernel has probably consumed all the enties while we were blocking. *)
+  gc_sketch t;
+  r
 
 let queue_depth {queue_depth;_} = queue_depth
 let buf {fixed_iobuf;_} = fixed_iobuf

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -271,6 +271,21 @@ val peek : 'a t -> 'a completion_option
 val error_of_errno : int -> Unix.error
 (** [error_of_errno e] converts the error code [abs e] to a Unix error type. *)
 
+module Stats : sig
+  type t = {
+    sqe_ready : int;
+    active_ops : int;
+    sketch_buffer_size : int;
+    sketch_used : int;
+    sketch_old_buffers : int;
+  }
+
+  val pp : t Fmt.t
+end
+
+val get_debug_stats : _ t -> Stats.t
+(** [get_debug_stats t] collects some metrics about the internal state of [t]. *)
+
 module Private : sig
   module Heap = Heap
 end

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -143,7 +143,7 @@ ocaml_uring_submit_nop(value v_uring, value v_id) {
 value /* noalloc */
 ocaml_uring_sq_ready(value v_uring) {
   struct io_uring *ring = Ring_val(v_uring);
-  return (Int_val(io_uring_sq_ready(ring)));
+  return (Val_int(io_uring_sq_ready(ring)));
 }
 
 struct open_how_data {

--- a/tests/main.md
+++ b/tests/main.md
@@ -160,7 +160,7 @@ val t : '_weak1 Uring.t = <abstr>
 # Fmt.pr "%a@." Uring.Stats.pp (Uring.get_debug_stats t);;
 SQEs ready: 0
 Operations active: 0
-Sketch buffer: 0/4096 (plus 0 old buffers)
+Sketch buffer: 0/0 (plus 0 old buffers)
 - : unit = ()
 
 # for i = 1 to queue_depth do
@@ -171,7 +171,7 @@ Sketch buffer: 0/4096 (plus 0 old buffers)
 # Fmt.pr "%a@." Uring.Stats.pp (Uring.get_debug_stats t);;
 SQEs ready: 5
 Operations active: 5
-Sketch buffer: 0/4096 (plus 0 old buffers)
+Sketch buffer: 0/0 (plus 0 old buffers)
 - : unit = ()
 
 # Uring.submit t;;
@@ -180,7 +180,7 @@ Sketch buffer: 0/4096 (plus 0 old buffers)
 # Fmt.pr "%a@." Uring.Stats.pp (Uring.get_debug_stats t);;
 SQEs ready: 0
 Operations active: 5
-Sketch buffer: 0/4096 (plus 0 old buffers)
+Sketch buffer: 0/0 (plus 0 old buffers)
 - : unit = ()
 
 # for i = 1 to queue_depth do
@@ -197,7 +197,7 @@ Sketch buffer: 0/4096 (plus 0 old buffers)
 # Fmt.pr "%a@." Uring.Stats.pp (Uring.get_debug_stats t);;
 SQEs ready: 0
 Operations active: 0
-Sketch buffer: 0/4096 (plus 0 old buffers)
+Sketch buffer: 0/0 (plus 0 old buffers)
 - : unit = ()
 
 # Uring.exit t;;

--- a/tests/main.md
+++ b/tests/main.md
@@ -153,13 +153,35 @@ Exception: Invalid_argument "Non-positive queue depth: 0".
 ```ocaml
 # let queue_depth = 5;;
 val queue_depth : int = 5
+
 # let t = Uring.create ~queue_depth ();;
 val t : '_weak1 Uring.t = <abstr>
+
+# Fmt.pr "%a@." Uring.Stats.pp (Uring.get_debug_stats t);;
+SQEs ready: 0
+Operations active: 0
+Sketch buffer: 0/4096 (plus 0 old buffers)
+- : unit = ()
+
 # for i = 1 to queue_depth do
     assert (Option.is_some (Uring.noop t i));
-  done;
-  Uring.submit t;;
+  done;;
+- : unit = ()
+
+# Fmt.pr "%a@." Uring.Stats.pp (Uring.get_debug_stats t);;
+SQEs ready: 5
+Operations active: 5
+Sketch buffer: 0/4096 (plus 0 old buffers)
+- : unit = ()
+
+# Uring.submit t;;
 - : int = 5
+
+# Fmt.pr "%a@." Uring.Stats.pp (Uring.get_debug_stats t);;
+SQEs ready: 0
+Operations active: 5
+Sketch buffer: 0/4096 (plus 0 old buffers)
+- : unit = ()
 
 # for i = 1 to queue_depth do
     let tkn, res = consume t in
@@ -170,6 +192,12 @@ val t : '_weak1 Uring.t = <abstr>
 3 returned 0
 4 returned 0
 5 returned 0
+- : unit = ()
+
+# Fmt.pr "%a@." Uring.Stats.pp (Uring.get_debug_stats t);;
+SQEs ready: 0
+Operations active: 0
+Sketch buffer: 0/4096 (plus 0 old buffers)
 - : unit = ()
 
 # Uring.exit t;;


### PR DESCRIPTION
The benchmark performs 16 concurrent reads of /dev/zero in a loop. Each time a read completes, it issues a new one.

This benchmark unconvered some problems in the current sketch buffer handling:

- A typo in the C stubs meant that the sketch buffer was never released.

- Even with that fixed it might still never be freed, as the application is not required to call submit explicitly. Instead, we now try to release the buffer when waiting or peeking.

- I set the initial sketch buffer size to 4096. Before, it was zero, which lead to quite a lot of allocation as it grows rather slowly. I'm not sure if this really matters, however.

On my machine, I get:

    Read 95.37 MB in 0.25 seconds (388.92 MB/second) # buffer_size=100, polling=false
    Read 95.37 MB in 0.47 seconds (203.45 MB/second) # buffer_size=100, polling=true
    Read 95.37 MB in 0.24 seconds (389.73 MB/second) # buffer_size=100, polling=false
    Read 95.37 MB in 0.48 seconds (200.75 MB/second) # buffer_size=100, polling=true

With a larger buffer:

    Read 124998.12 MB in 5.11 seconds (24452.64 MB/second) # buffer_size=131072, polling=false
    Read 124999.76 MB in 5.14 seconds (24318.08 MB/second) # buffer_size=131072, polling=true
    Read 124993.41 MB in 4.95 seconds (25236.34 MB/second) # buffer_size=131072, polling=false
    Read 124999.46 MB in 5.17 seconds (24157.28 MB/second) # buffer_size=131072, polling=true

I'm not sure why polling mode is slower. Possibly because reading from /dev/zero doesn't benefit from happing asynchronously.