### PR TITLE
Decouple Heap entries from ring size

### DIFF
--- a/lib/uring/heap.ml
+++ b/lib/uring/heap.ml
@@ -78,13 +78,14 @@ let release t =
 
 let is_released t = t.in_use < 0
 
+(* Note: t must be full *)
 let grow t =
   if is_released t then raise No_space;
+  if t.free_head <> free_list_nil then invalid_arg "Heap is not full";
   let old_len = Array.length t.free_tail_relation in
   if old_len = Sys.max_array_length then
     raise No_space;
   let new_len = min (max 64 (old_len * 2)) Sys.max_array_length in
-
   (* Build new t.free_tail_relation, keep in sync with create() *)
   let new_free_tail_relation =
     Array.init new_len
@@ -94,10 +95,8 @@ let grow t =
          else succ i)
   in
   new_free_tail_relation.(new_len - 1) <- free_list_nil;
-
   (* First element of enlarged array *)
   let new_free_head = old_len in
-
   (* Note: Keep in sync with create() *)
   let new_data =
     Array.init new_len
@@ -107,7 +106,6 @@ let grow t =
          else
            Empty)
   in
-
   (* Commit *)
   t.free_tail_relation <- new_free_tail_relation;
   t.free_head <- new_free_head;

--- a/lib/uring/heap.ml
+++ b/lib/uring/heap.ml
@@ -114,10 +114,8 @@ let grow t =
   t.data <- new_data
 
 let alloc t data ~extra_data =
-  maybe_already_released t;
   if t.free_head = free_list_nil then grow t;
   let ptr = t.free_head in
-  assert (ptr <> free_list_nil);
   let entry = Entry { data; extra_data; ptr } in
   t.data.(ptr) <- entry;
   (* Drop [ptr] from the free list. *)

--- a/lib/uring/heap.mli
+++ b/lib/uring/heap.mli
@@ -32,10 +32,15 @@ val ptr : 'a entry -> ptr
 
 exception No_space
 
-val alloc : 'a t -> 'a -> extra_data:'b -> 'a entry
-(** [alloc t a ~extra_data] adds the value [a] to [t] and returns a pointer to that value,
+val alloc_no_growth : 'a t -> 'a -> extra_data:'b -> 'a entry
+(** [alloc_no_growth t a ~extra_data] adds the value [a] to [t] and returns a pointer to that value,
     or raises {!No_space} if no space exists in [t].
     @param extra_data Prevent this from being GC'd until [free] is called. *)
+
+val alloc : 'a t -> 'a -> extra_data:'b -> 'a entry
+(** [alloc t a ~extra_data] is [alloc_no_growth] but grows the Heap
+   when it is full. It can still raise {!No_space } if called after
+   the Heap is [release]d. *)
 
 val free : 'a t -> ptr -> 'a
 (** [free t p] returns the element referenced by [p] and removes it from the

--- a/lib/uring/heap.mli
+++ b/lib/uring/heap.mli
@@ -30,17 +30,11 @@ val ptr : 'a entry -> ptr
 (** [ptr e] is the index of [e].
     @raise Invalid_arg if [e] has already been freed. *)
 
-exception No_space
-
-val alloc_no_growth : 'a t -> 'a -> extra_data:'b -> 'a entry
-(** [alloc_no_growth t a ~extra_data] adds the value [a] to [t] and returns a pointer to that value,
-    or raises {!No_space} if no space exists in [t].
-    @param extra_data Prevent this from being GC'd until [free] is called. *)
-
 val alloc : 'a t -> 'a -> extra_data:'b -> 'a entry
-(** [alloc t a ~extra_data] is [alloc_no_growth] but grows the Heap
-   when it is full. It can still raise {!No_space } if called after
-   the Heap is [release]d. *)
+(** [alloc t a ~extra_data] adds the value [a] to [t] and returns a
+    pointer to that value, or raises {!Invalid_arg} if no extra space
+    can be created for [t], or [t] has already been [release]d.
+    @param extra_data Prevent this from being GC'd until [free] is called. *)
 
 val free : 'a t -> ptr -> 'a
 (** [free t p] returns the element referenced by [p] and removes it from the
@@ -50,7 +44,7 @@ val in_use : 'a t -> int
 (** [in_use t] is the number of entries currently allocated. *)
 
 val release : _ t -> unit
-(**[ release t] marks [t] as unusable. Future operations on it will fail. [t] must be idle. *)
+(** [release t] marks [t] as unusable. Future operations on it will fail. [t] must be idle. *)
 
 val is_released : _ t -> bool
 (** [is_released t] is [true] once {!release} has succeeded. *)

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -344,9 +344,9 @@ let exit t =
 
 let with_id_full : type a. a t -> (Heap.ptr -> bool) -> a -> extra_data:'b -> a job option =
  fun t fn datum ~extra_data ->
- let entry = try Heap.alloc t.data datum ~extra_data
-   with exc -> check t; raise exc
- in
+   match Heap.alloc t.data datum ~extra_data with
+  | exception (Invalid_argument _ as ex) -> check t; raise ex
+  | entry ->
  let ptr = Heap.ptr entry in
  let has_space = fn ptr in
  if has_space then

--- a/tests/heap.md
+++ b/tests/heap.md
@@ -8,7 +8,6 @@
 module Heap = struct
   include Uring.Private.Heap
   let alloc = alloc ~extra_data:()
-  let alloc_no_growth = alloc_no_growth ~extra_data:()
 end
 
 let random_hashtbl_elt tbl =
@@ -27,23 +26,19 @@ let random_hashtbl_elt tbl =
 Test normal usage:
 
 ```ocaml
-# let max_size = 10 in
-  let t = Heap.create max_size in
-  let reference : (Heap.ptr, int) Hashtbl.t = Hashtbl.create max_size in
+# let initial_size = 10 in
+  let t = Heap.create initial_size in
+  let reference : (Heap.ptr, int) Hashtbl.t = Hashtbl.create initial_size in
   let currently_allocated = ref 0 in
   for _ = 1 to 100_000 do
     let attempt_alloc = !currently_allocated = 0 || Random.bool () in
     match attempt_alloc with
     | true ->
-      if !currently_allocated = max_size then
-        try ignore (Heap.alloc_no_growth t 0); assert false
-        with Heap.No_space -> ()
-      else
-        let data = Random.int 5000 in
-        let ptr = Heap.ptr (Heap.alloc_no_growth t data) in
-        assert (not (Hashtbl.mem reference ptr));
-        Hashtbl.add reference ptr data;
-        incr currently_allocated
+      let data = Random.int 5000 in
+      let ptr = Heap.ptr (Heap.alloc t data) in
+      assert (not (Hashtbl.mem reference ptr));
+      Hashtbl.add reference ptr data;
+      incr currently_allocated
     | false ->
       let (k, v) = random_hashtbl_elt reference in
       let v' = Heap.free t k in
@@ -52,6 +47,27 @@ Test normal usage:
       decr currently_allocated
   done;
   Hashtbl.iter (fun k _ -> ignore (Heap.free t k)) reference;
+  Heap.release t;;
+- : unit = ()
+```
+
+```ocaml
+let shuffle_list l =
+  List.map (fun i -> Random.bits (), i) l |>
+  List.sort (fun a b -> compare (fst a) (fst b)) |>
+  List.map snd
+```
+
+```ocaml
+# let t = Heap.create 0 in
+  let add_l = List.init 1024 (fun i -> i) |> shuffle_list in
+  assert (Heap.in_use t = 0);
+  let free_l = List.map (fun i -> Heap.alloc t i |> Heap.ptr) add_l |>
+    shuffle_list
+  in
+  assert (Heap.in_use t = 1024);
+  List.iter (fun p -> ignore (Heap.free t p)) free_l;
+  assert (Heap.in_use t = 0);
   Heap.release t;;
 - : unit = ()
 ```
@@ -88,73 +104,4 @@ Exception: Invalid_argument "Heap.free: pointer already freed".
 - : int = 2
 # let t : unit = Heap.release t;;
 val t : unit = ()
-```
-
-Out of space:
-
-```ocaml
-# let t : unit Heap.t = Heap.create 0 (* 1 > 0 *);;
-val t : unit Heap.t = <abstr>
-# Heap.ptr @@ Heap.alloc_no_growth t ();;
-Exception: Uring__Heap.No_space.
-# let t : unit = Heap.release t;;
-val t : unit = ()
-```
-
-```ocaml
-# let t : unit Heap.t = Heap.create 2;;
-val t : unit Heap.t = <abstr>
-# let p1 = Heap.ptr @@ Heap.alloc_no_growth t ();;
-val p1 : Heap.ptr = 0
-# let p2 = Heap.ptr @@ Heap.alloc_no_growth t ();;
-val p2 : Heap.ptr = 1
-# Heap.ptr @@ Heap.alloc_no_growth t () (* 3 > 2 *);;
-Exception: Uring__Heap.No_space.
-# List.iter (fun p -> ignore (Heap.free t p)) [p1; p2];;
-- : unit = ()
-# let t : unit = Heap.release t;;
-val t : unit = ()
-```
-
-```ocaml
-# let t : int Heap.t = Heap.create 3;;
-val t : int Heap.t = <abstr>
-# let p1 = Heap.ptr @@ Heap.alloc_no_growth t 1;;
-val p1 : Heap.ptr = 0
-# let p2 = Heap.ptr @@ Heap.alloc_no_growth t 2;;
-val p2 : Heap.ptr = 1
-# Heap.free t p1;;
-- : int = 1
-# let p3 = Heap.ptr @@ Heap.alloc_no_growth t 3;;
-val p3 : Heap.ptr = 0
-# let p4 = Heap.ptr @@ Heap.alloc_no_growth t 4;;
-val p4 : Heap.ptr = 2
-# Heap.ptr @@ Heap.alloc_no_growth t 5  (* 2 - 1 + 3 > 3 *);;
-Exception: Uring__Heap.No_space.
-# List.iter (fun p -> ignore (Heap.free t p)) [p2; p3; p4];;
-- : unit = ()
-# let t : unit = Heap.release t;;
-val t : unit = ()
-```
-
-Growth:
-```ocaml
-let shuffle_list l =
-  List.map (fun i -> Random.bits (), i) l |>
-  List.sort (fun a b -> compare (fst a) (fst b)) |>
-  List.map snd
-```
-
-```ocaml
-# let t = Heap.create 0 in
-  let add_l = List.init 1024 (fun i -> i) |> shuffle_list in
-  assert (Heap.in_use t = 0);
-  let free_l = List.map (fun i -> Heap.alloc t i |> Heap.ptr) add_l |>
-    shuffle_list
-  in
-  assert (Heap.in_use t = 1024);
-  List.iter (fun p -> ignore (Heap.free t p)) free_l;
-  assert (Heap.in_use t = 0);
-  Heap.release t;;
-- : unit = ()
 ```

--- a/tests/heap.md
+++ b/tests/heap.md
@@ -8,6 +8,7 @@
 module Heap = struct
   include Uring.Private.Heap
   let alloc = alloc ~extra_data:()
+  let alloc_no_growth = alloc_no_growth ~extra_data:()
 end
 
 let random_hashtbl_elt tbl =
@@ -35,11 +36,11 @@ Test normal usage:
     match attempt_alloc with
     | true ->
       if !currently_allocated = max_size then
-        try ignore (Heap.alloc t 0); assert false
+        try ignore (Heap.alloc_no_growth t 0); assert false
         with Heap.No_space -> ()
       else
         let data = Random.int 5000 in
-        let ptr = Heap.ptr (Heap.alloc t data) in
+        let ptr = Heap.ptr (Heap.alloc_no_growth t data) in
         assert (not (Hashtbl.mem reference ptr));
         Hashtbl.add reference ptr data;
         incr currently_allocated
@@ -49,7 +50,9 @@ Test normal usage:
       Hashtbl.remove reference k;
       assert (v = v');
       decr currently_allocated
-  done;;
+  done;
+  Hashtbl.iter (fun k _ -> ignore (Heap.free t k)) reference;
+  Heap.release t;;
 - : unit = ()
 ```
 
@@ -64,6 +67,8 @@ val p : Heap.ptr = 0
 - : int = 1
 # Heap.free t p;;
 Exception: Invalid_argument "Heap.free: pointer already freed".
+# let t : unit = Heap.release t;;
+val t : unit = ()
 ```
 
 Double free in a non-empty heap:
@@ -71,14 +76,18 @@ Double free in a non-empty heap:
 ```ocaml
 # let t : int Heap.t = Heap.create 2;;;
 val t : int Heap.t = <abstr>
-# let p = Heap.ptr @@ Heap.alloc t 1;;;
-val p : Heap.ptr = 0
-# let _ = Heap.ptr @@ Heap.alloc t 2;;;
-- : Heap.ptr = 1
-# Heap.free t p;;
+# let p1 = Heap.ptr @@ Heap.alloc t 1;;;
+val p1 : Heap.ptr = 0
+# let p2 = Heap.ptr @@ Heap.alloc t 2;;;
+val p2 : Heap.ptr = 1
+# Heap.free t p1;;
 - : int = 1
-# Heap.free t p;;
+# Heap.free t p1;;
 Exception: Invalid_argument "Heap.free: pointer already freed".
+# Heap.free t p2;;
+- : int = 2
+# let t : unit = Heap.release t;;
+val t : unit = ()
 ```
 
 Out of space:
@@ -86,34 +95,66 @@ Out of space:
 ```ocaml
 # let t : unit Heap.t = Heap.create 0 (* 1 > 0 *);;
 val t : unit Heap.t = <abstr>
-# Heap.ptr @@ Heap.alloc t ();;
+# Heap.ptr @@ Heap.alloc_no_growth t ();;
 Exception: Uring__Heap.No_space.
+# let t : unit = Heap.release t;;
+val t : unit = ()
 ```
 
 ```ocaml
 # let t : unit Heap.t = Heap.create 2;;
 val t : unit Heap.t = <abstr>
-# Heap.ptr @@ Heap.alloc t ();;
-- : Heap.ptr = 0
-# Heap.ptr @@ Heap.alloc t ();;
-- : Heap.ptr = 1
-# Heap.ptr @@ Heap.alloc t () (* 3 > 2 *);;
+# let p1 = Heap.ptr @@ Heap.alloc_no_growth t ();;
+val p1 : Heap.ptr = 0
+# let p2 = Heap.ptr @@ Heap.alloc_no_growth t ();;
+val p2 : Heap.ptr = 1
+# Heap.ptr @@ Heap.alloc_no_growth t () (* 3 > 2 *);;
 Exception: Uring__Heap.No_space.
+# List.iter (fun p -> ignore (Heap.free t p)) [p1; p2];;
+- : unit = ()
+# let t : unit = Heap.release t;;
+val t : unit = ()
 ```
 
 ```ocaml
 # let t : int Heap.t = Heap.create 3;;
 val t : int Heap.t = <abstr>
-# let p1 = Heap.ptr @@ Heap.alloc t 1;;
+# let p1 = Heap.ptr @@ Heap.alloc_no_growth t 1;;
 val p1 : Heap.ptr = 0
-# Heap.ptr @@ Heap.alloc t 2;;
-- : Heap.ptr = 1
+# let p2 = Heap.ptr @@ Heap.alloc_no_growth t 2;;
+val p2 : Heap.ptr = 1
 # Heap.free t p1;;
 - : int = 1
-# Heap.ptr @@ Heap.alloc t 3;;
-- : Heap.ptr = 0
-# Heap.ptr @@ Heap.alloc t 4;;
-- : Heap.ptr = 2
-# Heap.ptr @@ Heap.alloc t 5  (* 2 - 1 + 3 > 3 *);;
+# let p3 = Heap.ptr @@ Heap.alloc_no_growth t 3;;
+val p3 : Heap.ptr = 0
+# let p4 = Heap.ptr @@ Heap.alloc_no_growth t 4;;
+val p4 : Heap.ptr = 2
+# Heap.ptr @@ Heap.alloc_no_growth t 5  (* 2 - 1 + 3 > 3 *);;
 Exception: Uring__Heap.No_space.
+# List.iter (fun p -> ignore (Heap.free t p)) [p2; p3; p4];;
+- : unit = ()
+# let t : unit = Heap.release t;;
+val t : unit = ()
+```
+
+Growth:
+```ocaml
+let shuffle_list l =
+  List.map (fun i -> Random.bits (), i) l |>
+  List.sort (fun a b -> compare (fst a) (fst b)) |>
+  List.map snd
+```
+
+```ocaml
+# let t = Heap.create 0 in
+  let add_l = List.init 1024 (fun i -> i) |> shuffle_list in
+  assert (Heap.in_use t = 0);
+  let free_l = List.map (fun i -> Heap.alloc t i |> Heap.ptr) add_l |>
+    shuffle_list
+  in
+  assert (Heap.in_use t = 1024);
+  List.iter (fun p -> ignore (Heap.free t p)) free_l;
+  assert (Heap.in_use t = 0);
+  Heap.release t;;
+- : unit = ()
 ```


### PR DESCRIPTION
Before this change, we could only wait at most `queue_depth` events at a time,
we were wrongly tying the size of the CQ ring to the maximum number of syscalls
we could wait.

Example: I create a ring with queue_depth=1, in Uring this creates a CQ and SQ
ring, as well as a Heap with max storage of size 1. On the SQ side this means "I
can queue one element between each Uring.submit. On the CQ side this _should_
mean "I can wait _any_ number of events, but the kernel will only be able to put
one at the ring at a time, the others will be backlogged somewhere in the
kernel."

Imagine you have a ring(`queue_depth`) of 64, and 1000 TCP connections. Before,
we could only wait for events on 64 of these connections, we would literally
limit our submits by the size of the CQ ring. Now you can have a ring of 64, and
wait on """infinite""" TCP connections, but every time you wait on the ring, it
will have at most 64 entries (from _any_ of the 1000 connections).

This change grows the Heap when necessary, code is a bit primitive and basically
just resizes it, I made an attempt of Heap of Heaps but it became too convoluted
for very little gain.

We also need to work on respecting the return of Uring.submit, more
especifically:

```
EAGAIN - The kernel was unable to allocate memory for the request, or otherwise
ran out of resources to handle it. The application should wait for some
completions and try again.

EBUSY - The application is attempting to overcommit the number of requests it can
have pending. The application should wait for some completions and try again.
May occur if the application tries to queue more requests than we have room for
in the CQ ring, or if the application attempts to wait for more events without
having reaped the ones already present in the CQ ring.
 ```

I went over the tests that relied on the Heap not growing and changed it to
`alloc_no_growth`, but more eyes are necessary. I hate the name `no_growth` but
`can_fail` is also a lie since `growth` can fail if the Heap has already been
released or the allocation size blew up.