### PR TITLE
Add Uring.active_ops

### DIFF
--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -515,10 +515,12 @@ module Stats = struct
       sketch_used sketch_buffer_size sketch_old_buffers
 end
 
+let active_ops t = Heap.in_use t.data
+
 let get_debug_stats t =
   { Stats.
     sqe_ready = Uring.sq_ready t.uring;
-    active_ops = Heap.in_use t.data;
+    active_ops = active_ops t;
     sketch_used = t.sketch.off;
     sketch_buffer_size = Bigarray.Array1.dim t.sketch.buffer;
     sketch_old_buffers = List.length t.sketch.old_buffers;

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -295,13 +295,17 @@ val peek : 'a t -> 'a completion_option
 val error_of_errno : int -> Unix.error
 (** [error_of_errno e] converts the error code [abs e] to a Unix error type. *)
 
+val active_ops : _ t -> int
+(** [active_ops t] returns the number of operations added to the ring (whether submitted or not)
+    for which the completion event has not yet been collected. *)
+
 module Stats : sig
   type t = {
-    sqe_ready : int;
-    active_ops : int;
-    sketch_buffer_size : int;
-    sketch_used : int;
-    sketch_old_buffers : int;
+    sqe_ready : int;            (** SQEs not yet submitted. *)
+    active_ops : int;           (** See {!active_ops}. *)
+    sketch_buffer_size : int;   (** Size of the current sketch buffer. *)
+    sketch_used : int;          (** Bytes used within current sketch buffer. *)
+    sketch_old_buffers : int;   (** Old sketch buffers waiting to be freed. *)
   }
 
   val pp : t Fmt.t


### PR DESCRIPTION
Requested by Fabian in #66.

This will also allow us to stop tracking this number separately in Eio (which might get out of sync if something else calls `submit`).