### PR TITLE
timeout: add support for completion_count in timeout call

### DIFF
--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -230,7 +230,7 @@ module Uring = struct
 
   type offset = Optint.Int63.t
   external submit_nop : t -> id -> bool = "ocaml_uring_submit_nop" [@@noalloc]
-  external submit_timeout : t -> id -> Sketch.ptr -> clock -> bool -> int -> bool =
+  external submit_timeout : t -> id -> Sketch.ptr -> clock -> bool -> (int [@untagged]) -> bool =
     "ocaml_uring_submit_timeout" "ocaml_uring_submit_timeout_native" [@@noalloc]
   external submit_poll_add : t -> Unix.file_descr -> id -> Poll_mask.t -> bool = "ocaml_uring_submit_poll_add" [@@noalloc]
   external submit_read : t -> Unix.file_descr -> id -> Cstruct.t -> offset -> bool = "ocaml_uring_submit_read" [@@noalloc]

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -73,12 +73,15 @@ type clock = Boottime | Realtime
 (** Represents Linux clocks. [Boottime] and [Realtime] represents OS clocks CLOCK_BOOTTIME
     and CLOCK_REALTIME respectively. *)
 
-val timeout: ?absolute:bool -> 'a t -> clock -> int64 -> 'a -> 'a job option
+val timeout: ?absolute:bool -> ?completion_count:int -> 'a t -> clock -> int64 -> 'a -> 'a job option
 (** [timeout t clock ns d] submits a timeout request to uring [t].
 
     [absolute] denotes how [clock] and [ns] relate to one another. Default value is [false]
 
-    [ns] is the timeout time in nanoseconds *)
+    [ns] is the timeout time in nanoseconds.
+
+    [completion_count] is the count of completion entries after which the timeout request times out.
+    Default value is '0'. *)
 
 module type FLAGS = sig
   type t = private int

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -80,8 +80,12 @@ val timeout: ?absolute:bool -> ?completion_count:int -> 'a t -> clock -> int64 -
 
     [ns] is the timeout time in nanoseconds.
 
-    [completion_count] is the count of completion entries after which the timeout request times out.
-    Default value is '0'. *)
+    [completion_count] is the count of completion queue entries which must succeed - i.e. [0 = cqe->res] -
+    for the timeout sqe to also succeed, ie. [0 = timeout_cqe->res]. If the specified number of 
+    [completion_count] cqes are not reached within the given [ns] value, then the timeout request [cqe->res]
+    value is [-62] or [-ETIME]. [-62], [-ETIME] denotes that timeout [ns] was reached before uring could
+    complete [completion_count] cqes. Default value is '0' which always results in timeout request
+    returning [-ETIME]. *)
 
 module type FLAGS = sig
   type t = private int

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -172,7 +172,7 @@ ocaml_uring_submit_timeout_native(value v_uring,
     value v_sketch_ptr,
     value v_clock,
     value v_absolute,
-    int completion_count)
+    intnat completion_count)
 {
   struct __kernel_timespec *t = Sketch_ptr_val(v_sketch_ptr);
   struct io_uring* ring = Ring_val(v_uring);

--- a/tests/main.md
+++ b/tests/main.md
@@ -737,6 +737,32 @@ val timeout : int = -62
 - : unit = ()
 ```
 
+When a timeout and a normal sqe job is sent and the normal sqe job completes before the timeout, then timeout
+shouldn't complete. The timeout rqe should return with '0' - success.
+
+```ocaml
+# type job = Timeout : job | Noop : job | Cancel : job;;
+type job = Timeout : job | Noop : job | Cancel : job
+# let (t: job Uring.t) = Uring.create ~queue_depth:2 ();;
+val t : job Uring.t = <abstr>
+# Uring.noop t Noop;;
+- : job Uring.job option = Some <abstr>
+# let ns1 = Int64.(mul 10L 1_000_000L);;
+val ns1 : int64 = 10000000L
+# let timeout_job = Uring.(timeout ~completion_count:1 t Boottime ns1 Timeout);;
+val timeout_job : job Uring.job option = Some <abstr>
+# Uring.submit t;;
+- : int = 2
+# let completed_job, res = consume t;;
+val completed_job : job = Noop
+val res : int = 0
+# Uring.get_cqe_nonblocking t;;
+- : job Uring.completion_option =
+Uring.Some {Uring.result = 0; data = Timeout}
+# Uring.exit t;;
+- : unit = ()
+```
+
 ## Probing
 
 ```ocaml


### PR DESCRIPTION
This PR adds support for specifying 'completion (cqe) count' when issuing `timeout` sqe to uring. By specifying `completion_count`, timeout sqe returns `0` - success - when the specified number of `completion_count` cqes complete. 

The parameter is an optional type with default value of `0` to make it backwards compatible with earlier release.

I have also made a performance improvement to `set_timespec` c stub function by reducing the need to allocate `int64`.

`submit_timeout` c stub is also implemented in 2 c stubs since it has exceeded 5 parameters limit of OCaml stub functions. 