### PR TITLE
Rename peek to get_cqe_nonblocking

### DIFF
--- a/bench/readv.ml
+++ b/bench/readv.ml
@@ -6,7 +6,7 @@ let n_concurrent = 16   (* How many requests to have active at once *)
 let n_iters = 1_000_000 (* How many times to accept and resubmit *)
 
 let rec wait t handle =
-  match Uring.peek t with
+  match Uring.get_cqe_nonblocking t with
   | Some { result; data = buf } -> handle result buf
   | None ->
     match Uring.wait t with

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -458,9 +458,11 @@ let fn_on_ring fn t =
     let data = Heap.free t.data user_data_id in
     Some { result = res; data }
 
-let peek t =
+let get_cqe_nonblocking t =
   gc_sketch t;
   fn_on_ring Uring.peek_cqe t
+
+let peek = get_cqe_nonblocking
 
 let wait ?timeout t =
   let r =

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -275,11 +275,15 @@ type 'a completion_option =
 
 val wait : ?timeout:float -> 'a t -> 'a completion_option
 (** [wait ?timeout t] will block indefinitely (the default) or for [timeout]
-    seconds for any outstanding events to complete on uring [t]. Events should
-    have been queued via {!submit} previously to this call. *)
+    seconds for any outstanding events to complete on uring [t].
+    This calls {!submit} automatically. *)
+
+val get_cqe_nonblocking : 'a t -> 'a completion_option
+(** [get_cqe_nonblocking t] returns the next completion entry from the uring [t].
+    It is like {!wait} except that it returns [None] instead of blocking. *)
 
 val peek : 'a t -> 'a completion_option
-(** [peek t] looks for completed requests on the uring [t] without blocking. *)
+[@@deprecated "Renamed to Uring.get_cqe_nonblocking"]
 
 val error_of_errno : int -> Unix.error
 (** [error_of_errno e] converts the error code [abs e] to a Unix error type. *)

--- a/tests/urcp_fixed_lib.ml
+++ b/tests/urcp_fixed_lib.ml
@@ -135,7 +135,7 @@ let copy_file uring t =
     let got_completion = ref false in
     let rec handle_completions () =
       if t.write_left > 0 then begin
-        let check_q = if !got_completion then Uring.peek uring else Uring.wait uring  in
+        let check_q = if !got_completion then Uring.get_cqe_nonblocking uring else Uring.wait uring  in
         match check_q with
         |None -> Logs.debug (fun l -> l "completions: retry so finishing loop")
         |Some { data; result } ->

--- a/tests/urcp_lib.ml
+++ b/tests/urcp_lib.ml
@@ -140,7 +140,7 @@ let copy_file uring t =
     let got_completion = ref false in
     let rec handle_completions () =
       if t.write_left > 0 then begin
-        let check_q = if !got_completion then Uring.peek uring else Uring.wait uring  in
+        let check_q = if !got_completion then Uring.get_cqe_nonblocking uring else Uring.wait uring  in
         match check_q with
         |None -> Logs.debug (fun l -> l "completions: retry so finishing loop")
         |Some { data; result } ->


### PR DESCRIPTION
`peek` suggests no side-effects, but this does in fact remove the entry from the queue.

Also, update the docs to note that `wait` does a submit.