### PR TITLE
Add Uring.iov_max constant

### DIFF
--- a/lib/uring/include/discover.ml
+++ b/lib/uring/include/discover.ml
@@ -4,7 +4,7 @@ let () =
   C.main ~name:"discover" (fun c ->
       let defs =
         C.C_define.import c ~c_flags:["-D_GNU_SOURCE"; "-I"; Filename.concat (Sys.getcwd ()) "include"]
-          ~includes:["fcntl.h"; "poll.h"; "sys/uio.h"; "liburing.h"]
+          ~includes:["fcntl.h"; "poll.h"; "sys/uio.h"; "limits.h"; "liburing.h"]
           C.C_define.Type.[
             "POLLIN", Int;
             "POLLOUT", Int;
@@ -32,6 +32,7 @@ let () =
             "O_TMPFILE", Int;
 
             "AT_FDCWD", Int;
+            "IOV_MAX", Int;
 
             "sizeof(struct iovec)", Int;
             "sizeof(struct __kernel_timespec)", Int;

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -387,6 +387,8 @@ let read t ~file_offset fd (buf : Cstruct.t) user_data =
 let write t ~file_offset fd (buf : Cstruct.t) user_data =
   with_id_full t (fun id -> Uring.submit_write t.uring fd id buf file_offset) user_data ~extra_data:buf
 
+let iov_max = Config.iov_max
+
 let readv t ~file_offset fd buffers user_data =
   with_id_full t (fun id ->
       let iovec = Sketch.Iovec.alloc t.sketch buffers in

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -181,17 +181,24 @@ val write : 'a t -> file_offset:offset -> Unix.file_descr -> Cstruct.t -> 'a -> 
     the memory pointed to by [buf].  The user data [d] will be returned by
     {!wait} or {!peek} upon completion. *)
 
+val iov_max : int
+(** The maximum length of the list that can be passed to [readv] and similar. *)
+
 val readv : 'a t -> file_offset:offset -> Unix.file_descr -> Cstruct.t list -> 'a -> 'a job option
 (** [readv t ~file_offset fd iov d] will submit a [readv(2)] request to uring [t].
     It reads from absolute [file_offset] on the [fd] file descriptor and writes
     the results into the memory pointed to by [iov].  The user data [d] will
-    be returned by {!wait} or {!peek} upon completion. *)
+    be returned by {!wait} or {!peek} upon completion.
+
+    Requires [List.length iov <= Uring.iov_max] *)
 
 val writev : 'a t -> file_offset:offset -> Unix.file_descr -> Cstruct.t list -> 'a -> 'a job option
 (** [writev t ~file_offset fd iov d] will submit a [writev(2)] request to uring [t].
     It writes to absolute [file_offset] on the [fd] file descriptor from the
     the memory pointed to by [iov].  The user data [d] will be returned by
-    {!wait} or {!peek} upon completion. *)
+    {!wait} or {!peek} upon completion.
+
+    Requires [List.length iov <= Uring.iov_max] *)
 
 val read_fixed : 'a t -> file_offset:offset -> Unix.file_descr -> off:int -> len:int -> 'a -> 'a job option
 (** [read t ~file_offset fd ~off ~len d] will submit a [read(2)] request to uring [t].
@@ -248,6 +255,9 @@ module Msghdr : sig
   val create : ?n_fds:int -> ?addr:Sockaddr.t -> Cstruct.t list -> t
   (** [create buffs] makes a new [msghdr] using the [buffs]
       for the underlying [iovec].
+
+      Requires [List.length buffs <= Uring.iov_max]
+
       @param addr The remote address.
                   Use {!Sockaddr.create} to create a dummy address that will be filled when data is received.
       @param n_fds Reserve space to receive this many FDs (default 0) *)
@@ -258,6 +268,9 @@ end
 val send_msg : ?fds:Unix.file_descr list -> ?dst:Unix.sockaddr -> 'a t -> Unix.file_descr -> Cstruct.t list -> 'a -> 'a job option
 (** [send_msg t fd buffs d] will submit a [sendmsg(2)] request. The [Msghdr] will be constructed
     from the FDs ([fds]), address ([dst]) and buffers ([buffs]).
+
+    Requires [List.length buffs <= Uring.iov_max]
+
     @param dst Destination address.
     @param fds Extra file descriptors to attach to the message. *)
 


### PR DESCRIPTION
I think it might be better to truncate the list ourselves, since we're counting it anyway. But if not, we should expose this constant.