### PR TITLE
Prevent ring from being used after exit

### DIFF
--- a/lib/uring/heap.ml
+++ b/lib/uring/heap.ml
@@ -44,7 +44,7 @@ type 'a t =
 
      The user is given only pointers [p] such that [free_tail_relation.(p) =
      slot_taken]. *)
-  ; mutable in_use: int
+  ; mutable in_use: int         (* Negative after release *)
   }
 
 let ptr = function
@@ -110,3 +110,11 @@ let free t ptr =
   datum
 
 let in_use t = t.in_use
+
+let release t =
+  if t.in_use > 0 then invalid_arg "Heap still in use!"
+  else if t.in_use < 0 then invalid_arg "Heap already released!";
+  t.in_use <- -100;
+  t.free_head <- free_list_nil
+
+let is_released t = t.in_use < 0

--- a/lib/uring/heap.mli
+++ b/lib/uring/heap.mli
@@ -43,3 +43,9 @@ val free : 'a t -> ptr -> 'a
 
 val in_use : 'a t -> int
 (** [in_use t] is the number of entries currently allocated. *)
+
+val release : _ t -> unit
+(**[ release t] marks [t] as unusable. Future operations on it will fail. [t] must be idle. *)
+
+val is_released : _ t -> bool
+(** [is_released t] is [true] once {!release} has succeeded. *)

--- a/tests/sketch.md
+++ b/tests/sketch.md
@@ -45,8 +45,8 @@ val b : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 1}
 # consume t;;
 - : unit * int = ((), 1000)
 
-# Unix.close fd;;
-- : unit = ()
+# let fd : unit = Unix.close fd;;
+val fd : unit = ()
 # Uring.exit t;;
 - : unit = ()
 ```


### PR DESCRIPTION
This could cause a segfault.

Also, in the tests, poison every FD variable after closing it. Otherwise, if a later `open` fails then we may try to use or close an invalid FD (possibly crashing MDX). Also, this revealed a test that was closing an old FD by mistake.

Might fix the mysterious CI errors we've been seeing.