### PR TITLE
Remove use of notty for formatting benchmark results

### DIFF
--- a/bench/bechamel_csv/bechamel_csv.ml
+++ b/bench/bechamel_csv/bechamel_csv.ml
@@ -1,0 +1,44 @@
+open Bechamel
+
+let pad width v =
+  let padding = String.make (width - String.length v) ' ' in
+  padding ^ v
+
+let pp_row ~width f data =
+  data |> List.iteri (fun i v ->
+      if i > 0 then Fmt.comma f ();
+      Fmt.pf f "%s" (pad width.(i) v)
+    )
+
+let pp f results =
+  let results = Hashtbl.to_seq results |> Array.of_seq in
+  Array.sort (fun (n1, _) (n2, _) -> String.compare n1 n2) results;     (* Sort columns *)
+  let rows = snd results.(0) |> Hashtbl.to_seq |> Seq.map fst |> Array.of_seq in
+  let width = Array.make (Array.length results + 1) 0 in
+  width.(0) <- String.length "name, ";
+  results |> Array.iteri (fun i (name, _) -> width.(i + 1) <- String.length name + 2);
+  Array.sort String.compare rows;
+  let rows =
+    rows |> Array.map (fun name ->
+        width.(0) <- max width.(0) (String.length name + 2);
+        let values =
+          results |> Array.mapi (fun i (_, col) ->
+              let v =
+                match Hashtbl.find col name |> Analyze.OLS.estimates with
+                | Some [v] -> Printf.sprintf "%f" v
+                | _ -> assert false
+              in
+              width.(i + 1) <- max width.(i + 1) (String.length v + 2);
+              v
+            )
+        in
+        name, values
+      )
+  in
+  let metrics = Array.to_list results |> List.map fst in
+  let headings = List.mapi (fun i v -> pad width.(i) v) ("name" :: metrics) in
+  Fmt.pf f "@[<v>@[<h>%a@]" Fmt.(list ~sep:comma string) headings;
+  rows |> Array.iter (fun (name, data) ->
+      Fmt.pf f "@,@[<h>%a@]" (pp_row ~width) (name :: Array.to_list data);
+    );
+  Fmt.pf f "@]"

--- a/bench/bechamel_csv/bechamel_csv.mli
+++ b/bench/bechamel_csv/bechamel_csv.mli
@@ -1,0 +1,2 @@
+val pp : (string, (string, Bechamel.Analyze.OLS.t) Stdlib.Hashtbl.t) Stdlib.Hashtbl.t Fmt.t
+(** [pp] formats the results of {!Bechamel.Analyze.merge} as a CSV table. *)

--- a/bench/bechamel_csv/dune
+++ b/bench/bechamel_csv/dune
@@ -1,0 +1,3 @@
+(library
+  (name bechamel_csv)
+  (libraries bechamel fmt))

--- a/bench/cptest.ml
+++ b/bench/cptest.ml
@@ -73,20 +73,5 @@ let benchmark () =
       (results, raw_results)
 
 let () =
-  List.iter
-    (fun v -> Bechamel_notty.Unit.add v (Measure.unit v))
-    Instance.[ minor_allocated; major_allocated; monotonic_clock ]
-
-let img (window, results) =
-  Bechamel_notty.Multiple.image_of_ols_results ~rect:window
-    ~predictor:Measure.run results
-
-open Notty_unix
-    
-let () =
-  let window =
-    match winsize Unix.stdout with
-    | Some (w, h) -> { Bechamel_notty.w; h }
-    | None -> { Bechamel_notty.w = 80; h = 1 } in
   let results, _ = benchmark () in
-  img (window, results) |> eol |> output_image
+  Fmt.pr "%a@." Bechamel_csv.pp results

--- a/bench/dune
+++ b/bench/dune
@@ -1,9 +1,20 @@
 (executable
  (name main)
  (modules main)
- (libraries uring bechamel bechamel-notty notty.unix))
+ (libraries uring bechamel bechamel_csv))
 
 (executable
  (name readv)
  (modules readv)
  (libraries uring))
+
+(executable
+ (name cptest)
+ (modules cptest)
+ (libraries urcp_fixed_lib urcp_lib lwtcp_lib uring bechamel bechamel_csv))
+
+(rule
+ (alias runbenchmark)
+ (package uring)
+ (action
+  (run ./cptest.exe)))

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -31,14 +31,6 @@ let benchmark () =
   List.map (fun i -> Analyze.all ols i raw_results) metrics
   |> Analyze.merge ols metrics
 
-let rect =
-  match Notty_unix.winsize Unix.stdout with
-  | Some (w, h) -> { Bechamel_notty.w; h }
-  | None -> { Bechamel_notty.w = 80; h = 1 }
-
 let () =
-  List.iter (fun v -> Bechamel_notty.Unit.add v (Measure.unit v)) metrics;
-  benchmark ()
-  |> Bechamel_notty.Multiple.image_of_ols_results ~rect ~predictor:Measure.run
-  |> Notty_unix.eol
-  |> Notty_unix.output_image
+  let results = benchmark () in
+  Fmt.pr "@[<v>%a@]@." Bechamel_csv.pp results

--- a/dune-project
+++ b/dune-project
@@ -17,8 +17,6 @@
   (ocaml (>= 4.12.0))
   dune-configurator
   (lwt (and :with-test (>= 5.0.0)))
-  (notty (and (>= 0.2.2) :with-test))
-  (bechamel-notty (and (>= 0.1.0) :with-test))
   (bechamel (and (>= 0.1.0) :with-test))
   (logs (and :with-test (>= 0.5.0)))
   (cmdliner (and :with-test (>= 1.1.0)))

--- a/tests/dune
+++ b/tests/dune
@@ -34,12 +34,6 @@
  (modules poll_add)
  (libraries unix uring logs logs.fmt))
 
-(executable
- (name cptest)
- (modules cptest)
- (libraries urcp_fixed_lib urcp_lib lwtcp_lib uring bechamel notty.unix
-   bechamel-notty))
-
 (rule
  (alias runtest)
  (package uring)
@@ -50,7 +44,7 @@
  (package uring)
  (deps urcp.exe)
  (action
-  (run ./cptest.exe ./urcp.exe)))
+  (run ./urcp.exe)))
 
 (mdx
   (deps (package uring)))

--- a/uring.opam
+++ b/uring.opam
@@ -15,8 +15,6 @@ depends: [
   "ocaml" {>= "4.12.0"}
   "dune-configurator"
   "lwt" {with-test & >= "5.0.0"}
-  "notty" {>= "0.2.2" & with-test}
-  "bechamel-notty" {>= "0.1.0" & with-test}
   "bechamel" {>= "0.1.0" & with-test}
   "logs" {with-test & >= "0.5.0"}
   "cmdliner" {with-test & >= "1.1.0"}


### PR DESCRIPTION
The dependency on notty prevents uring from being tested on OCaml 5.

Old output:
```
╭────────────────┬───────────────────────────┬───────────────────────────┬───────────────────────────╮
│name            │  major-allocated          │  minor-allocated          │  monotonic-clock          │
├────────────────┼───────────────────────────┼───────────────────────────┼───────────────────────────┤
│  noop      10  │             0.0000 mjw/run│           160.2533 mnw/run│           1003.7415 ns/run│
│  noop      30  │             0.0000 mjw/run│           480.3344 mnw/run│           2687.7522 ns/run│
│  noop     100  │             0.0930 mjw/run│          1600.4478 mnw/run│           9072.9584 ns/run│
│  noop     300  │            12.2791 mjw/run│          4800.6122 mnw/run│          27520.1296 ns/run│
│  noop    1000  │           114.9145 mjw/run│         16000.9554 mnw/run│          98416.3581 ns/run│
│  noop    3000  │          1030.7835 mjw/run│         48001.5152 mnw/run│         298576.3733 ns/run│
│  noop   10000  │         13413.3058 mjw/run│        160002.6316 mnw/run│        1078551.5092 ns/run│
╰────────────────┴───────────────────────────┴───────────────────────────┴───────────────────────────╯
```
New output:
```
          name,   major-allocated,   minor-allocated,   monotonic-clock
  noop      10,          0.003163,         89.035794,       1122.076257
  noop      30,          0.010071,        272.687218,       2796.151085
  noop     100,          0.914579,        978.710714,       9079.485427
  noop     300,         11.478316,       3511.237206,      28500.701765
  noop    1000,        115.853532,      13936.387169,     104048.680888
  noop    3000,       1033.692225,      44261.436753,     308647.065684
  noop   10000,      12420.745528,     153296.414960,    1216105.351957
```
The units have gone, but on the plus side you can now graph it as CSV data.

The results do seem to be slightly different, though, which is odd. Hmm. Restoring the `List.iter (fun v -> Bechamel_notty.Unit.add v (Measure.unit v)) metrics;` line affects things:

```
          name,   major-allocated,   minor-allocated,   monotonic-clock
  noop      10,          0.000000,        160.284696,       1124.221385
  noop      30,          0.000000,        480.360509,       2997.389849
  noop     100,          0.000000,       1600.467290,       9834.411904
  noop     300,         12.125976,       4800.649351,      30976.050309
  noop    1000,        112.719320,      16001.034483,     115284.222115
  noop    3000,       1022.773418,      48001.612903,     339099.821312
  noop   10000,      13348.487663,     160002.830189,    1201494.350105
```

@dinosaure: is this the right way to do this?