### PR TITLE
update to liburing-2.3

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,23 @@
+# Maintainer notes
+
+## liburing updates
+
+`vendor/liburing/` contains the upstream version of liburing. Updating it
+is normally done using `git subtree`.
+
+To do an update, first fetch the remote references from the liburing repo:
+
+```
+git remote add liburing https://github.com/axboe/liburing.git
+git fetch
+```
+
+Then run a subtree pull, and substitute `2.3` with the right version:
+
+```
+git subtree pull --prefix vendor/liburing https://github.com/axboe/liburing.git liburing-2.3 --squash
+```
+
+Then modify the build rules over at `lib/uring/dune` to pick up the
+right version of the shared library that's built.
+

--- a/lib/uring/dune
+++ b/lib/uring/dune
@@ -35,7 +35,7 @@
        "%{ocaml-config:ocamlc_cflags}"
        (run make -j -C src))))
     (copy %{project_root}/vendor/liburing/src/liburing.a liburing.a)
-    (copy %{project_root}/vendor/liburing/src/liburing.so.2.2 dlluring.so)
+    (copy %{project_root}/vendor/liburing/src/liburing.so.2.3 dlluring.so)
     (copy %{project_root}/vendor/liburing/src/include/liburing.h liburing.h)
     (copy %{project_root}/vendor/liburing/src/include/liburing/io_uring.h
       io_uring.h)

--- a/vendor/liburing/.github/workflows/build.yml
+++ b/vendor/liburing/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -26,6 +26,7 @@ jobs:
             cxx_pkg: clang
             cc: clang
             cxx: clang++
+            extra_flags: -Wshorten-64-to-32
 
           # x86 (32-bit) gcc
           - arch: i686
@@ -84,7 +85,10 @@ jobs:
             cxx: mips-linux-gnu-g++
 
     env:
-      FLAGS: -g -O2 -Wall -Wextra -Werror
+      FLAGS: -g -O3 -Wall -Wextra -Werror
+
+      # Flags for building sources in src/ dir only.
+      LIBURING_CFLAGS: ${{matrix.extra_flags}}
 
     steps:
     - name: Checkout source
@@ -94,9 +98,9 @@ jobs:
       run: |
         if [[ "${{matrix.cc_pkg}}" == "clang" ]]; then \
             wget https://apt.llvm.org/llvm.sh -O /tmp/llvm.sh; \
-            sudo bash /tmp/llvm.sh 15; \
-            sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 400; \
-            sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 400; \
+            sudo bash /tmp/llvm.sh 16; \
+            sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-16 400; \
+            sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-16 400; \
         else \
             sudo apt-get update -y; \
             sudo apt-get install -y ${{matrix.cc_pkg}} ${{matrix.cxx_pkg}}; \
@@ -114,7 +118,7 @@ jobs:
 
     - name: Build nolibc
       run: |
-        if [[ "${{matrix.arch}}" == "x86_64" || "${{matrix.arch}}" == "i686" ]]; then \
+        if [[ "${{matrix.arch}}" == "x86_64" || "${{matrix.arch}}" == "i686" || "${{matrix.arch}}" == "aarch64" ]]; then \
             make clean; \
             ./configure --cc=${{matrix.cc}} --cxx=${{matrix.cxx}} --nolibc; \
             make -j$(nproc) V=1 CPPFLAGS="-Werror" CFLAGS="$FLAGS" CXXFLAGS="$FLAGS"; \

--- a/vendor/liburing/.github/workflows/shellcheck.yml
+++ b/vendor/liburing/.github/workflows/shellcheck.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Checkout source

--- a/vendor/liburing/.gitignore
+++ b/vendor/liburing/.gitignore
@@ -13,8 +13,11 @@
 
 /examples/io_uring-cp
 /examples/io_uring-test
+/examples/io_uring-udp
 /examples/link-cp
 /examples/ucontext-cp
+/examples/poll-bench
+/examples/send-zerocopy
 
 /test/*.t
 /test/*.dmesg

--- a/vendor/liburing/CHANGELOG
+++ b/vendor/liburing/CHANGELOG
@@ -1,3 +1,20 @@
+liburing-2.3 release
+
+- Support non-libc build for aarch64.
+- Add io_uring_{enter,enter2,register,setup} syscall functions.
+- Add sync cancel interface, io_uring_register_sync_cancel().
+- Fix return value of io_uring_submit_and_wait_timeout() to match the
+  man page.
+- Improvements to the regression tests
+- Add support and test case for passthrough IO
+- Add recv and recvmsg multishot helpers and support
+- Add documentation and support for IORING_SETUP_DEFER_TASKRUN
+- Fix potential missing kernel entry with IORING_SETUP_IOPOLL
+- Add support and documentation for zero-copy network transmit
+- Various optimizations
+- Many cleanups
+- Many man page additions and updates
+
 liburing-2.2 release
 
 - Support non-libc builds.
@@ -6,7 +23,7 @@ liburing-2.2 release
 - Add support for multishot accept.
 - io_uring_register_files() will set RLIMIT_NOFILE if necessary.
 - Add support for registered ring fds, io_uring_register_ring_fd(),
-  reducingthe overhead of an io_uring_enter() system call.
+  reducing the overhead of an io_uring_enter() system call.
 - Add support for the message ring opcode.
 - Add support for newer request cancelation features.
 - Add support for IORING_SETUP_COOP_TASKRUN, which can help reduce the

--- a/vendor/liburing/configure
+++ b/vendor/liburing/configure
@@ -368,21 +368,21 @@ fi
 print_config "has_ucontext" "$has_ucontext"
 
 ##########################################
-# check for memfd_create(2)
-has_memfd_create="no"
+# Check NVME_URING_CMD support
+nvme_uring_cmd="no"
 cat > $TMPC << EOF
-#include <sys/mman.h>
-int main(int argc, char **argv)
+#include <linux/nvme_ioctl.h>
+int main(void)
 {
-  int memfd = memfd_create("test", 0);
-  return 0;
+  struct nvme_uring_cmd *cmd;
+
+  return sizeof(struct nvme_uring_cmd);
 }
 EOF
-if compile_prog "-Werror=implicit-function-declaration" "" "has_memfd_create"; then
-  has_memfd_create="yes"
+if compile_prog "" "" "nvme uring cmd"; then
+  nvme_uring_cmd="yes"
 fi
-print_config "has_memfd_create" "$has_memfd_create"
-
+print_config "NVMe uring command support" "$nvme_uring_cmd"
 
 #############################################################################
 if test "$liburing_nolibc" = "yes"; then
@@ -419,8 +419,8 @@ fi
 if test "$array_bounds" = "yes"; then
   output_sym "CONFIG_HAVE_ARRAY_BOUNDS"
 fi
-if test "$has_memfd_create" = "yes"; then
-  output_sym "CONFIG_HAVE_MEMFD_CREATE"
+if test "$nvme_uring_cmd" = "yes"; then
+  output_sym "CONFIG_HAVE_NVME_URING"
 fi
 
 echo "CC=$cc" >> $config_host_mak

--- a/vendor/liburing/examples/Makefile
+++ b/vendor/liburing/examples/Makefile
@@ -13,7 +13,10 @@ endif
 example_srcs := \
 	io_uring-cp.c \
 	io_uring-test.c \
-	link-cp.c
+	io_uring-udp.c \
+	link-cp.c \
+	poll-bench.c \
+	send-zerocopy.c
 
 all_targets :=
 

--- a/vendor/liburing/examples/io_uring-udp.c
+++ b/vendor/liburing/examples/io_uring-udp.c
@@ -1,0 +1,395 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/mman.h>
+#include <stdlib.h>
+#include <string.h>
+#include <netinet/udp.h>
+#include <arpa/inet.h>
+
+#include "liburing.h"
+
+#define QD 64
+#define BUF_SHIFT 12 /* 4k */
+#define CQES (QD * 16)
+#define BUFFERS CQES
+#define CONTROLLEN 0
+
+struct sendmsg_ctx {
+	struct msghdr msg;
+	struct iovec iov;
+};
+
+struct ctx {
+	struct io_uring ring;
+	struct io_uring_buf_ring *buf_ring;
+	unsigned char *buffer_base;
+	struct msghdr msg;
+	int buf_shift;
+	int af;
+	bool verbose;
+	struct sendmsg_ctx send[BUFFERS];
+	size_t buf_ring_size;
+};
+
+static size_t buffer_size(struct ctx *ctx)
+{
+	return 1U << ctx->buf_shift;
+}
+
+static unsigned char *get_buffer(struct ctx *ctx, int idx)
+{
+	return ctx->buffer_base + (idx << ctx->buf_shift);
+}
+
+static int setup_buffer_pool(struct ctx *ctx)
+{
+	int ret, i;
+	void *mapped;
+	struct io_uring_buf_reg reg = { .ring_addr = 0,
+					.ring_entries = BUFFERS,
+					.bgid = 0 };
+
+	ctx->buf_ring_size = (sizeof(struct io_uring_buf) + buffer_size(ctx)) * BUFFERS;
+	mapped = mmap(NULL, ctx->buf_ring_size, PROT_READ | PROT_WRITE,
+		      MAP_ANONYMOUS | MAP_PRIVATE, 0, 0);
+	if (mapped == MAP_FAILED) {
+		fprintf(stderr, "buf_ring mmap: %s\n", strerror(errno));
+		return -1;
+	}
+	ctx->buf_ring = (struct io_uring_buf_ring *)mapped;
+
+	io_uring_buf_ring_init(ctx->buf_ring);
+
+	reg = (struct io_uring_buf_reg) {
+		.ring_addr = (unsigned long)ctx->buf_ring,
+		.ring_entries = BUFFERS,
+		.bgid = 0
+	};
+	ctx->buffer_base = (unsigned char *)ctx->buf_ring +
+			   sizeof(struct io_uring_buf) * BUFFERS;
+
+	ret = io_uring_register_buf_ring(&ctx->ring, &reg, 0);
+	if (ret) {
+		fprintf(stderr, "buf_ring init failed: %s\n"
+				"NB This requires a kernel version >= 6.0\n",
+				strerror(-ret));
+		return ret;
+	}
+
+	for (i = 0; i < BUFFERS; i++) {
+		io_uring_buf_ring_add(ctx->buf_ring, get_buffer(ctx, i), buffer_size(ctx), i,
+				      io_uring_buf_ring_mask(BUFFERS), i);
+	}
+	io_uring_buf_ring_advance(ctx->buf_ring, BUFFERS);
+
+	return 0;
+}
+
+static int setup_context(struct ctx *ctx)
+{
+	struct io_uring_params params;
+	int ret;
+
+	memset(&params, 0, sizeof(params));
+	params.cq_entries = QD * 8;
+	params.flags = IORING_SETUP_SUBMIT_ALL | IORING_SETUP_COOP_TASKRUN |
+		       IORING_SETUP_CQSIZE;
+
+	ret = io_uring_queue_init_params(QD, &ctx->ring, &params);
+	if (ret < 0) {
+		fprintf(stderr, "queue_init failed: %s\n"
+				"NB: This requires a kernel version >= 6.0\n",
+				strerror(-ret));
+		return ret;
+	}
+
+	ret = setup_buffer_pool(ctx);
+	if (ret)
+		io_uring_queue_exit(&ctx->ring);
+
+	memset(&ctx->msg, 0, sizeof(ctx->msg));
+	ctx->msg.msg_namelen = sizeof(struct sockaddr_storage);
+	ctx->msg.msg_controllen = CONTROLLEN;
+	return ret;
+}
+
+static int setup_sock(int af, int port)
+{
+	int ret;
+	int fd;
+	uint16_t nport = port <= 0 ? 0 : htons(port);
+
+	fd = socket(af, SOCK_DGRAM, 0);
+	if (fd < 0) {
+		fprintf(stderr, "sock_init: %s\n", strerror(errno));
+		return -1;
+	}
+
+	if (af == AF_INET6) {
+		struct sockaddr_in6 addr6 = {
+			.sin6_family = af,
+			.sin6_port = nport,
+			.sin6_addr = IN6ADDR_ANY_INIT
+		};
+
+		ret = bind(fd, (struct sockaddr *) &addr6, sizeof(addr6));
+	} else {
+		struct sockaddr_in addr = {
+			.sin_family = af,
+			.sin_port = nport,
+			.sin_addr = { INADDR_ANY }
+		};
+
+		ret = bind(fd, (struct sockaddr *) &addr, sizeof(addr));
+	}
+
+	if (ret) {
+		fprintf(stderr, "sock_bind: %s\n", strerror(errno));
+		close(fd);
+		return -1;
+	}
+
+	if (port <= 0) {
+		int port;
+		struct sockaddr_storage s;
+		socklen_t sz = sizeof(s);
+
+		if (getsockname(fd, (struct sockaddr *)&s, &sz)) {
+			fprintf(stderr, "getsockname failed\n");
+			close(fd);
+			return -1;
+		}
+
+		port = ntohs(((struct sockaddr_in *)&s)->sin_port);
+		fprintf(stderr, "port bound to %d\n", port);
+	}
+
+	return fd;
+}
+
+static void cleanup_context(struct ctx *ctx)
+{
+	munmap(ctx->buf_ring, ctx->buf_ring_size);
+	io_uring_queue_exit(&ctx->ring);
+}
+
+static bool get_sqe(struct ctx *ctx, struct io_uring_sqe **sqe)
+{
+	*sqe = io_uring_get_sqe(&ctx->ring);
+
+	if (!*sqe) {
+		io_uring_submit(&ctx->ring);
+		*sqe = io_uring_get_sqe(&ctx->ring);
+	}
+	if (!*sqe) {
+		fprintf(stderr, "cannot get sqe\n");
+		return true;
+	}
+	return false;
+}
+
+static int add_recv(struct ctx *ctx, int idx)
+{
+	struct io_uring_sqe *sqe;
+
+	if (get_sqe(ctx, &sqe))
+		return -1;
+
+	io_uring_prep_recvmsg_multishot(sqe, idx, &ctx->msg, MSG_TRUNC);
+	sqe->flags |= IOSQE_FIXED_FILE;
+
+	sqe->flags |= IOSQE_BUFFER_SELECT;
+	sqe->buf_group = 0;
+	io_uring_sqe_set_data64(sqe, BUFFERS + 1);
+	return 0;
+}
+
+static void recycle_buffer(struct ctx *ctx, int idx)
+{
+	io_uring_buf_ring_add(ctx->buf_ring, get_buffer(ctx, idx), buffer_size(ctx), idx,
+			      io_uring_buf_ring_mask(BUFFERS), 0);
+	io_uring_buf_ring_advance(ctx->buf_ring, 1);
+}
+
+static int process_cqe_send(struct ctx *ctx, struct io_uring_cqe *cqe)
+{
+	int idx = cqe->user_data;
+
+	if (cqe->res < 0)
+		fprintf(stderr, "bad send %s\n", strerror(-cqe->res));
+	recycle_buffer(ctx, idx);
+	return 0;
+}
+
+static int process_cqe_recv(struct ctx *ctx, struct io_uring_cqe *cqe,
+			    int fdidx)
+{
+	int ret, idx;
+	struct io_uring_recvmsg_out *o;
+	struct io_uring_sqe *sqe;
+
+	if (!(cqe->flags & IORING_CQE_F_MORE)) {
+		ret = add_recv(ctx, fdidx);
+		if (ret)
+			return ret;
+	}
+
+	if (cqe->res == -ENOBUFS)
+		return 0;
+
+	if (!(cqe->flags & IORING_CQE_F_BUFFER) || cqe->res < 0) {
+		fprintf(stderr, "recv cqe bad res %d\n", cqe->res);
+		if (cqe->res == -EFAULT || cqe->res == -EINVAL)
+			fprintf(stderr,
+				"NB: This requires a kernel version >= 6.0\n");
+		return -1;
+	}
+	idx = cqe->flags >> 16;
+
+	o = io_uring_recvmsg_validate(get_buffer(ctx, cqe->flags >> 16),
+				      cqe->res, &ctx->msg);
+	if (!o) {
+		fprintf(stderr, "bad recvmsg\n");
+		return -1;
+	}
+	if (o->namelen > ctx->msg.msg_namelen) {
+		fprintf(stderr, "truncated name\n");
+		recycle_buffer(ctx, idx);
+		return 0;
+	}
+	if (o->flags & MSG_TRUNC) {
+		unsigned int r;
+
+		r = io_uring_recvmsg_payload_length(o, cqe->res, &ctx->msg);
+		fprintf(stderr, "truncated msg need %u received %u\n",
+				o->payloadlen, r);
+		recycle_buffer(ctx, idx);
+		return 0;
+	}
+
+	if (ctx->verbose) {
+		char buff[INET6_ADDRSTRLEN + 1];
+		const char *name;
+		struct sockaddr_in *addr = io_uring_recvmsg_name(o);
+
+		name = inet_ntop(ctx->af, addr, buff, sizeof(buff));
+		if (!name)
+			name = "<INVALID>";
+		fprintf(stderr, "received %u bytes %d from %s:%d\n",
+			io_uring_recvmsg_payload_length(o, cqe->res, &ctx->msg),
+			o->namelen, name, (int)ntohs(addr->sin_port));
+	}
+
+	if (get_sqe(ctx, &sqe))
+		return -1;
+
+	ctx->send[idx].iov = (struct iovec) {
+		.iov_base = io_uring_recvmsg_payload(o, &ctx->msg),
+		.iov_len =
+			io_uring_recvmsg_payload_length(o, cqe->res, &ctx->msg)
+	};
+	ctx->send[idx].msg = (struct msghdr) {
+		.msg_namelen = o->namelen,
+		.msg_name = io_uring_recvmsg_name(o),
+		.msg_control = NULL,
+		.msg_controllen = 0,
+		.msg_iov = &ctx->send[idx].iov,
+		.msg_iovlen = 1
+	};
+
+	io_uring_prep_sendmsg(sqe, fdidx, &ctx->send[idx].msg, 0);
+	io_uring_sqe_set_data64(sqe, idx);
+	sqe->flags |= IOSQE_FIXED_FILE;
+
+	return 0;
+}
+static int process_cqe(struct ctx *ctx, struct io_uring_cqe *cqe, int fdidx)
+{
+	if (cqe->user_data < BUFFERS)
+		return process_cqe_send(ctx, cqe);
+	else
+		return process_cqe_recv(ctx, cqe, fdidx);
+}
+
+int main(int argc, char *argv[])
+{
+	struct ctx ctx;
+	int ret;
+	int port = -1;
+	int sockfd;
+	int opt;
+	struct io_uring_cqe *cqes[CQES];
+	unsigned int count, i;
+
+	memset(&ctx, 0, sizeof(ctx));
+	ctx.verbose = false;
+	ctx.af = AF_INET;
+	ctx.buf_shift = BUF_SHIFT;
+
+	while ((opt = getopt(argc, argv, "6vp:b:")) != -1) {
+		switch (opt) {
+		case '6':
+			ctx.af = AF_INET6;
+			break;
+		case 'p':
+			port = atoi(optarg);
+			break;
+		case 'b':
+			ctx.buf_shift = atoi(optarg);
+			break;
+		case 'v':
+			ctx.verbose = true;
+			break;
+		default:
+			fprintf(stderr, "Usage: %s [-p port] "
+					"[-b log2(BufferSize)] [-6] [-v]\n",
+					argv[0]);
+			exit(-1);
+		}
+	}
+
+	sockfd = setup_sock(ctx.af, port);
+	if (sockfd < 0)
+		return 1;
+
+	if (setup_context(&ctx)) {
+		close(sockfd);
+		return 1;
+	}
+
+	ret = io_uring_register_files(&ctx.ring, &sockfd, 1);
+	if (ret) {
+		fprintf(stderr, "register files: %s\n", strerror(-ret));
+		return -1;
+	}
+
+	ret = add_recv(&ctx, 0);
+	if (ret)
+		return 1;
+
+	while (true) {
+		ret = io_uring_submit_and_wait(&ctx.ring, 1);
+		if (ret == -EINTR)
+			continue;
+		if (ret < 0) {
+			fprintf(stderr, "submit and wait failed %d\n", ret);
+			break;
+		}
+
+		count = io_uring_peek_batch_cqe(&ctx.ring, &cqes[0], CQES);
+		for (i = 0; i < count; i++) {
+			ret = process_cqe(&ctx, cqes[i], 0);
+			if (ret)
+				goto cleanup;
+		}
+		io_uring_cq_advance(&ctx.ring, count);
+	}
+
+cleanup:
+	cleanup_context(&ctx);
+	close(sockfd);
+	return ret;
+}

--- a/vendor/liburing/examples/poll-bench.c
+++ b/vendor/liburing/examples/poll-bench.c
@@ -1,0 +1,101 @@
+/* SPDX-License-Identifier: MIT */
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <poll.h>
+#include <sys/time.h>
+#include <sys/wait.h>
+
+#include "liburing.h"
+
+static char buf[4096];
+static unsigned long runtime_ms = 10000;
+
+static unsigned long gettimeofday_ms(void)
+{
+	struct timeval tv;
+
+	gettimeofday(&tv, NULL);
+	return (tv.tv_sec * 1000) + (tv.tv_usec / 1000);
+}
+
+int main(void)
+{
+	unsigned long tstop;
+	unsigned long nr_reqs = 0;
+	struct io_uring_cqe *cqe;
+	struct io_uring_sqe *sqe;
+	struct io_uring ring;
+	int pipe1[2];
+	int ret, i, qd = 32;
+
+	if (pipe(pipe1) != 0) {
+		perror("pipe");
+		return 1;
+	}
+
+	ret = io_uring_queue_init(1024, &ring, IORING_SETUP_SINGLE_ISSUER);
+	if (ret == -EINVAL) {
+		fprintf(stderr, "can't single\n");
+		ret = io_uring_queue_init(1024, &ring, 0);
+	}
+	if (ret) {
+		fprintf(stderr, "child: ring setup failed: %d\n", ret);
+		return 1;
+	}
+
+	ret = io_uring_register_files(&ring, pipe1, 2);
+	if (ret < 0) {
+		fprintf(stderr, "io_uring_register_files failed\n");
+		return 1;
+	}
+
+	ret = io_uring_register_ring_fd(&ring);
+	if (ret < 0) {
+		fprintf(stderr, "io_uring_register_ring_fd failed\n");
+		return 1;
+	}
+
+	tstop = gettimeofday_ms() + runtime_ms;
+	do {
+		for (i = 0; i < qd; i++) {
+			sqe = io_uring_get_sqe(&ring);
+			io_uring_prep_poll_add(sqe, 0, POLLIN);
+			sqe->flags |= IOSQE_FIXED_FILE;
+			sqe->user_data = 1;
+		}
+
+		ret = io_uring_submit(&ring);
+		if (ret != qd) {
+			fprintf(stderr, "child: sqe submit failed: %d\n", ret);
+			return 1;
+		}
+
+		ret = write(pipe1[1], buf, 1);
+		if (ret != 1) {
+			fprintf(stderr, "write failed %i\n", errno);
+			return 1;
+		}
+		ret = read(pipe1[0], buf, 1);
+		if (ret != 1) {
+			fprintf(stderr, "read failed %i\n", errno);
+			return 1;
+		}
+
+		for (i = 0; i < qd; i++) {
+			ret = io_uring_wait_cqe(&ring, &cqe);
+			if (ret < 0) {
+				fprintf(stderr, "child: wait completion %d\n", ret);
+				break;
+			}
+			io_uring_cqe_seen(&ring, cqe);
+			nr_reqs++;
+		}
+	} while (gettimeofday_ms() < tstop);
+
+	fprintf(stderr, "requests/s: %lu\n", nr_reqs * 1000UL / runtime_ms);
+	return 0;
+}

--- a/vendor/liburing/examples/send-zerocopy.c
+++ b/vendor/liburing/examples/send-zerocopy.c
@@ -1,0 +1,339 @@
+/* SPDX-License-Identifier: MIT */
+/* based on linux-kernel/tools/testing/selftests/net/msg_zerocopy.c */
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <assert.h>
+#include <errno.h>
+#include <error.h>
+#include <limits.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include <arpa/inet.h>
+#include <linux/errqueue.h>
+#include <linux/if_packet.h>
+#include <linux/ipv6.h>
+#include <linux/socket.h>
+#include <linux/sockios.h>
+#include <net/ethernet.h>
+#include <net/if.h>
+#include <netinet/ip.h>
+#include <netinet/in.h>
+#include <netinet/ip6.h>
+#include <netinet/tcp.h>
+#include <netinet/udp.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+#include <sys/un.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include "liburing.h"
+
+#define ZC_TAG 0xfffffffULL
+#define MAX_SUBMIT_NR 512
+
+static bool cfg_reg_ringfd = true;
+static bool cfg_fixed_files = 1;
+static bool cfg_zc = 1;
+static int  cfg_nr_reqs = 8;
+static bool cfg_fixed_buf = 1;
+
+static int  cfg_family		= PF_UNSPEC;
+static int  cfg_payload_len;
+static int  cfg_port		= 8000;
+static int  cfg_runtime_ms	= 4200;
+
+static socklen_t cfg_alen;
+static struct sockaddr_storage cfg_dst_addr;
+
+static char payload[IP_MAXPACKET] __attribute__((aligned(4096)));
+
+static unsigned long gettimeofday_ms(void)
+{
+	struct timeval tv;
+
+	gettimeofday(&tv, NULL);
+	return (tv.tv_sec * 1000) + (tv.tv_usec / 1000);
+}
+
+static void do_setsockopt(int fd, int level, int optname, int val)
+{
+	if (setsockopt(fd, level, optname, &val, sizeof(val)))
+		error(1, errno, "setsockopt %d.%d: %d", level, optname, val);
+}
+
+static void setup_sockaddr(int domain, const char *str_addr,
+			   struct sockaddr_storage *sockaddr)
+{
+	struct sockaddr_in6 *addr6 = (void *) sockaddr;
+	struct sockaddr_in *addr4 = (void *) sockaddr;
+
+	switch (domain) {
+	case PF_INET:
+		memset(addr4, 0, sizeof(*addr4));
+		addr4->sin_family = AF_INET;
+		addr4->sin_port = htons(cfg_port);
+		if (str_addr &&
+		    inet_pton(AF_INET, str_addr, &(addr4->sin_addr)) != 1)
+			error(1, 0, "ipv4 parse error: %s", str_addr);
+		break;
+	case PF_INET6:
+		memset(addr6, 0, sizeof(*addr6));
+		addr6->sin6_family = AF_INET6;
+		addr6->sin6_port = htons(cfg_port);
+		if (str_addr &&
+		    inet_pton(AF_INET6, str_addr, &(addr6->sin6_addr)) != 1)
+			error(1, 0, "ipv6 parse error: %s", str_addr);
+		break;
+	default:
+		error(1, 0, "illegal domain");
+	}
+}
+
+static int do_setup_tx(int domain, int type, int protocol)
+{
+	int fd;
+
+	fd = socket(domain, type, protocol);
+	if (fd == -1)
+		error(1, errno, "socket t");
+
+	do_setsockopt(fd, SOL_SOCKET, SO_SNDBUF, 1 << 21);
+
+	if (connect(fd, (void *) &cfg_dst_addr, cfg_alen))
+		error(1, errno, "connect");
+	return fd;
+}
+
+static inline struct io_uring_cqe *wait_cqe_fast(struct io_uring *ring)
+{
+	struct io_uring_cqe *cqe;
+	unsigned head;
+	int ret;
+
+	io_uring_for_each_cqe(ring, head, cqe)
+		return cqe;
+
+	ret = io_uring_wait_cqe(ring, &cqe);
+	if (ret)
+		error(1, ret, "wait cqe");
+	return cqe;
+}
+
+static void do_tx(int domain, int type, int protocol)
+{
+	unsigned long packets = 0;
+	unsigned long bytes = 0;
+	struct io_uring ring;
+	struct iovec iov;
+	uint64_t tstop;
+	int i, fd, ret;
+	int compl_cqes = 0;
+
+	fd = do_setup_tx(domain, type, protocol);
+
+	ret = io_uring_queue_init(512, &ring, IORING_SETUP_COOP_TASKRUN);
+	if (ret)
+		error(1, ret, "io_uring: queue init");
+
+	if (cfg_fixed_files) {
+		ret = io_uring_register_files(&ring, &fd, 1);
+		if (ret < 0)
+			error(1, ret, "io_uring: files registration");
+	}
+	if (cfg_reg_ringfd) {
+		ret = io_uring_register_ring_fd(&ring);
+		if (ret < 0)
+			error(1, ret, "io_uring: io_uring_register_ring_fd");
+	}
+
+	iov.iov_base = payload;
+	iov.iov_len = cfg_payload_len;
+
+	ret = io_uring_register_buffers(&ring, &iov, 1);
+	if (ret)
+		error(1, ret, "io_uring: buffer registration");
+
+	tstop = gettimeofday_ms() + cfg_runtime_ms;
+	do {
+		struct io_uring_sqe *sqe;
+		struct io_uring_cqe *cqe;
+		unsigned buf_idx = 0;
+		unsigned msg_flags = MSG_WAITALL;
+
+		for (i = 0; i < cfg_nr_reqs; i++) {
+			sqe = io_uring_get_sqe(&ring);
+
+			if (!cfg_zc)
+				io_uring_prep_send(sqe, fd, payload,
+						   cfg_payload_len, 0);
+			else {
+				io_uring_prep_send_zc(sqe, fd, payload,
+						     cfg_payload_len, msg_flags, 0);
+				if (cfg_fixed_buf) {
+					sqe->ioprio |= IORING_RECVSEND_FIXED_BUF;
+					sqe->buf_index = buf_idx;
+				}
+			}
+			sqe->user_data = 1;
+			if (cfg_fixed_files) {
+				sqe->fd = 0;
+				sqe->flags |= IOSQE_FIXED_FILE;
+			}
+		}
+
+		ret = io_uring_submit(&ring);
+		if (ret != cfg_nr_reqs)
+			error(1, ret, "submit");
+
+		for (i = 0; i < cfg_nr_reqs; i++) {
+			cqe = wait_cqe_fast(&ring);
+
+			if (cqe->flags & IORING_CQE_F_NOTIF) {
+				if (cqe->flags & IORING_CQE_F_MORE)
+					error(1, -EINVAL, "F_MORE notif");
+				compl_cqes--;
+				i--;
+				io_uring_cqe_seen(&ring, cqe);
+				continue;
+			}
+			if (cqe->flags & IORING_CQE_F_MORE)
+				compl_cqes++;
+
+			if (cqe->res >= 0) {
+				packets++;
+				bytes += cqe->res;
+			} else if (cqe->res == -ECONNREFUSED || cqe->res == -EPIPE ||
+				   cqe->res == -ECONNRESET) {
+				fprintf(stderr, "Connection failure");
+				goto out_fail;
+			} else if (cqe->res != -EAGAIN) {
+				error(1, cqe->res, "send failed");
+			}
+			io_uring_cqe_seen(&ring, cqe);
+		}
+	} while (gettimeofday_ms() < tstop);
+
+out_fail:
+	shutdown(fd, SHUT_RDWR);
+	if (close(fd))
+		error(1, errno, "close");
+
+	fprintf(stderr, "tx=%lu (MB=%lu), tx/s=%lu (MB/s=%lu)\n",
+			packets, bytes >> 20,
+			packets / (cfg_runtime_ms / 1000),
+			(bytes >> 20) / (cfg_runtime_ms / 1000));
+
+	while (compl_cqes) {
+		struct io_uring_cqe *cqe = wait_cqe_fast(&ring);
+
+		io_uring_cqe_seen(&ring, cqe);
+		compl_cqes--;
+	}
+	io_uring_queue_exit(&ring);
+}
+
+static void do_test(int domain, int type, int protocol)
+{
+	int i;
+
+	for (i = 0; i < IP_MAXPACKET; i++)
+		payload[i] = 'a' + (i % 26);
+
+	do_tx(domain, type, protocol);
+}
+
+static void usage(const char *filepath)
+{
+	error(1, 0, "Usage: %s [-n<N>] [-z<val>] [-s<payload size>] "
+		    "(-4|-6) [-t<time s>] -D<dst_ip> udp", filepath);
+}
+
+static void parse_opts(int argc, char **argv)
+{
+	const int max_payload_len = sizeof(payload) -
+				    sizeof(struct ipv6hdr) -
+				    sizeof(struct tcphdr) -
+				    40 /* max tcp options */;
+	int c;
+	char *daddr = NULL;
+
+	if (argc <= 1)
+		usage(argv[0]);
+
+	cfg_payload_len = max_payload_len;
+
+	while ((c = getopt(argc, argv, "46D:p:s:t:n:z:b:k")) != -1) {
+		switch (c) {
+		case '4':
+			if (cfg_family != PF_UNSPEC)
+				error(1, 0, "Pass one of -4 or -6");
+			cfg_family = PF_INET;
+			cfg_alen = sizeof(struct sockaddr_in);
+			break;
+		case '6':
+			if (cfg_family != PF_UNSPEC)
+				error(1, 0, "Pass one of -4 or -6");
+			cfg_family = PF_INET6;
+			cfg_alen = sizeof(struct sockaddr_in6);
+			break;
+		case 'D':
+			daddr = optarg;
+			break;
+		case 'p':
+			cfg_port = strtoul(optarg, NULL, 0);
+			break;
+		case 's':
+			cfg_payload_len = strtoul(optarg, NULL, 0);
+			break;
+		case 't':
+			cfg_runtime_ms = 200 + strtoul(optarg, NULL, 10) * 1000;
+			break;
+		case 'n':
+			cfg_nr_reqs = strtoul(optarg, NULL, 0);
+			break;
+		case 'z':
+			cfg_zc = strtoul(optarg, NULL, 0);
+			break;
+		case 'b':
+			cfg_fixed_buf = strtoul(optarg, NULL, 0);
+			break;
+		}
+	}
+
+	if (cfg_nr_reqs > MAX_SUBMIT_NR)
+		error(1, 0, "-n: submit batch nr exceeds max (%d)", MAX_SUBMIT_NR);
+	if (cfg_payload_len > max_payload_len)
+		error(1, 0, "-s: payload exceeds max (%d)", max_payload_len);
+
+	setup_sockaddr(cfg_family, daddr, &cfg_dst_addr);
+
+	if (optind != argc - 1)
+		usage(argv[0]);
+}
+
+int main(int argc, char **argv)
+{
+	const char *cfg_test;
+
+	parse_opts(argc, argv);
+
+	cfg_test = argv[argc - 1];
+	if (!strcmp(cfg_test, "tcp"))
+		do_test(cfg_family, SOCK_STREAM, 0);
+	else if (!strcmp(cfg_test, "udp"))
+		do_test(cfg_family, SOCK_DGRAM, 0);
+	else
+		error(1, 0, "unknown cfg_test %s", cfg_test);
+
+	return 0;
+}

--- a/vendor/liburing/liburing.spec
+++ b/vendor/liburing/liburing.spec
@@ -1,5 +1,5 @@
 Name: liburing
-Version: 2.2
+Version: 2.3
 Release: 1%{?dist}
 Summary: Linux-native io_uring I/O access library
 License: (GPLv2 with exceptions and LGPLv2+) or MIT

--- a/vendor/liburing/man/io_uring.7
+++ b/vendor/liburing/man/io_uring.7
@@ -2,7 +2,7 @@
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
 
-.TH IO_URING 7 2020-07-26 "Linux" "Linux Programmer's Manual"
+.TH io_uring 7 2020-07-26 "Linux" "Linux Programmer's Manual"
 .SH NAME
 io_uring \- Asynchronous I/O facility
 .SH SYNOPSIS
@@ -405,10 +405,36 @@ this field can be used to correlate a submission with a completion.
 is the result from the system call that was performed as part of the
 submission;
 its return value.
+
 The
 .I flags
-field could carry request-specific metadata in the future,
-but is currently unused.
+field carries request-specific information. As of the 6.0 kernel, the following
+flags are defined:
+
+.TP
+.B IORING_CQE_F_BUFFER
+If set, the upper 16 bits of the flags field carries the buffer ID that was
+chosen for this request. The request must have been issued with
+.B IOSQE_BUFFER_SELECT
+set, and used with a request type that supports buffer selection. Additionally,
+buffers must have been provided upfront either via the
+.B IORING_OP_PROVIDE_BUFFERS
+or the
+.B IORING_REGISTER_PBUF_RING
+methods.
+.TP
+.B IORING_CQE_F_MORE
+If set, the application should expect more completions from the request. This
+is used for requests that can generate multiple completions, such as multi-shot
+requests, receive, or accept.
+.TP
+.B IORING_CQE_F_SOCK_NONEMPTY
+If set, upon receiving the data from the socket in the current request, the
+socket still had data left on completion of this request.
+.TP
+.B IORING_CQE_F_NOTIF
+Set for notification CQEs, as seen with the zero-copy networking send and
+receive support.
 .PP
 The general sequence to read completion events off the completion queue is
 as follows:

--- a/vendor/liburing/man/io_uring_buf_ring_advance.3
+++ b/vendor/liburing/man/io_uring_buf_ring_advance.3
@@ -9,8 +9,8 @@ io_uring_buf_ring_advance \- advance index of provided buffer in buffer ring
 .nf
 .B #include <liburing.h>
 .PP
-.BI "int io_uring_buf_ring_advance(struct io_uring_buf_ring *" br ",
-.BI "                              int " count ");"
+.BI "void io_uring_buf_ring_advance(struct io_uring_buf_ring *" br ",
+.BI "                               int " count ");"
 .fi
 .SH DESCRIPTION
 .PP

--- a/vendor/liburing/man/io_uring_buf_ring_cq_advance.3
+++ b/vendor/liburing/man/io_uring_buf_ring_cq_advance.3
@@ -9,9 +9,9 @@ io_uring_buf_ring_cq_advance \- advance index of provided buffer and CQ ring
 .nf
 .B #include <liburing.h>
 .PP
-.BI "int io_uring_buf_ring_cq_advance(struct io_uring *" ring ",
-.BI "                                 struct io_uring_buf_ring *" br ",
-.BI "                                 int " count ");"
+.BI "void io_uring_buf_ring_cq_advance(struct io_uring *" ring ",
+.BI "                                  struct io_uring_buf_ring *" br ",
+.BI "                                  int " count ");"
 .fi
 .SH DESCRIPTION
 .PP

--- a/vendor/liburing/man/io_uring_cq_has_overflow.3
+++ b/vendor/liburing/man/io_uring_cq_has_overflow.3
@@ -1,0 +1,25 @@
+.\" Copyright (C) 2022 Dylan Yudaken <dylany@fb.com>
+.\"
+.\" SPDX-License-Identifier: LGPL-2.0-or-later
+.\"
+.TH io_uring_cq_has_overflow 3 "September 5, 2022" "liburing-2.3" "liburing Manual"
+.SH NAME
+io_uring_cq_has_overflow \- returns if there are overflow entries waiting to move to the CQ ring
+.SH SYNOPSIS
+.nf
+.B #include <liburing.h>
+.PP
+.BI "bool io_uring_cq_has_overflow(const struct io_uring *" ring ");"
+.fi
+.SH DESCRIPTION
+.PP
+The
+.BR io_uring_cq_has_overflow (3)
+function informs the application if CQ entries have overflowed and are waiting to be flushed to
+the CQ ring. For example using
+.BR io_uring_get_events (3)
+.
+.SH RETURN VALUE
+True if there are CQ entries waiting to be flushed to the CQ ring.
+.SH SEE ALSO
+.BR io_uring_get_events (3)

--- a/vendor/liburing/man/io_uring_cq_ready.3
+++ b/vendor/liburing/man/io_uring_cq_ready.3
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_cq_ready "January 25, 2022" "liburing-2.1" "liburing Manual"
+.TH io_uring_cq_ready 3 "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
 io_uring_cq_ready \- returns number of unconsumed ready entries in the CQ ring
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ io_uring_cq_ready \- returns number of unconsumed ready entries in the CQ ring
 .PP
 The
 .BR io_uring_cq_ready (3)
-function retuns the number of unconsumed entries that are ready belonging to the
+function returns the number of unconsumed entries that are ready belonging to the
 .I ring
 param.
 

--- a/vendor/liburing/man/io_uring_enter.2
+++ b/vendor/liburing/man/io_uring_enter.2
@@ -3,27 +3,31 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH IO_URING_ENTER 2 2019-01-22 "Linux" "Linux Programmer's Manual"
+.TH io_uring_enter 2 2019-01-22 "Linux" "Linux Programmer's Manual"
 .SH NAME
 io_uring_enter \- initiate and/or complete asynchronous I/O
 .SH SYNOPSIS
 .nf
-.BR "#include <linux/io_uring.h>"
+.BR "#include <liburing.h>"
 .PP
 .BI "int io_uring_enter(unsigned int " fd ", unsigned int " to_submit ,
 .BI "                   unsigned int " min_complete ", unsigned int " flags ,
 .BI "                   sigset_t *" sig );
+.PP
+.BI "int io_uring_enter2(unsigned int " fd ", unsigned int " to_submit ,
+.BI "                    unsigned int " min_complete ", unsigned int " flags ,
+.BI "                    sigset_t *" sig ", size_t " sz );
 .fi
 .PP
 .SH DESCRIPTION
 .PP
-.BR io_uring_enter ()
+.BR io_uring_enter (2)
 is used to initiate and complete I/O using the shared submission and
 completion queues setup by a call to
 .BR io_uring_setup (2).
 A single call can both submit new I/O and wait for completions of I/O
 initiated by this call or previous calls to
-.BR io_uring_enter ().
+.BR io_uring_enter (2).
 
 .I fd
 is the file descriptor returned by
@@ -34,7 +38,7 @@ specifies the number of I/Os to submit from the submission queue.
 is a bitmask of the following values:
 .TP
 .B IORING_ENTER_GETEVENTS
-If this flag is set, then the system call will wait for the specificied
+If this flag is set, then the system call will wait for the specified
 number of events in
 .I min_complete
 before returning. This flag can be set along with
@@ -61,12 +65,12 @@ Since kernel 5.11, the system calls arguments have been modified to look like
 the following:
 
 .nf
-.BI "int io_uring_enter(unsigned int " fd ", unsigned int " to_submit ,
-.BI "                   unsigned int " min_complete ", unsigned int " flags ,
-.BI "                   const void *" arg ", size_t " argsz );
+.BI "int io_uring_enter2(unsigned int " fd ", unsigned int " to_submit ,
+.BI "                    unsigned int " min_complete ", unsigned int " flags ,
+.BI "                    const void *" arg ", size_t " argsz );
 .fi
 
-which is behaves just like the original definition by default. However, if
+which behaves just like the original definition by default. However, if
 .B IORING_ENTER_EXT_ARG
 is set, then instead of a
 .I sigset_t
@@ -137,12 +141,12 @@ is a pointer to a signal mask (see
 if
 .I sig
 is not NULL,
-.BR io_uring_enter ()
+.BR io_uring_enter (2)
 first replaces the current signal mask by the one pointed to by
 .IR sig ,
 then waits for events to become available in the completion queue, and
 then restores the original signal mask.  The following
-.BR io_uring_enter ()
+.BR io_uring_enter (2)
 call:
 .PP
 .in +4n
@@ -249,7 +253,7 @@ and
 .BR pwritev2 (2).
 If the file is not seekable,
 .I off
-must be set to zero.
+must be set to zero or -1.
 
 .TP
 .B IORING_OP_READ_FIXED
@@ -390,11 +394,45 @@ holds the flags associated with the system call. See also
 .BR sendmsg (2)
 for the general description of the related system call. Available since 5.3.
 
+This command also supports the following modifiers in
+.I ioprio:
+
+.PP
+.in +12
+.B IORING_RECVSEND_POLL_FIRST
+If set, io_uring will assume the socket is currently full and attempting to
+send data will be unsuccessful. For this case, io_uring will arm internal
+poll and trigger a send of the data when there is enough space available.
+This initial send attempt can be wasteful for the case where the socket
+is expected to be full, setting this flag will bypass the initial send
+attempt and go straight to arming poll. If poll does indicate that data can
+be sent, the operation will proceed.
+.EE
+.in
+.PP
+
 .TP
 .B IORING_OP_RECVMSG
 Works just like IORING_OP_SENDMSG, except for
 .BR recvmsg(2)
 instead. See the description of IORING_OP_SENDMSG. Available since 5.3.
+
+This command also supports the following modifiers in
+.I ioprio:
+
+.PP
+.in +12
+.B IORING_RECVSEND_POLL_FIRST
+If set, io_uring will assume the socket is currently empty and attempting to
+receive data will be unsuccessful. For this case, io_uring will arm internal
+poll and trigger a receive of the data when the socket has data to be read.
+This initial receive attempt can be wasteful for the case where the socket
+is expected to be empty, setting this flag will bypass the initial receive
+attempt and go straight to arming poll. If poll does indicate that data is
+ready to be received, the operation will proceed.
+.EE
+.in
+.PP
 
 .TP
 .B IORING_OP_SEND
@@ -412,11 +450,45 @@ holds the flags associated with the system call. See also
 .BR send(2)
 for the general description of the related system call. Available since 5.6.
 
+This command also supports the following modifiers in
+.I ioprio:
+
+.PP
+.in +12
+.B IORING_RECVSEND_POLL_FIRST
+If set, io_uring will assume the socket is currently full and attempting to
+send data will be unsuccessful. For this case, io_uring will arm internal
+poll and trigger a send of the data when there is enough space available.
+This initial send attempt can be wasteful for the case where the socket
+is expected to be full, setting this flag will bypass the initial send
+attempt and go straight to arming poll. If poll does indicate that data can
+be sent, the operation will proceed.
+.EE
+.in
+.PP
+
 .TP
 .B IORING_OP_RECV
 Works just like IORING_OP_SEND, except for
 .BR recv(2)
 instead. See the description of IORING_OP_SEND. Available since 5.6.
+
+This command also supports the following modifiers in
+.I ioprio:
+
+.PP
+.in +12
+.B IORING_RECVSEND_POLL_FIRST
+If set, io_uring will assume the socket is currently empty and attempting to
+receive data will be unsuccessful. For this case, io_uring will arm internal
+poll and trigger a receive of the data when the socket has data to be read.
+This initial receive attempt can be wasteful for the case where the socket
+is expected to be empty, setting this flag will bypass the initial receive
+attempt and go straight to arming poll. If poll does indicate that data is
+ready to be received, the operation will proceed.
+.EE
+.in
+.PP
 
 .TP
 .B IORING_OP_TIMEOUT
@@ -460,7 +532,7 @@ suspend while having a timeout request in-flight.
 
 .B IORING_TIMEOUT_REALTIME
 If set, then the clocksource used is
-.I CLOCK_BOOTTIME
+.I CLOCK_REALTIME
 instead of
 .I CLOCK_MONOTONIC.
 .EE
@@ -785,7 +857,7 @@ contains the read or write offset. If
 .I fd
 does not refer to a seekable file,
 .I off
-must be set to zero. If
+must be set to zero or -1. If
 .I offs
 is set to
 .B -1
@@ -1052,8 +1124,123 @@ set, and a
 field matching the
 .I off
 value being passed in. This request type can be used to either just wake or
-interrupt anyone waiting for completions on the target ring, ot it can be used
+interrupt anyone waiting for completions on the target ring, or it can be used
 to pass messages via the two fields. Available since 5.18.
+
+.TP
+.B IORING_OP_SOCKET
+Issue the equivalent of a
+.BR socket(2)
+system call.
+.I fd
+must contain the communication domain,
+.I off
+must contain the communication type,
+.I len
+must contain the protocol, and
+.I rw_flags
+is currently unused and must be set to zero. See also
+.BR socket(2)
+for the general description of the related system call. Available since 5.19.
+
+If the
+.I file_index
+field is set to a positive number, the file won't be installed into the
+normal file table as usual but will be placed into the fixed file table at index
+.I file_index - 1.
+In this case, instead of returning a file descriptor, the result will contain
+either 0 on success or an error. If the index points to a valid empty slot, the
+installation is guaranteed to not fail. If there is already a file in the slot,
+it will be replaced, similar to
+.B IORING_OP_FILES_UPDATE.
+Please note that only io_uring has access to such files and no other syscall
+can use them. See
+.B IOSQE_FIXED_FILE
+and
+.B IORING_REGISTER_FILES.
+
+Available since 5.19.
+
+.TP
+.B IORING_OP_SEND_ZC
+Issue the zerocopy equivalent of a
+.BR send(2)
+system call. Similar to IORING_OP_SEND, but tries to avoid making intermediate
+copies of data. Zerocopy execution is not guaranteed and may fall back to
+copying. The request may also fail with
+.B -EOPNOTSUPP ,
+when a protocol doesn't support zerocopy, in which case users are recommended
+to use copying sends instead.
+
+The
+.I flags
+field of the first
+.I "struct io_uring_cqe"
+may likely contain
+.B IORING_CQE_F_MORE ,
+which means that there will be a second completion event / notification for
+the request, with the
+.I user_data
+field set to the same value. The user must not modify the data buffer until the
+notification is posted. The first cqe follows the usual rules and so its
+.I res
+field will contain the number of bytes sent or a negative error code. The
+notification's
+.I res
+field will be set to zero and the
+.I flags
+field will contain
+.B IORING_CQE_F_NOTIF .
+The two step model is needed because the kernel may hold on to buffers for a
+long time, e.g. waiting for a TCP ACK, and having a separate cqe for request
+completions allows userspace to push more data without extra delays. Note,
+notifications are only responsible for controlling the lifetime of the buffers,
+and as such don't mean anything about whether the data has atually been sent
+out or received by the other end. Even errored requests may generate a
+notification, and the user must check for
+.B IORING_CQE_F_MORE
+rather than relying on the result.
+
+.I fd
+must be set to the socket file descriptor,
+.I addr
+must contain a pointer to the buffer,
+.I len
+denotes the length of the buffer to send, and
+.I msg_flags
+holds the flags associated with the system call. When
+.I addr2
+is non-zero it points to the address of the target with
+.I addr_len
+specifying its size, turning the request into a
+.BR sendto(2)
+system call equivalent.
+
+Available since 6.0.
+
+This command also supports the following modifiers in
+.I ioprio:
+
+.PP
+.in +12
+.B IORING_RECVSEND_POLL_FIRST
+If set, io_uring will assume the socket is currently full and attempting to
+send data will be unsuccessful. For this case, io_uring will arm internal
+poll and trigger a send of the data when there is enough space available.
+This initial send attempt can be wasteful for the case where the socket
+is expected to be full, setting this flag will bypass the initial send
+attempt and go straight to arming poll. If poll does indicate that data can
+be sent, the operation will proceed.
+
+.B IORING_RECVSEND_FIXED_BUF
+If set, instructs io_uring to use a pre-mapped buffer. The
+.I buf_index
+field should contain an index into an array of fixed buffers. See
+.BR io_uring_register (2)
+for details on how to setup a context for fixed buffer I/O.
+.EE
+.in
+.PP
 
 .PP
 The
@@ -1143,7 +1330,7 @@ linked timeout has the flag set, it's guaranteed to not post a CQE.
 
 The semantics are chosen to accommodate several use cases. First, when all but
 the last request of a normal link without linked timeouts are marked with the
-flag, only one CQE per lin is posted. Additionally, it enables supression of
+flag, only one CQE per lin is posted. Additionally, it enables suppression of
 CQEs in cases where the side effects of a successfully executed operation is
 enough for userspace to know the state of the system. One such example would
 be writing to a synchronisation file.
@@ -1282,7 +1469,7 @@ in the matching man page for that type, or in the opcodes section above for
 io_uring-specific opcodes.
 .PP
 .SH RETURN VALUE
-.BR io_uring_enter ()
+.BR io_uring_enter (2)
 returns the number of I/Os successfully consumed.  This can be zero
 if
 .I to_submit
@@ -1299,15 +1486,14 @@ completion queue entry (see section
 rather than through the system call itself.
 
 Errors that occur not on behalf of a submission queue entry are returned via the
-system call directly. On such an error,
-.B -1
-is returned and
+system call directly. On such an error, a negative error code is returned. The
+caller should not rely on
 .I errno
-is set appropriately.
+variable.
 .PP
 .SH ERRORS
 These are the errors returned by
-.BR io_uring_enter ()
+.BR io_uring_enter (2)
 system call.
 .TP
 .B EAGAIN
@@ -1326,8 +1512,30 @@ is a valid file descriptor, but the io_uring ring is not in the right state
 .BR io_uring_register (2)
 for details on how to enable the ring.
 .TP
+.B EBADR
+At least one CQE was dropped even with the
+.B IORING_FEAT_NODROP
+feature, and there are no otherwise available CQEs. This clears the error state
+and so with no other changes the next call to
+.BR io_uring_setup (2)
+will not have this error. This error should be extremely rare and indicates the
+machine is running critically low on memory and. It may be reasonable for the
+application to terminate running unless it is able to safely handle any CQE
+being lost.
+.TP
 .B EBUSY
-The application is attempting to overcommit the number of requests it can have
+If the
+.B IORING_FEAT_NODROP
+feature flag is set, then
+.B EBUSY
+will be returned if there were overflow entries,
+.B IORING_ENTER_GETEVENTS
+flag is set and not all of the overflow entries were able to be flushed to
+the CQ ring.
+
+Without
+.B IORING_FEAT_NODROP
+the application is attempting to overcommit the number of requests it can have
 pending. The application should wait for some completions and try again. May
 occur if the application tries to queue more requests than we have room for in
 the CQ ring, or if the application attempts to wait for more events without

--- a/vendor/liburing/man/io_uring_enter2.2
+++ b/vendor/liburing/man/io_uring_enter2.2
@@ -1,0 +1,1 @@
+io_uring_enter.2

--- a/vendor/liburing/man/io_uring_free_probe.3
+++ b/vendor/liburing/man/io_uring_free_probe.3
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_free_probe "January 25, 2022" "liburing-2.1" "liburing Manual"
+.TH io_uring_free_probe 3 "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
 io_uring_free_probe \- free probe instance
 .SH SYNOPSIS

--- a/vendor/liburing/man/io_uring_get_events.3
+++ b/vendor/liburing/man/io_uring_get_events.3
@@ -1,0 +1,33 @@
+.\" Copyright (C) 2022 Dylan Yudaken
+.\"
+.\" SPDX-License-Identifier: LGPL-2.0-or-later
+.\"
+.TH io_uring_get_events 3 "September 5, 2022" "liburing-2.3" "liburing Manual"
+.SH NAME
+io_uring_get_events \- Flush outstanding requests to CQE ring
+.SH SYNOPSIS
+.nf
+.B #include <liburing.h>
+.PP
+.BI "int io_uring_get_events(struct io_uring *" ring ");"
+.fi
+.SH DESCRIPTION
+.PP
+The
+.BR io_uring_get_events (3)
+function runs outstanding work and flushes completion events to the CQE ring.
+
+There can be events needing to be flushed if the ring was full and had overflowed.
+Alternatively if the ring was setup with the
+.BR IORING_SETUP_DEFER_TASKRUN
+flag then this will process outstanding tasks, possibly resulting in more CQEs.
+
+.SH RETURN VALUE
+On success
+.BR io_uring_get_events (3)
+returns 0. On failure it returns
+.BR -errno .
+.SH SEE ALSO
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit_and_get_events (3),
+.BR io_uring_cq_has_overflow (3)

--- a/vendor/liburing/man/io_uring_get_probe.3
+++ b/vendor/liburing/man/io_uring_get_probe.3
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_get_probe "January 25, 2022" "liburing-2.1" "liburing Manual"
+.TH io_uring_get_probe 3 "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
 io_uring_get_probe \- get probe instance
 .SH SYNOPSIS

--- a/vendor/liburing/man/io_uring_get_sqe.3
+++ b/vendor/liburing/man/io_uring_get_sqe.3
@@ -32,10 +32,26 @@ prep functions such as
 and submitted via
 .BR io_uring_submit (3).
 
+Note that neither
+.BR io_uring_get_sqe
+nor the prep functions set (or clear) the
+.B user_data
+field of the SQE. If the caller expects
+.BR io_uring_cqe_get_data (3)
+or
+.BR io_uring_cqe_get_data64 (3)
+to return valid data when reaping IO completions, either
+.BR io_uring_sqe_set_data (3)
+or
+.BR io_uring_sqe_set_data64 (3)
+.B MUST
+have been called before submitting the request.
+
 .SH RETURN VALUE
 .BR io_uring_get_sqe (3)
 returns a pointer to the next submission queue event on success and NULL on
 failure. If NULL is returned, the SQ ring is currently full and entries must
 be submitted for processing before new ones can get allocated.
 .SH SEE ALSO
-.BR io_uring_submit (3)
+.BR io_uring_submit (3),
+.BR io_uring_sqe_set_data (3)

--- a/vendor/liburing/man/io_uring_opcode_supported.3
+++ b/vendor/liburing/man/io_uring_opcode_supported.3
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_opcode_supported "January 25, 2022" "liburing-2.1" "liburing Manual"
+.TH io_uring_opcode_supported 3 "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
 io_uring_opcode_supported \- is op code supported?
 .SH SYNOPSIS

--- a/vendor/liburing/man/io_uring_prep_accept.3
+++ b/vendor/liburing/man/io_uring_prep_accept.3
@@ -39,7 +39,9 @@ io_uring_prep_accept \- prepare an accept request
 .PP
 The
 .BR io_uring_prep_accept (3)
-function prepares an accept request. The submission queue entry
+function and its three variants prepare an accept request similar to
+.BR accept4 (2).
+The submission queue entry
 .I sqe
 is setup to use the file descriptor
 .I sockfd
@@ -50,51 +52,65 @@ and of structure length
 and using modifier flags in
 .IR flags .
 
-For a direct descriptor accept request, the offset is specified by the
-.I file_index
-argument. Direct descriptors are io_uring private file descriptors. They
+The three variants allow combining the direct file table and multishot features.
+
+Direct descriptors are io_uring private file descriptors. They
 avoid some of the overhead associated with thread shared file tables and
-can be used in any io_uring request that takes a file descriptor. To do so,
+can be used in any io_uring request that takes a file descriptor.
+The two direct variants here create such direct descriptors.
+Subsequent to their creation, they can be used by setting
 .B IOSQE_FIXED_FILE
-must be set in the SQE
+in the SQE
 .I flags
-member, and the SQE
+member, and setting the SQE
 .I fd
-field should use the direct descriptor value rather than the regular file
+field to the direct descriptor value rather than the regular file
 descriptor. Direct descriptors are managed like registered files.
 
-If the direct variant is used, the application must first have registered
-a file table using
+To use an accept direct variant, the application must first have registered
+a file table of a desired size using
 .BR io_uring_register_files (3)
-of the appropriate size. Once registered, a direct accept request may use any
-entry in that table, as long as it is within the size of the registered table.
-If a specified entry already contains a file, the file will first be removed
-from the table and closed. It's consistent with the behavior of updating an
+or
+.BR io_uring_register_files_sparse (3).
+Once registered,
+.BR io_uring_prep_accept_direct (3)
+allows an entry in that table to be specifically selected through the
+.I file_index
+argument.
+If the specified entry already contains a file, the file will first be removed
+from the table and closed, consistent with the behavior of updating an
 existing file with
 .BR io_uring_register_files_update (3).
+.I file_index
+can also be set to
+.B IORING_FILE_INDEX_ALLOC
+for this variant and
+an unused table index will be dynamically chosen and returned.
+Likewise,
+.B io_uring_prep_multishot_accept_direct
+will have an unused table index dynamically chosen and returned for each connection accepted.
+If both forms of direct selection will be employed, specific and dynamic, see
+.BR io_uring_register_file_alloc_range (3)
+for setting up the table so dynamically chosen entries are made against
+a different range than that targetted by specific requests.
+
 Note that old kernels don't check the SQE
 .I file_index
-field, which is not a problem for liburing helpers, but users of the raw
-io_uring interface need to zero SQEs to avoid unexpected behavior. This also
-means that applications should check for availability of
-.B IORING_OP_ACCEPT_DIRECT
-before using it, they cannot rely on a
+field meaning
+applications cannot rely on a
 .B -EINVAL
 CQE
 .I res
-return.
+being returned when the kernel is too old because older kernels
+may not recognize they are being asked to use a direct table slot.
 
-For a direct descriptor accept request, the
-.I file_index
-argument can be set to
-.BR IORING_FILE_INDEX_ALLOC ,
-In this case a free entry in io_uring file table will
-be used automatically and the file index will be returned as CQE
-.IR res .
+When a direct descriptor accept request asks for a table slot to be
+dynamically chosen but there are no free entries,
 .B -ENFILE
-is otherwise returned if there is no free entries in the io_uring file table.
+is returned as the CQE
+.IR res .
 
-The multishot version accept and accept_direct allow an application to issue
+The multishot variants allow an application to issue
 a single accept request, which will repeatedly trigger a CQE when a connection
 request comes in. Like other multishot type requests, the application should
 look at the CQE
@@ -102,42 +118,61 @@ look at the CQE
 and see if
 .B IORING_CQE_F_MORE
 is set on completion as an indication of whether or not the accept request
-will generate further CQEs. The multishot variants are available since 5.19.
+will generate further CQEs. Note that for the multishot variants, setting
+.B addr
+and
+.B addrlen
+may not make a lot of sense, as the same value would be used for every
+accepted connection. This means that the data written to
+.B addr
+may be overwritten by a new connection before the application has had time
+to process a past connection. If the application knows that a new connection
+cannot come in before a previous one has been processed, it may be used as
+expected. The multishot variants are available since 5.19.
 
-For multishot with direct descriptors,
-.B IORING_FILE_INDEX_ALLOC
-must be used as the file descriptor. This tells io_uring to allocate a free
-direct descriptor from our table, rather than the application passing one in.
-Failure to do so will result in the accept request being terminated with
-.BR -EINVAL .
-The allocated descriptor will be returned in the CQE
-.I res
-field, like a non-direct accept request.
-
-These functions prepare an async
+See the man page
 .BR accept4 (2)
-request. See that man page for details.
+for details of the accept function itself.
 
 .SH RETURN VALUE
 None
 .SH ERRORS
 The CQE
 .I res
-field will contain the result of the operation. For singleshot accept, the
-non-direct accept returns the installed file descriptor as its value, the
-direct accept returns
+field will contain the result of the operation.
+
+.BR io_uring_prep_accept (3)
+generates the installed file descriptor as its result.
+
+.BR io_uring_prep_accept_direct (3)
+and
+.I file_index
+set to a specific direct descriptor
+generates
 .B 0
-on success. The caller must know which direct descriptor was picked for this
-request. For multishot accept, the non-direct accept returns the installed
-file descriptor as its value, the direct accept returns the file index used on
-success. See the related man page for details on possible values for the
-non-direct accept. Note that where synchronous system calls will return
+on success.
+The caller must remember which direct descriptor was picked for this request.
+
+.BR io_uring_prep_accept_direct (3)
+and
+.I file_index
+set to
+.B IORING_FILE_INDEX_ALLOC
+generates the dynamically chosen direct descriptor.
+
+.BR io_uring_prep_multishot_accept (3)
+generates the installed file descriptor in each result.
+
+.BR io_uring_prep_multishot_accept_direct (3),
+generates the dynamically chosen direct descriptor in each result.
+
+Note that where synchronous system calls will return
 .B -1
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
 .IR errno .
-Instead it returns the negated
+Instead it generates the negated
 .I errno
 directly in the CQE
 .I res
@@ -155,5 +190,8 @@ flag passed back from
 .SH SEE ALSO
 .BR io_uring_get_sqe (3),
 .BR io_uring_submit (3),
+.BR io_uring_register_files (3),
+.BR io_uring_register_files_sparse (3),
+.BR io_uring_register_file_alloc_range (3),
 .BR io_uring_register (2),
 .BR accept4 (2)

--- a/vendor/liburing/man/io_uring_prep_nop.3
+++ b/vendor/liburing/man/io_uring_prep_nop.3
@@ -1,0 +1,28 @@
+.\" Copyright (C) 2022 Samuel Williams
+.\"
+.\" SPDX-License-Identifier: LGPL-2.0-or-later
+.\"
+.TH io_uring_prep_nop 3 "October 20, 2022" "liburing-2.2" "liburing Manual"
+.SH NAME
+io_uring_prep_nop \- prepare a nop request
+.SH SYNOPSIS
+.nf
+.B #include <liburing.h>
+.PP
+.BI "void io_uring_prep_nop(struct io_uring_sqe *" sqe ");"
+.fi
+.SH DESCRIPTION
+.PP
+The
+.BR io_uring_prep_nop (3)
+function prepares nop (no operation) request. The submission queue entry
+.I sqe
+does not require any additional setup.
+
+.SH RETURN VALUE
+None
+.SH ERRORS
+None
+.SH SEE ALSO
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),

--- a/vendor/liburing/man/io_uring_prep_read.3
+++ b/vendor/liburing/man/io_uring_prep_read.3
@@ -40,7 +40,7 @@ current file offset may result in unpredictable behavior, unless access
 to the file is serialized. It is not encouraged to use this feature, if it's
 possible to provide the desired IO offset from the application or library.
 
-On files that are not capable of seeking, the offset is ignored.
+On files that are not capable of seeking, the offset must be 0 or -1.
 
 After the read has been prepared it can be submitted with one of the submit
 functions.

--- a/vendor/liburing/man/io_uring_prep_read_fixed.3
+++ b/vendor/liburing/man/io_uring_prep_read_fixed.3
@@ -42,7 +42,7 @@ The
 .I buf
 and
 .I nbytes
-arguments must fall within a region specificed by
+arguments must fall within a region specified by
 .I buf_index
 in the previously registered buffer. The buffer need not be aligned with
 the start of the registered buffer.

--- a/vendor/liburing/man/io_uring_prep_readv.3
+++ b/vendor/liburing/man/io_uring_prep_readv.3
@@ -41,7 +41,7 @@ current file offset may result in unpredictable behavior, unless access
 to the file is serialized. It is not encouraged to use this feature, if it's
 possible to provide the desired IO offset from the application or library.
 
-On files that are not capable of seeking, the offset is ignored.
+On files that are not capable of seeking, the offset must be 0 or -1.
 
 After the write has been prepared it can be submitted with one of the submit
 functions.

--- a/vendor/liburing/man/io_uring_prep_readv2.3
+++ b/vendor/liburing/man/io_uring_prep_readv2.3
@@ -67,7 +67,7 @@ current file offset may result in unpredictable behavior, unless access
 to the file is serialized. It is not encouraged to use this feature, if it's
 possible to provide the desired IO offset from the application or library.
 
-On files that are not capable of seeking, the offset is ignored.
+On files that are not capable of seeking, the offset must be 0 or -1.
 
 After the write has been prepared, it can be submitted with one of the submit
 functions.

--- a/vendor/liburing/man/io_uring_prep_recv.3
+++ b/vendor/liburing/man/io_uring_prep_recv.3
@@ -14,6 +14,12 @@ io_uring_prep_recv \- prepare a recv request
 .BI "                        void *" buf ","
 .BI "                        size_t " len ","
 .BI "                        int " flags ");"
+.PP
+.BI "void io_uring_prep_recv_multishot(struct io_uring_sqe *" sqe ","
+.BI "                                  int " sockfd ","
+.BI "                                  void *" buf ","
+.BI "                                  size_t " len ","
+.BI "                                  int " flags ");"
 .fi
 .SH DESCRIPTION
 .PP
@@ -36,9 +42,25 @@ This function prepares an async
 request. See that man page for details on the arguments specified to this
 prep helper.
 
+The multishot version allows the application to issue a single receive request,
+which repeatedly posts a CQE when data is available. It requires length to be 0
+, the
+.B IOSQE_BUFFER_SELECT
+flag to be set and no
+.B MSG_WAITALL
+flag to be set.
+Therefore each CQE will take a buffer out of a provided buffer pool for receiving.
+The application should check the flags of each CQE, regardless of it's result.
+If a posted CQE does not have the
+.B IORING_CQE_F_MORE
+flag set then the multishot receive will be done and the application should issue a
+new request.
+Multishot variants are available since kernel 6.0.
+
+
 After calling this function, additional io_uring internal modifier flags
 may be set in the SQE
-.I off
+.I ioprio
 field. The following flags are supported:
 .TP
 .B IORING_RECVSEND_POLL_FIRST

--- a/vendor/liburing/man/io_uring_prep_recv_multishot.3
+++ b/vendor/liburing/man/io_uring_prep_recv_multishot.3
@@ -1,0 +1,1 @@
+io_uring_prep_recv.3

--- a/vendor/liburing/man/io_uring_prep_recvmsg.3
+++ b/vendor/liburing/man/io_uring_prep_recvmsg.3
@@ -15,6 +15,11 @@ io_uring_prep_recvmsg \- prepare a recvmsg request
 .BI "                           int " fd ","
 .BI "                           struct msghdr *" msg ","
 .BI "                           unsigned " flags ");"
+.PP
+.BI "void io_uring_prep_recvmsg_multishot(struct io_uring_sqe *" sqe ","
+.BI "                                     int " fd ","
+.BI "                                     struct msghdr *" msg ","
+.BI "                                     unsigned " flags ");"
 .fi
 .SH DESCRIPTION
 .PP
@@ -37,9 +42,34 @@ This function prepares an async
 request. See that man page for details on the arguments specified to this
 prep helper.
 
+The multishot version allows the application to issue a single receive request,
+which repeatedly posts a CQE when data is available. It requires the
+.B IOSQE_BUFFER_SELECT
+flag to be set and no
+.B MSG_WAITALL
+flag to be set.
+Therefore each CQE will take a buffer out of a provided buffer pool for receiving.
+The application should check the flags of each CQE, regardless of it's result.
+If a posted CQE does not have the
+.B IORING_CQE_F_MORE
+flag set then the multishot receive will be done and the application should issue a
+new request.
+
+Unlike
+.BR recvmsg (2)
+, multishot recvmsg will prepend a
+.I struct io_uring_recvmsg_out
+which describes the layout of the rest of the buffer in combination with the initial
+.I struct msghdr
+submitted with the request. See
+.B io_uring_recvmsg_out (3)
+for more information on accessing the data.
+
+Multishot variants are available since kernel 6.0.
+
 After calling this function, additional io_uring internal modifier flags
 may be set in the SQE
-.I off
+.I ioprio
 field. The following flags are supported:
 .TP
 .B IORING_RECVSEND_POLL_FIRST

--- a/vendor/liburing/man/io_uring_prep_recvmsg_multishot.3
+++ b/vendor/liburing/man/io_uring_prep_recvmsg_multishot.3
@@ -1,0 +1,1 @@
+io_uring_prep_recvmsg.3

--- a/vendor/liburing/man/io_uring_prep_renameat.3
+++ b/vendor/liburing/man/io_uring_prep_renameat.3
@@ -16,12 +16,12 @@ io_uring_prep_renameat \- prepare a renameat request
 .BI "                            const char *" oldpath ","
 .BI "                            int " newdirfd ","
 .BI "                            const char *" newpath ","
-.BI "                            int " flags ");"
+.BI "                            unsigned int " flags ");"
 .PP
 .BI "void io_uring_prep_rename(struct io_uring_sqe *" sqe ","
 .BI "                          const char *" oldpath ","
 .BI "                          const char *" newpath ","
-.BI "                          int " flags ");"
+.BI "                          unsigned int " flags ");"
 .fi
 .SH DESCRIPTION
 .PP

--- a/vendor/liburing/man/io_uring_prep_send.3
+++ b/vendor/liburing/man/io_uring_prep_send.3
@@ -26,8 +26,8 @@ is setup to use the file descriptor
 to start sending the data from
 .I buf
 of size
-.I size
-and with modifier flags
+.I len
+bytes and with modifier flags
 .IR flags .
 
 This function prepares an async

--- a/vendor/liburing/man/io_uring_prep_send_zc.3
+++ b/vendor/liburing/man/io_uring_prep_send_zc.3
@@ -1,0 +1,64 @@
+.\" Copyright (C) 2022 Jens Axboe <axboe@kernel.dk>
+.\"
+.\" SPDX-License-Identifier: LGPL-2.0-or-later
+.\"
+.TH io_uring_prep_send_zc 3 "September 6, 2022" "liburing-2.3" "liburing Manual"
+.SH NAME
+io_uring_prep_send_zc \- prepare a zerocopy send request
+.SH SYNOPSIS
+.nf
+.B #include <liburing.h>
+.PP
+.BI "void io_uring_prep_send_zc(struct io_uring_sqe *" sqe ","
+.BI "                        int " sockfd ","
+.BI "                        const void *" buf ","
+.BI "                        size_t " len ","
+.BI "                        int " flags ","
+.BI "                        int " zc_flags ");"
+.fi
+.SH DESCRIPTION
+.PP
+The
+.BR io_uring_prep_send_zc (3)
+function prepares a zerocopy send request. The submission queue entry
+.I sqe
+is setup to use the file descriptor
+.I sockfd
+to start sending the data from
+.I buf
+of size
+.I len
+bytes with send modifier flags
+.IR flags
+and zerocopy modifier flags
+.IR zc_flags .
+
+This function prepares an async zerocopy
+.BR send (2)
+request. See that man page for details. For details on the zerocopy nature
+of it, see
+.BR io_uring_enter (2) .
+
+.SH RETURN VALUE
+None
+.SH ERRORS
+The CQE
+.I res
+field will contain the result of the operation. See the related man page for
+details on possible values. Note that where synchronous system calls will return
+.B -1
+on failure and set
+.I errno
+to the actual error value, io_uring never uses
+.IR errno .
+Instead it returns the negated
+.I errno
+directly in the CQE
+.I res
+field.
+.SH SEE ALSO
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR io_uring_prep_send (3),
+.BR io_uring_enter (2),
+.BR send (2)

--- a/vendor/liburing/man/io_uring_prep_socket.3
+++ b/vendor/liburing/man/io_uring_prep_socket.3
@@ -22,6 +22,12 @@ io_uring_prep_socket \- prepare a socket creation request
 .BI "                                 int " protocol ","
 .BI "                                 unsigned int " file_index ","
 .BI "                                 unsigned int " flags ");"
+.PP
+.BI "void io_uring_prep_socket_direct_alloc(struct io_uring_sqe *" sqe ","
+.BI "                                 int " domain ","
+.BI "                                 int " type ","
+.BI "                                 int " protocol ","
+.BI "                                 unsigned int " flags ");"
 .fi
 .SH DESCRIPTION
 .PP
@@ -41,16 +47,31 @@ argument are currently unused.
 
 The
 .BR io_uring_prep_socket_direct (3)
-works just like
+helper works just like
 .BR io_uring_prep_socket (3),
 except it maps the socket to a direct descriptor rather than return a normal
 file descriptor. The
 .I file_index
-argument should be set to the slot that should be used for this socket, or
-.B IORING_FILE_INDEX_ALLOC
-if io_uring should allocate a free one.
+argument should be set to the slot that should be used for this socket.
 
-If the direct variant is used, the application must first have registered
+The
+.BR io_uring_prep_socket_direct_alloc (3)
+helper works just like
+.BR io_uring_prep_socket_alloc (3),
+except it allocates a new direct descriptor rather than pass a free slot in. It
+is equivalent to using
+.BR io_uring_prep_socket_direct (3)
+with
+.B IORING_FILE_INDEX_ALLOC
+as the
+.I
+file_index .
+Upon completion, the
+.I res
+field of the CQE will return the direct slot that was allocated for the
+socket.
+
+If the direct variants are used, the application must first have registered
 a file table using
 .BR io_uring_register_files (3)
 of the appropriate size. Once registered, a direct socket request may use any

--- a/vendor/liburing/man/io_uring_prep_socket_direct_alloc.3
+++ b/vendor/liburing/man/io_uring_prep_socket_direct_alloc.3
@@ -1,0 +1,1 @@
+io_uring_prep_socket.3

--- a/vendor/liburing/man/io_uring_prep_write.3
+++ b/vendor/liburing/man/io_uring_prep_write.3
@@ -40,7 +40,7 @@ current file offset may result in unpredictable behavior, unless access
 to the file is serialized. It is not encouraged to use this feature if it's
 possible to provide the desired IO offset from the application or library.
 
-On files that are not capable of seeking, the offset is ignored.
+On files that are not capable of seeking, the offset must be 0 or -1.
 
 After the write has been prepared, it can be submitted with one of the submit
 functions.

--- a/vendor/liburing/man/io_uring_prep_write_fixed.3
+++ b/vendor/liburing/man/io_uring_prep_write_fixed.3
@@ -42,7 +42,7 @@ The
 .I buf
 and
 .I nbytes
-arguments must fall within a region specificed by
+arguments must fall within a region specified by
 .I buf_index
 in the previously registered buffer. The buffer need not be aligned with
 the start of the registered buffer.

--- a/vendor/liburing/man/io_uring_prep_writev.3
+++ b/vendor/liburing/man/io_uring_prep_writev.3
@@ -41,7 +41,7 @@ current file offset may result in unpredictable behavior, unless access
 to the file is serialized. It is not encouraged to use this feature if it's
 possible to provide the desired IO offset from the application or library.
 
-On files that are not capable of seeking, the offset is ignored.
+On files that are not capable of seeking, the offset must be 0 or -1.
 
 After the write has been prepared it can be submitted with one of the submit
 functions.

--- a/vendor/liburing/man/io_uring_prep_writev2.3
+++ b/vendor/liburing/man/io_uring_prep_writev2.3
@@ -67,7 +67,7 @@ current file offset may result in unpredictable behavior, unless access
 to the file is serialized. It is not encouraged to use this feature if it's
 possible to provide the desired IO offset from the application or library.
 
-On files that are not capable of seeking, the offset is ignored.
+On files that are not capable of seeking, the offset must be 0 or -1.
 
 After the write has been prepared, it can be submitted with one of the submit
 functions.

--- a/vendor/liburing/man/io_uring_recvmsg_cmsg_firsthdr.3
+++ b/vendor/liburing/man/io_uring_recvmsg_cmsg_firsthdr.3
@@ -1,0 +1,1 @@
+io_uring_recvmsg_out.3

--- a/vendor/liburing/man/io_uring_recvmsg_cmsg_nexthdr.3
+++ b/vendor/liburing/man/io_uring_recvmsg_cmsg_nexthdr.3
@@ -1,0 +1,1 @@
+io_uring_recvmsg_out.3

--- a/vendor/liburing/man/io_uring_recvmsg_name.3
+++ b/vendor/liburing/man/io_uring_recvmsg_name.3
@@ -1,0 +1,1 @@
+io_uring_recvmsg_out.3

--- a/vendor/liburing/man/io_uring_recvmsg_out.3
+++ b/vendor/liburing/man/io_uring_recvmsg_out.3
@@ -1,0 +1,78 @@
+.\" Copyright (C), 2022  Dylan Yudaken <dylany@fb.com>
+.\"
+.\" SPDX-License-Identifier: LGPL-2.0-or-later
+.\"
+.TH io_uring_recvmsg_out 3 "Julyu 26, 2022" "liburing-2.2" "liburing Manual"
+.SH NAME
+io_uring_recvmsg_out - access data from multishot recvmsg
+.SH SYNOPSIS
+.nf
+.B #include <liburing.h>
+.PP
+.BI "struct io_uring_recvmsg_out *io_uring_recvmsg_validate(void *" buf ","
+.BI "                                                       int " buf_len ","
+.BI "                                                       struct msghdr *" msgh ");"
+.PP
+.BI "void *io_uring_recvmsg_name(struct io_uring_recvmsg_out *" o ");"
+.PP
+.BI "struct cmsghdr *io_uring_recvmsg_cmsg_firsthdr(struct io_uring_recvmsg_out * " o ","
+.BI "                                                struct msghdr *" msgh ");"
+.BI "struct cmsghdr *io_uring_recvmsg_cmsg_nexthdr(struct io_uring_recvmsg_out * " o ","
+.BI "                                              struct msghdr *" msgh ","
+.BI "                                              struct cmsghdr *" cmsg ");"
+.PP
+.BI "void *io_uring_recvmsg_payload(struct io_uring_recvmsg_out * " o ","
+.BI "                               struct msghdr *" msgh ");"
+.BI "unsigned int io_uring_recvmsg_payload_length(struct io_uring_recvmsg_out *" o ","
+.BI "                                             int " buf_len ","
+.BI "                                             struct msghdr *" msgh ");"
+.PP
+.fi
+
+.SH DESCRIPTION
+
+These functions are used to access data in the payload delivered by
+.BR io_uring_prep_recv_multishot (3)
+.
+.PP
+.BR io_uring_recvmsg_validate (3)
+will validate a buffer delivered by
+.BR io_uring_prep_recv_multishot (3)
+and extract the
+.I io_uring_recvmsg_out
+if it is valid, returning a pointer to it or else NULL.
+.PP
+The structure is defined as follows:
+.PP
+.in +4n
+.EX
+
+struct io_uring_recvmsg_out {
+        __u32 namelen;    /* Name byte count as would have been populated
+                           * by recvmsg(2) */
+        __u32 controllen; /* Control byte count */
+        __u32 payloadlen; /* Payload byte count as would have been returned
+                           * by recvmsg(2) */
+        __u32 flags;      /* Flags result as would have been populated
+                           * by recvmsg(2) */
+};
+
+.IP * 3
+.BR io_uring_recvmsg_name (3)
+returns a pointer to the name in the buffer.
+.IP *
+.BR io_uring_recvmsg_cmsg_firsthdr (3)
+returns a pointer to the first cmsg in the buffer, or NULL.
+.IP *
+.BR io_uring_recvmsg_cmsg_nexthdr (3)
+returns a pointer to the next cmsg in the buffer, or NULL.
+.IP *
+.BR io_uring_recvmsg_payload (3)
+returns a pointer to the payload in the buffer.
+.IP *
+.BR io_uring_recvmsg_payload_length (3)
+Calculates the usable payload length in bytes.
+
+
+.SH "SEE ALSO"
+.BR io_uring_prep_recv_multishot (3)

--- a/vendor/liburing/man/io_uring_recvmsg_payload.3
+++ b/vendor/liburing/man/io_uring_recvmsg_payload.3
@@ -1,0 +1,1 @@
+io_uring_recvmsg_out.3

--- a/vendor/liburing/man/io_uring_recvmsg_payload_length.3
+++ b/vendor/liburing/man/io_uring_recvmsg_payload_length.3
@@ -1,0 +1,1 @@
+io_uring_recvmsg_out.3

--- a/vendor/liburing/man/io_uring_recvmsg_validate.3
+++ b/vendor/liburing/man/io_uring_recvmsg_validate.3
@@ -1,0 +1,1 @@
+io_uring_recvmsg_out.3

--- a/vendor/liburing/man/io_uring_register.2
+++ b/vendor/liburing/man/io_uring_register.2
@@ -3,12 +3,12 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH IO_URING_REGISTER 2 2019-01-17 "Linux" "Linux Programmer's Manual"
+.TH io_uring_register 2 2019-01-17 "Linux" "Linux Programmer's Manual"
 .SH NAME
 io_uring_register \- register files or user buffers for asynchronous I/O 
 .SH SYNOPSIS
 .nf
-.BR "#include <linux/io_uring.h>"
+.BR "#include <liburing.h>"
 .PP
 .BI "int io_uring_register(unsigned int " fd ", unsigned int " opcode ,
 .BI "                      void *" arg ", unsigned int " nr_args );
@@ -18,7 +18,7 @@ io_uring_register \- register files or user buffers for asynchronous I/O
 .PP
 
 The
-.BR io_uring_register ()
+.BR io_uring_register (2)
 system call registers resources (e.g. user buffers, files, eventfd,
 personality, restrictions) for use in an
 .BR io_uring (7)
@@ -85,7 +85,7 @@ region.
 An application can increase or decrease the size or number of
 registered buffers by first unregistering the existing buffers, and
 then issuing a new call to
-.BR io_uring_register ()
+.BR io_uring_register (2)
 with the new buffers.
 
 Note that before 5.13 registering buffers would wait for the ring to idle.
@@ -428,7 +428,7 @@ array of
 entries.
 
 With an entry it is possible to allow an
-.BR io_uring_register ()
+.BR io_uring_register (2)
 .I opcode,
 or specify which
 .I opcode
@@ -440,7 +440,7 @@ or require certain
 to be specified (these flags must be set on each submission queue entry).
 
 All the restrictions must be submitted with a single
-.BR io_uring_register ()
+.BR io_uring_register (2)
 call and they are handled as an allowlist (opcodes and flags not registered,
 are not allowed).
 
@@ -546,7 +546,7 @@ for the system call. This flag tells the kernel that a registered descriptor
 is used rather than a real file descriptor.
 
 Each thread or process using a ring must register the file descriptor directly
-by issuing this request.o
+by issuing this request.
 
 The maximum number of supported registered ring descriptors is currently
 limited to
@@ -579,15 +579,151 @@ slot, making it available for future use.
 
 Available since 5.18.
 
+.TP
+.B IORING_REGISTER_PBUF_RING
+Registers a shared buffer ring to be used with provided buffers. This is a
+newer alternative to using
+.B IORING_OP_PROVIDE_BUFFERS
+which is more efficient, to be used with request types that support the
+.B IOSQE_BUFFER_SELECT
+flag.
+
+The
+.I arg
+argument must be filled in with the appropriate information. It looks as
+follows:
+.PP
+.in +12n
+.EX
+struct io_uring_buf_reg {
+    __u64 ring_addr;
+    __u32 ring_entries;
+    __u16 bgid;
+    __u16 pad;
+    __u64 resv[3];
+};
+.EE
+.in
+.PP
+.in +8n
+The
+.I ring_addr
+field must contain the address to the memory allocated to fit this ring.
+The memory must be page aligned and hence allocated appropriately using eg
+.BR posix_memalign (3)
+or similar. The size of the ring is the product of
+.I ring_entries
+and the size of
+.IR "struct io_uring_buf" .
+.I ring_entries
+is the desired size of the ring, and must be a power-of-2 in size. The maximum
+size allowed is 2^15 (32768).
+.I bgid
+is the buffer group ID associated with this ring. SQEs that select a buffer
+has a buffer group associated with them in their
+.I buf_group
+field, and the associated CQE will have
+.B IORING_CQE_F_BUFFER
+set in their
+.I flags
+member, which will also contain the specific ID of the buffer selected. The rest
+of the fields are reserved and must be cleared to zero.
+
+The
+.I flags
+argument is currently unused and must be set to zero.
+
+.i nr_args
+must be set to 1.
+
+Also see
+.BR io_uring_register_buf_ring (3)
+for more details. Available since 5.19.
+
+.TP
+.B IORING_UNREGISTER_PBUF_RING
+Unregister a previously registered provided buffer ring.
+.I arg
+must be set to the address of a struct io_uring_buf_reg, with just the
+.I bgid
+field set to the buffer group ID of the previously registered provided buffer
+group.
+.I nr_args
+must be set to 1. Also see
+.B IORING_REGISTER_PBUF_RING .
+
+Available since 5.19.
+
+.TP
+.B IORING_REGISTER_SYNC_CANCEL
+Performs a synchronous cancelation request, which works in a similar fashion to
+.B IORING_OP_ASYNC_CANCEL
+except it completes inline. This can be useful for scenarios where cancelations
+should happen synchronously, rather than needing to issue an SQE and wait for
+completion of that specific CQE.
+
+.I arg
+must be set to a pointer to a struct io_uring_sync_cancel_reg structure, with
+the details filled in for what request(s) to target for cancelation. See
+.BR io_uring_register_sync_cancel (3)
+for details on that. The return values are the same, except they are passed
+back synchronously rather than through the CQE
+.I res
+field.
+.I nr_args
+must be set to 1.
+
+Available since 6.0.
+
+.TP
+.B IORING_REGISTER_FILE_ALLOC_RANGE
+sets the allowable range for fixed file index allocations within the
+kernel. When requests that can instantiate a new fixed file are used with
+.B IORING_FILE_INDEX_ALLOC ,
+the application is asking the kernel to allocate a new fixed file descriptor
+rather than pass in a specific value for one. By default, the kernel will
+pick any available fixed file descriptor within the range available.
+This effectively allows the application to set aside a range just for dynamic
+allocations, with the remainder being used for specific values.
+
+.I nr_args
+must be set to 1 and
+.I arg
+must be set to a pointer to a struct io_uring_file_index_range:
+.PP
+.in +12n
+.EX
+struct io_uring_file_index_range {
+    __u32 off;
+    __u32 len;
+    __u64 resv;
+};
+.EE
+.in
+.PP
+.in +8n
+with
+.I off
+being set to the starting value for the range, and
+.I len
+being set to the number of descriptors. The reserved
+.I resv
+field must be cleared to zero.
+
+The application must have registered a file table first.
+
+Available since 6.0.
+
 .SH RETURN VALUE
 
 On success,
-.BR io_uring_register ()
-returns 0.  On error,
-.B -1
-is returned, and
+.BR io_uring_register (2)
+returns either 0 or a positive value, depending on the
+.I opcode
+used.  On error, a negative error value is returned. The caller should not rely
+on the
 .I errno
-is set accordingly.
+variable.
 
 .SH ERRORS
 .TP

--- a/vendor/liburing/man/io_uring_register_buf_ring.3
+++ b/vendor/liburing/man/io_uring_register_buf_ring.3
@@ -55,7 +55,8 @@ or similar. The size of the ring is the product of
 and the size of
 .IR "struct io_uring_buf" .
 .I ring_entries
-is the desired size of the ring, and must be a power-of-2 in size.
+is the desired size of the ring, and must be a power-of-2 in size. The maximum
+size allowed is 2^15 (32768).
 .I bgid
 is the buffer group ID associated with this ring. SQEs that select a buffer
 has a buffer group associated with them in their
@@ -64,7 +65,7 @@ field, and the associated CQE will have
 .B IORING_CQE_F_BUFFER
 set in their
 .I flags
-member, which will also contain the specific ID of the buffer seleted. The rest
+member, which will also contain the specific ID of the buffer selected. The rest
 of the fields are reserved and must be cleared to zero.
 
 The

--- a/vendor/liburing/man/io_uring_register_file_alloc_range.3
+++ b/vendor/liburing/man/io_uring_register_file_alloc_range.3
@@ -1,0 +1,52 @@
+.\" Copyright (C) 2022 Jens Axboe <axboe@kernel.dk>
+.\"
+.\" SPDX-License-Identifier: LGPL-2.0-or-later
+.\"
+.TH io_uring_register_file_alloc_range 3 "Oct 21, 2022" "liburing-2.3" "liburing Manual"
+.SH NAME
+io_uring_register_file_alloc_range \- set range for fixed file allocations
+.SH SYNOPSIS
+.nf
+.B #include <liburing.h>
+.PP
+.BI "int io_uring_register_file_alloc_range(struct io_uring *" ring ",
+.BI "                                       unsigned " off ","
+.BI "                                       unsigned " len ");"
+.BI "
+.fi
+.SH DESCRIPTION
+.PP
+The
+.BR io_uring_register_file_alloc_range (3)
+function sets the allowable range for fixed file index allocations within the
+kernel. When requests that can instantiate a new fixed file are used with
+.B IORING_FILE_INDEX_ALLOC ,
+the application is asking the kernel to allocate a new fixed file descriptor
+rather than pass in a specific value for one. By default, the kernel will
+pick any available fixed file descriptor within the range available. Calling
+this function with
+.I off
+set to the starting offset and
+.I len
+set to the number of descriptors, the application can limit the allocated
+descriptors to that particular range. This effectively allows the application
+to set aside a range just for dynamic allocations, with the remainder being
+used for specific values.
+
+The application must have registered a fixed file table upfront, eg through
+.BR io_uring_register_files (3)
+or
+.BR io_uring_register_files_sparse (3) .
+
+Available since 6.0.
+
+.SH RETURN VALUE
+On success
+.BR io_uring_register_buf_ring (3)
+returns 0. On failure it returns
+.BR -errno .
+.SH SEE ALSO
+.BR io_uring_register_files (3)
+.BR io_uring_prep_accept_direct (3)
+.BR io_uring_prep_openat_direct (3)
+.BR io_uring_prep_socket_direct (3)

--- a/vendor/liburing/man/io_uring_register_files.3
+++ b/vendor/liburing/man/io_uring_register_files.3
@@ -38,6 +38,13 @@ and later.
 Registering a file table is a prerequisite for using any request that uses
 direct descriptors.
 
+Registered files have less overhead per operation than normal files. This
+is due to the kernel grabbing a reference count on a file when an operation
+begins, and dropping it when it's done. When the process file table is
+shared, for example if the process has ever created any threads, then this
+cost goes up even more. Using registered files reduces the overhead of
+file reference management across requests that operate on a file.
+
 .SH RETURN VALUE
 On success
 .BR io_uring_register_files (3)

--- a/vendor/liburing/man/io_uring_register_files_sparse.3
+++ b/vendor/liburing/man/io_uring_register_files_sparse.3
@@ -1,0 +1,1 @@
+io_uring_register_files.3

--- a/vendor/liburing/man/io_uring_register_sync_cancel.3
+++ b/vendor/liburing/man/io_uring_register_sync_cancel.3
@@ -1,0 +1,71 @@
+.\" Copyright (C) 2022 Jens Axboe <axboe@kernel.dk>
+.\"
+.\" SPDX-License-Identifier: LGPL-2.0-or-later
+.\"
+.TH io_uring_register_sync_cancel 3 "September 21, 2022" "liburing-2.3" "liburing Manual"
+.SH NAME
+io_uring_register_sync_cancel \- issue a synchronous cancelation request
+.SH SYNOPSIS
+.nf
+.B #include <liburing.h>
+.PP
+.BI "int io_uring_register_sync_cancel(struct io_uring *" ring ",
+.BI "                                  struct io_uring_sync_cancel_reg *" reg ");
+.PP
+.SH DESCRIPTION
+.PP
+The
+.BR io_uring_register_sync_cancel (3)
+function performs a synchronous cancelation request based on the parameters
+specified in
+.I reg .
+
+The
+.I reg
+argument must be filled in with the appropriate information for the
+cancelation request. It looks as follows:
+.PP
+.in +4n
+.EX
+struct io_uring_sync_cancel_reg {
+    __u64 addr;
+    __s32 fd;
+    __u32 flags;
+    struct __kernel_timespec timeout;
+    __u64 pad[4];
+};
+.EE
+.in
+.PP
+
+The arguments largely mirror what the async prep functions support, see
+.BR io_uring_prep_cancel (3)
+for details. Similarly, the return value is the same. The exception is the
+.I timeout
+argument, which can be used to limit the time that the kernel will wait for
+cancelations to be successful. If the
+.I tv_sec
+and
+.I tv_nsec
+values are set to anything but
+.B -1UL ,
+then they indicate a relative timeout upon which cancelations should be
+completed by.
+
+The
+.I pad
+values must be zero filled.
+
+.SH RETURN VALUE
+See
+.BR io_uring_prep_cancel (3)
+for details on the return value. If
+.I timeout
+is set to indicate a timeout, then
+.B -ETIME
+will be returned if exceeded. If an unknown value is set in the request,
+or if the pad values are not cleared to zero, then
+.I -EINVAL
+is returned.
+.SH SEE ALSO
+.BR io_uring_prep_cancel (3)

--- a/vendor/liburing/man/io_uring_setup.2
+++ b/vendor/liburing/man/io_uring_setup.2
@@ -4,20 +4,22 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH IO_URING_SETUP 2 2019-01-29 "Linux" "Linux Programmer's Manual"
+.TH io_uring_setup 2 2019-01-29 "Linux" "Linux Programmer's Manual"
 .SH NAME
 io_uring_setup \- setup a context for performing asynchronous I/O
 .SH SYNOPSIS
 .nf
-.BR "#include <linux/io_uring.h>"
+.BR "#include <liburing.h>"
 .PP
 .BI "int io_uring_setup(u32 " entries ", struct io_uring_params *" p );
 .fi
-.PP
+.PPAA
 .SH DESCRIPTION
 .PP
-The io_uring_setup() system call sets up a submission queue (SQ) and
-completion queue (CQ) with at least
+The
+.BR io_uring_setup (2)
+system call sets up a submission queue (SQ) and completion queue (CQ) with at
+least
 .I entries
 entries, and returns a file descriptor which can be used to perform
 subsequent operations on the io_uring instance.  The submission and
@@ -234,11 +236,48 @@ only the
 passthrough command for NVMe passthrough needs this. Available since 5.19.
 .TP
 .B IORING_SETUP_CQE32
-If set, io_uring will use 32-byte CQEs rather than the normal 32-byte sized
+If set, io_uring will use 32-byte CQEs rather than the normal 16-byte sized
 variant. This is a requirement for using certain request types, as of 5.19
 only the
 .B IORING_OP_URING_CMD
 passthrough command for NVMe passthrough needs this. Available since 5.19.
+.TP
+.B IORING_SETUP_SINGLE_ISSUER
+A hint to the kernel that only a single task (or thread) will submit requests, which is
+used for internal optimisations. The submission task is either the task that created the
+ring, or if
+.B IORING_SETUP_R_DISABLED
+is specified then it is the task that enables the ring through
+.BR io_uring_register (2) .
+The kernel enforces this rule, failing requests with
+.B -EEXIST
+if the restriction is violated.
+Note that when
+.B IORING_SETUP_SQPOLL
+is set it is considered that the polling task is doing all submissions
+on behalf of the userspace and so it always complies with the rule disregarding
+how many userspace tasks do
+.BR io_uring_enter(2).
+Available since 6.0.
+.TP
+.B IORING_SETUP_DEFER_TASKRUN
+By default, io_uring will process all outstanding work at the end of any system
+call or thread interrupt. This can delay the application from making other progress.
+Setting this flag will hint to io_uring that it should defer work until an
+.BR io_uring_enter(2)
+call with the 
+.B IORING_ENTER_GETEVENTS
+flag set. This allows the application to request work to run just before it wants to
+process completions.
+This flag requires the
+.BR IORING_SETUP_SINGLE_ISSUER
+flag to be set, and also enforces that the call to
+.BR io_uring_enter(2)
+is called from the same thread that submitted requests.
+Note that if this flag is set then it is the application's responsibility to periodically
+trigger work (for example via any of the CQE waiting functions) or else completions may
+not be delivered.
+Available since 6.1.
 .PP
 If no flags are specified, the io_uring instance is setup for
 interrupt driven I/O.  I/O may be submitted using
@@ -261,7 +300,7 @@ call. The SQEs must still be allocated separately. This brings the necessary
 calls down from three to two. Available since kernel 5.4.
 .TP
 .B IORING_FEAT_NODROP
-If this flag is set, io_uring supports never dropping completion events.
+If this flag is set, io_uring supports almost never dropping completion events.
 If a completion event occurs and the CQ ring is full, the kernel stores
 the event internally until such a time that the CQ ring has room for more
 entries. If this overflow condition is entered, attempting to submit more
@@ -269,7 +308,14 @@ IO will fail with the
 .B -EBUSY
 error value, if it can't flush the overflown events to the CQ ring. If this
 happens, the application must reap events from the CQ ring and attempt the
-submit again. Available since kernel 5.5.
+submit again. If the kernel has no free memory to store the event internally
+it will be visible by an increase in the overflow value on the cqring.
+Available since kernel 5.5. Additionally
+.BR io_uring_enter (2)
+will return
+.B -EBADR
+the next time it would otherwise sleep waiting for completions (since kernel 5.19).
+
 .TP
 .B IORING_FEAT_SUBMIT_STABLE
 If this flag is set, applications can be certain that any data for
@@ -548,11 +594,9 @@ or
 .BR io_uring_enter (2)
 system calls.
 
-On error,
-.B -1
-is returned and
+On error, a negative error code is returned. The caller should not rely on
 .I errno
-is set appropriately.
+variable.
 .PP
 .SH ERRORS
 .TP

--- a/vendor/liburing/man/io_uring_sq_ready.3
+++ b/vendor/liburing/man/io_uring_sq_ready.3
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_sq_ready "January 25, 2022" "liburing-2.1" "liburing Manual"
+.TH io_uring_sq_ready 3 "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
 io_uring_sq_ready \- number of unconsumed or unsubmitted entries in the SQ ring
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ io_uring_sq_ready \- number of unconsumed or unsubmitted entries in the SQ ring
 .PP
 The
 .BR io_uring_sq_ready (3)
-function retuns the number of unconsumed (if SQPOLL) or unsubmitted entries
+function returns the number of unconsumed (if SQPOLL) or unsubmitted entries
 that exist in the SQ ring belonging to the
 .I ring
 param.

--- a/vendor/liburing/man/io_uring_sq_space_left.3
+++ b/vendor/liburing/man/io_uring_sq_space_left.3
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_sq_space-left "January 25, 2022" "liburing-2.1" "liburing Manual"
+.TH io_uring_sq_space-left 3 "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
 io_uring_sq_space_left \- free space in the SQ ring
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ io_uring_sq_space_left \- free space in the SQ ring
 .PP
 The
 .BR io_uring_sq_space_left (3)
-function retuns how much space is left in the SQ ring belonging to the
+function returns how much space is left in the SQ ring belonging to the
 .I ring
 param.
 

--- a/vendor/liburing/man/io_uring_sqe_set_flags.3
+++ b/vendor/liburing/man/io_uring_sqe_set_flags.3
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_sqe_set_flags "January 25, 2022" "liburing-2.1" "liburing Manual"
+.TH io_uring_sqe_set_flags 3 "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
 io_uring_sqe_set_flags \- set flags for submission queue entry
 .SH SYNOPSIS
@@ -37,7 +37,8 @@ overlapped operation of requests that the application knows/assumes will
 always (or most of the time) block, the application can ask for an sqe to be
 issued async from the start. Note that this flag immediately causes the SQE
 to be offloaded to an async helper thread with no initial non-blocking attempt.
-This may be less efficient and should not be used sporadically.
+This may be less efficient and should not be used liberally or without
+understanding the performance and efficiency tradeoffs.
 .TP
 .B IOSQE_IO_LINK
 When this flag is specified, the SQE forms a link with the next SQE in the
@@ -65,7 +66,7 @@ one completes.
 .B IOSQE_CQE_SKIP_SUCCESS
 Request that no CQE be generated for this request, if it completes successfully.
 This can be useful in cases where the application doesn't need to know when
-a specific request completed, if it completed succesfully.
+a specific request completed, if it completed successfully.
 .TP
 .B IOSQE_BUFFER_SELECT
 If set, and if the request types supports it, select an IO buffer from the

--- a/vendor/liburing/man/io_uring_sqring_wait.3
+++ b/vendor/liburing/man/io_uring_sqring_wait.3
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_sqring_wait "January 25, 2022" "liburing-2.1" "liburing Manual"
+.TH io_uring_sqring_wait 3 "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
 io_uring_sqring_wait \- wait for free space in the SQ ring
 .SH SYNOPSIS

--- a/vendor/liburing/man/io_uring_submit_and_get_events.3
+++ b/vendor/liburing/man/io_uring_submit_and_get_events.3
@@ -1,0 +1,31 @@
+.\" Copyright (C), 2022  dylany
+.\" You may distribute this file under the terms of the GNU Free
+.\" Documentation License.
+.TH io_uring_submit_and_get_events 3 "September 5, 2022" "liburing-2.3" "liburing Manual"
+.SH NAME
+io_uring_submit_and_get_events \- submit requests to the submission queue and flush completions
+.SH SYNOPSIS
+.nf
+.B #include <liburing.h>
+.PP
+.BI "int io_uring_submit_and_get_events(struct io_uring *" ring ");"
+.fi
+
+.SH DESCRIPTION
+The
+.BR io_uring_submit_and_get_events (3)
+function submits the next events to the submission queue as with
+.BR io_uring_submit (3) .
+After submission it will flush CQEs as with
+.BR io_uring_get_events (3) .
+
+The benefit of this function is that it does both with only one system call.
+
+.SH RETURN VALUE
+On success
+.BR io_uring_submit_and_get_events (3)
+returns the number of submitted submission queue entries. On failure it returns
+.BR -errno .
+.SH SEE ALSO
+.BR io_uring_submit (3),
+.BR io_uring_get_events (3)

--- a/vendor/liburing/man/io_uring_submit_and_wait.3
+++ b/vendor/liburing/man/io_uring_submit_and_wait.3
@@ -16,7 +16,7 @@ io_uring_submit_and_wait \- submit requests to the submission queue and wait for
 .PP
 The
 .BR io_uring_submit_and_wait (3)
-function submits the next events to the submission queue belonging to the
+function submits the next requests from the submission queue belonging to the
 .I ring
 and waits for
 .I wait_nr

--- a/vendor/liburing/man/io_uring_submit_and_wait_timeout.3
+++ b/vendor/liburing/man/io_uring_submit_and_wait_timeout.3
@@ -20,11 +20,11 @@ wait for the completion with timeout
 .PP
 The
 .BR io_uring_submit_and_wait_timeout (3)
-function submits the next events to the submission queue belonging to the
+function submits the next requests from the submission queue belonging to the
 .I ring
 and waits for
 .I wait_nr
-completion events or until the timeout
+completion events, or until the timeout
 .I ts
 expires. The completion events are stored in the
 .I cqe_ptr
@@ -43,6 +43,8 @@ On success
 .BR io_uring_submit_and_wait_timeout (3)
 returns the number of submitted submission queue entries. On failure it returns
 .BR -errno .
+Note that in earlier versions of the liburing library, the return value was 0
+on success.
 The most common failure case is not receiving a completion within the specified
 timeout,
 .B -ETIME

--- a/vendor/liburing/man/io_uring_wait_cqe.3
+++ b/vendor/liburing/man/io_uring_wait_cqe.3
@@ -31,7 +31,7 @@ the application can retrieve the completion with
 .SH RETURN VALUE
 On success
 .BR io_uring_wait_cqe (3)
-returns 0 and the cqe_ptr parm is filled in. On failure it returns
+returns 0 and the cqe_ptr param is filled in. On failure it returns
 .BR -errno .
 The return value indicates the result of waiting for a CQE, and it has no
 relation to the CQE result itself.

--- a/vendor/liburing/man/io_uring_wait_cqe_nr.3
+++ b/vendor/liburing/man/io_uring_wait_cqe_nr.3
@@ -34,7 +34,7 @@ the application can retrieve the completion with
 .SH RETURN VALUE
 On success
 .BR io_uring_wait_cqe_nr (3)
-returns 0 and the cqe_ptr parm is filled in. On failure it returns
+returns 0 and the cqe_ptr param is filled in. On failure it returns
 .BR -errno .
 The return value indicates the result of waiting for a CQE, and it has no
 relation to the CQE result itself.

--- a/vendor/liburing/man/io_uring_wait_cqe_timeout.3
+++ b/vendor/liburing/man/io_uring_wait_cqe_timeout.3
@@ -43,7 +43,7 @@ when waiting for a request.
 .SH RETURN VALUE
 On success
 .BR io_uring_wait_cqes (3)
-returns 0 and the cqe_ptr parm is filled in. On failure it returns
+returns 0 and the cqe_ptr param is filled in. On failure it returns
 .BR -errno .
 The return value indicates the result of waiting for a CQE, and it has no
 relation to the CQE result itself.

--- a/vendor/liburing/man/io_uring_wait_cqes.3
+++ b/vendor/liburing/man/io_uring_wait_cqes.3
@@ -48,7 +48,7 @@ when waiting for a request.
 .SH RETURN VALUE
 On success
 .BR io_uring_wait_cqes (3)
-returns 0 and the cqe_ptr parm is filled in. On failure it returns
+returns 0 and the cqe_ptr param is filled in. On failure it returns
 .BR -errno .
 .SH SEE ALSO
 .BR io_uring_submit (3),

--- a/vendor/liburing/src/Makefile
+++ b/vendor/liburing/src/Makefile
@@ -5,11 +5,14 @@ includedir ?= $(prefix)/include
 libdir ?= $(prefix)/lib
 libdevdir ?= $(prefix)/lib
 
+LIBURING_CFLAGS ?=
 CPPFLAGS ?=
 override CPPFLAGS += -D_GNU_SOURCE \
 	-Iinclude/ -include ../config-host.h
-CFLAGS ?= -g -O2 -Wall -Wextra -fno-stack-protector
-override CFLAGS += -Wno-unused-parameter -Wno-sign-compare -DLIBURING_INTERNAL
+CFLAGS ?= -g -O3 -Wall -Wextra -fno-stack-protector
+override CFLAGS += -Wno-unused-parameter -Wno-sign-compare \
+	-DLIBURING_INTERNAL \
+	$(LIBURING_CFLAGS)
 SO_CFLAGS=-fPIC $(CFLAGS)
 L_CFLAGS=$(CFLAGS)
 LINK_FLAGS=
@@ -32,15 +35,13 @@ endif
 
 all: $(all_targets)
 
-liburing_srcs := setup.c queue.c register.c
+liburing_srcs := setup.c queue.c register.c syscall.c
 
 ifeq ($(CONFIG_NOLIBC),y)
 	liburing_srcs += nolibc.c
 	override CFLAGS += -nostdlib -nodefaultlibs -ffreestanding
 	override CPPFLAGS += -nostdlib -nodefaultlibs -ffreestanding
 	override LINK_FLAGS += -nostdlib -nodefaultlibs
-else
-	liburing_srcs += syscall.c
 endif
 
 override CPPFLAGS += -MT "$@" -MMD -MP -MF "$@.d"

--- a/vendor/liburing/src/arch/aarch64/lib.h
+++ b/vendor/liburing/src/arch/aarch64/lib.h
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef LIBURING_ARCH_AARCH64_LIB_H
+#define LIBURING_ARCH_AARCH64_LIB_H
+
+#include <elf.h>
+#include <sys/auxv.h>
+#include "../../syscall.h"
+
+static inline long __get_page_size(void)
+{
+	Elf64_Off buf[2];
+	long ret = 4096;
+	int fd;
+
+	fd = __sys_open("/proc/self/auxv", O_RDONLY, 0);
+	if (fd < 0)
+		return ret;
+
+	while (1) {
+		ssize_t x;
+
+		x = __sys_read(fd, buf, sizeof(buf));
+		if (x < sizeof(buf))
+			break;
+
+		if (buf[0] == AT_PAGESZ) {
+			ret = buf[1];
+			break;
+		}
+	}
+
+	__sys_close(fd);
+	return ret;
+}
+
+static inline long get_page_size(void)
+{
+	static long cache_val;
+
+	if (cache_val)
+		return cache_val;
+
+	cache_val = __get_page_size();
+	return cache_val;
+}
+
+#endif /* #ifndef LIBURING_ARCH_AARCH64_LIB_H */

--- a/vendor/liburing/src/arch/aarch64/syscall.h
+++ b/vendor/liburing/src/arch/aarch64/syscall.h
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: MIT */
 
-#ifndef __INTERNAL__LIBURING_SYSCALL_H
-	#error "This file should be included from src/syscall.h (liburing)"
-#endif
-
 #ifndef LIBURING_ARCH_AARCH64_SYSCALL_H
 #define LIBURING_ARCH_AARCH64_SYSCALL_H
 

--- a/vendor/liburing/src/arch/generic/lib.h
+++ b/vendor/liburing/src/arch/generic/lib.h
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: MIT */
 
-#ifndef __INTERNAL__LIBURING_LIB_H
-	#error "This file should be included from src/lib.h (liburing)"
-#endif
-
 #ifndef LIBURING_ARCH_GENERIC_LIB_H
 #define LIBURING_ARCH_GENERIC_LIB_H
 

--- a/vendor/liburing/src/arch/generic/syscall.h
+++ b/vendor/liburing/src/arch/generic/syscall.h
@@ -1,31 +1,30 @@
 /* SPDX-License-Identifier: MIT */
 
-#ifndef __INTERNAL__LIBURING_SYSCALL_H
-	#error "This file should be included from src/syscall.h (liburing)"
-#endif
-
 #ifndef LIBURING_ARCH_GENERIC_SYSCALL_H
 #define LIBURING_ARCH_GENERIC_SYSCALL_H
 
-static inline int ____sys_io_uring_register(int fd, unsigned opcode,
-					    const void *arg, unsigned nr_args)
+#include <fcntl.h>
+
+static inline int __sys_io_uring_register(unsigned int fd, unsigned int opcode,
+					  const void *arg, unsigned int nr_args)
 {
 	int ret;
 	ret = syscall(__NR_io_uring_register, fd, opcode, arg, nr_args);
 	return (ret < 0) ? -errno : ret;
 }
 
-static inline int ____sys_io_uring_setup(unsigned entries,
-					 struct io_uring_params *p)
+static inline int __sys_io_uring_setup(unsigned int entries,
+				       struct io_uring_params *p)
 {
 	int ret;
 	ret = syscall(__NR_io_uring_setup, entries, p);
 	return (ret < 0) ? -errno : ret;
 }
 
-static inline int ____sys_io_uring_enter2(int fd, unsigned to_submit,
-					  unsigned min_complete, unsigned flags,
-					  sigset_t *sig, int sz)
+static inline int __sys_io_uring_enter2(unsigned int fd, unsigned int to_submit,
+					unsigned int min_complete,
+					unsigned int flags, sigset_t *sig,
+					size_t sz)
 {
 	int ret;
 	ret = syscall(__NR_io_uring_enter, fd, to_submit, min_complete, flags,
@@ -33,12 +32,26 @@ static inline int ____sys_io_uring_enter2(int fd, unsigned to_submit,
 	return (ret < 0) ? -errno : ret;
 }
 
-static inline int ____sys_io_uring_enter(int fd, unsigned to_submit,
-					 unsigned min_complete, unsigned flags,
-					 sigset_t *sig)
+static inline int __sys_io_uring_enter(unsigned int fd, unsigned int to_submit,
+				       unsigned int min_complete,
+				       unsigned int flags, sigset_t *sig)
 {
-	return ____sys_io_uring_enter2(fd, to_submit, min_complete, flags, sig,
-				       _NSIG / 8);
+	return __sys_io_uring_enter2(fd, to_submit, min_complete, flags, sig,
+				     _NSIG / 8);
+}
+
+static inline int __sys_open(const char *pathname, int flags, mode_t mode)
+{
+	int ret;
+	ret = open(pathname, flags, mode);
+	return (ret < 0) ? -errno : ret;
+}
+
+static inline ssize_t __sys_read(int fd, void *buffer, size_t size)
+{
+	ssize_t ret;
+	ret = read(fd, buffer, size);
+	return (ret < 0) ? -errno : ret;
 }
 
 static inline void *__sys_mmap(void *addr, size_t length, int prot, int flags,

--- a/vendor/liburing/src/arch/syscall-defs.h
+++ b/vendor/liburing/src/arch/syscall-defs.h
@@ -3,12 +3,31 @@
 #ifndef LIBURING_ARCH_SYSCALL_DEFS_H
 #define LIBURING_ARCH_SYSCALL_DEFS_H
 
+#include <fcntl.h>
+
+static inline int __sys_open(const char *pathname, int flags, mode_t mode)
+{
+	/*
+	 * Some architectures don't have __NR_open, but __NR_openat.
+	 */
+#ifdef __NR_open
+	return (int) __do_syscall3(__NR_open, pathname, flags, mode);
+#else
+	return (int) __do_syscall4(__NR_openat, AT_FDCWD, pathname, flags, mode);
+#endif
+}
+
+static inline ssize_t __sys_read(int fd, void *buffer, size_t size)
+{
+	return (ssize_t) __do_syscall3(__NR_read, fd, buffer, size);
+}
+
 static inline void *__sys_mmap(void *addr, size_t length, int prot, int flags,
 			       int fd, off_t offset)
 {
 	int nr;
 
-#if defined(__i386__)
+#if defined(__NR_mmap2)
 	nr = __NR_mmap2;
 	offset >>= 12;
 #else
@@ -42,33 +61,34 @@ static inline int __sys_close(int fd)
 	return (int) __do_syscall1(__NR_close, fd);
 }
 
-static inline int ____sys_io_uring_register(int fd, unsigned opcode,
-					    const void *arg, unsigned nr_args)
+static inline int __sys_io_uring_register(unsigned int fd, unsigned int opcode,
+					  const void *arg, unsigned int nr_args)
 {
 	return (int) __do_syscall4(__NR_io_uring_register, fd, opcode, arg,
 				   nr_args);
 }
 
-static inline int ____sys_io_uring_setup(unsigned entries,
-					 struct io_uring_params *p)
+static inline int __sys_io_uring_setup(unsigned int entries,
+				       struct io_uring_params *p)
 {
 	return (int) __do_syscall2(__NR_io_uring_setup, entries, p);
 }
 
-static inline int ____sys_io_uring_enter2(int fd, unsigned to_submit,
-					  unsigned min_complete, unsigned flags,
-					  sigset_t *sig, int sz)
+static inline int __sys_io_uring_enter2(unsigned int fd, unsigned int to_submit,
+					unsigned int min_complete,
+					unsigned int flags, sigset_t *sig,
+					size_t sz)
 {
 	return (int) __do_syscall6(__NR_io_uring_enter, fd, to_submit,
 				   min_complete, flags, sig, sz);
 }
 
-static inline int ____sys_io_uring_enter(int fd, unsigned to_submit,
-					 unsigned min_complete, unsigned flags,
-					 sigset_t *sig)
+static inline int __sys_io_uring_enter(unsigned int fd, unsigned int to_submit,
+				       unsigned int min_complete,
+				       unsigned int flags, sigset_t *sig)
 {
-	return ____sys_io_uring_enter2(fd, to_submit, min_complete, flags, sig,
-				       _NSIG / 8);
+	return __sys_io_uring_enter2(fd, to_submit, min_complete, flags, sig,
+				     _NSIG / 8);
 }
 
 #endif

--- a/vendor/liburing/src/arch/x86/lib.h
+++ b/vendor/liburing/src/arch/x86/lib.h
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: MIT */
 
-#ifndef __INTERNAL__LIBURING_LIB_H
-	#error "This file should be included from src/lib.h (liburing)"
-#endif
-
 #ifndef LIBURING_ARCH_X86_LIB_H
 #define LIBURING_ARCH_X86_LIB_H
 

--- a/vendor/liburing/src/arch/x86/syscall.h
+++ b/vendor/liburing/src/arch/x86/syscall.h
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: MIT */
 
-#ifndef __INTERNAL__LIBURING_SYSCALL_H
-	#error "This file should be included from src/syscall.h (liburing)"
-#endif
-
 #ifndef LIBURING_ARCH_X86_SYSCALL_H
 #define LIBURING_ARCH_X86_SYSCALL_H
 

--- a/vendor/liburing/src/include/liburing/io_uring.h
+++ b/vendor/liburing/src/include/liburing/io_uring.h
@@ -10,6 +10,16 @@
 
 #include <linux/fs.h>
 #include <linux/types.h>
+/*
+ * this file is shared with liburing and that has to autodetect
+ * if linux/time_types.h is available
+ */
+#ifdef __KERNEL__
+#define HAVE_LINUX_TIME_TYPES_H 1
+#endif
+#ifdef HAVE_LINUX_TIME_TYPES_H
+#include <linux/time_types.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,6 +36,10 @@ struct io_uring_sqe {
 	union {
 		__u64	off;	/* offset into file */
 		__u64	addr2;
+		struct {
+			__u32	cmd_op;
+			__u32	__pad1;
+		};
 	};
 	union {
 		__u64	addr;	/* pointer to buffer or iovecs */
@@ -50,6 +64,8 @@ struct io_uring_sqe {
 		__u32		unlink_flags;
 		__u32		hardlink_flags;
 		__u32		xattr_flags;
+		__u32		msg_ring_flags;
+		__u32		uring_cmd_flags;
 	};
 	__u64	user_data;	/* data to be passed back at completion time */
 	/* pack this to avoid bogus arm OABI complaints */
@@ -64,9 +80,22 @@ struct io_uring_sqe {
 	union {
 		__s32	splice_fd_in;
 		__u32	file_index;
+		struct {
+			__u16	addr_len;
+			__u16	__pad3[1];
+		};
 	};
-	__u64	addr3;
-	__u64	__pad2[1];
+	union {
+		struct {
+			__u64	addr3;
+			__u64	__pad2[1];
+		};
+		/*
+		 * If the ring is initialized with IORING_SETUP_SQE128, then
+		 * this field is used for 80 bytes of arbitrary command data
+		 */
+		__u8	cmd[0];
+	};
 };
 
 /*
@@ -131,9 +160,19 @@ enum {
  * IORING_SQ_TASKRUN in the sq ring flags. Not valid with COOP_TASKRUN.
  */
 #define IORING_SETUP_TASKRUN_FLAG	(1U << 9)
-
 #define IORING_SETUP_SQE128		(1U << 10) /* SQEs are 128 byte */
 #define IORING_SETUP_CQE32		(1U << 11) /* CQEs are 32 byte */
+/*
+ * Only one task is allowed to submit requests
+ */
+#define IORING_SETUP_SINGLE_ISSUER	(1U << 12)
+
+/*
+ * Defer running task work to get events.
+ * Rather than running bits of task work whenever the task transitions
+ * try to do it just before it is needed.
+ */
+#define IORING_SETUP_DEFER_TASKRUN	(1U << 13)
 
 enum io_uring_op {
 	IORING_OP_NOP,
@@ -183,10 +222,20 @@ enum io_uring_op {
 	IORING_OP_GETXATTR,
 	IORING_OP_SOCKET,
 	IORING_OP_URING_CMD,
+	IORING_OP_SEND_ZC,
+	IORING_OP_SENDMSG_ZC,
 
 	/* this goes last, obviously */
 	IORING_OP_LAST,
 };
+
+/*
+ * sqe->uring_cmd_flags
+ * IORING_URING_CMD_FIXED	use registered buffer; pass thig flag
+ *				along with setting sqe->buf_index.
+ */
+#define IORING_URING_CMD_FIXED	(1U << 0)
+
 
 /*
  * sqe->fsync_flags
@@ -220,10 +269,13 @@ enum io_uring_op {
  *
  * IORING_POLL_UPDATE		Update existing poll request, matching
  *				sqe->addr as the old user_data field.
+ *
+ * IORING_POLL_LEVEL		Level triggered poll.
  */
 #define IORING_POLL_ADD_MULTI	(1U << 0)
 #define IORING_POLL_UPDATE_EVENTS	(1U << 1)
 #define IORING_POLL_UPDATE_USER_DATA	(1U << 2)
+#define IORING_POLL_ADD_LEVEL		(1U << 3)
 
 /*
  * ASYNC_CANCEL flags.
@@ -232,25 +284,52 @@ enum io_uring_op {
  * IORING_ASYNC_CANCEL_FD	Key off 'fd' for cancelation rather than the
  *				request 'user_data'
  * IORING_ASYNC_CANCEL_ANY	Match any request
+ * IORING_ASYNC_CANCEL_FD_FIXED	'fd' passed in is a fixed descriptor
  */
 #define IORING_ASYNC_CANCEL_ALL	(1U << 0)
 #define IORING_ASYNC_CANCEL_FD	(1U << 1)
-#define IORING_ASYNC_CANCEL_ANY (1U << 2)
+#define IORING_ASYNC_CANCEL_ANY	(1U << 2)
+#define IORING_ASYNC_CANCEL_FD_FIXED	(1U << 3)
 
 /*
- * send/sendmsg and recv/recvmsg flags (sqe->addr2)
+ * send/sendmsg and recv/recvmsg flags (sqe->ioprio)
  *
  * IORING_RECVSEND_POLL_FIRST	If set, instead of first attempting to send
  *				or receive and arm poll if that yields an
  *				-EAGAIN result, arm poll upfront and skip
  *				the initial transfer attempt.
+ *
+ * IORING_RECV_MULTISHOT	Multishot recv. Sets IORING_CQE_F_MORE if
+ *				the handler will continue to report
+ *				CQEs on behalf of the same SQE.
+ *
+ * IORING_RECVSEND_FIXED_BUF	Use registered buffers, the index is stored in
+ *				the buf_index field.
  */
 #define IORING_RECVSEND_POLL_FIRST	(1U << 0)
+#define IORING_RECV_MULTISHOT		(1U << 1)
+#define IORING_RECVSEND_FIXED_BUF	(1U << 2)
 
 /*
  * accept flags stored in sqe->ioprio
  */
 #define IORING_ACCEPT_MULTISHOT	(1U << 0)
+
+/*
+ * IORING_OP_MSG_RING command types, stored in sqe->addr
+ */
+enum {
+	IORING_MSG_DATA,	/* pass sqe->len as 'res' and off as user_data */
+	IORING_MSG_SEND_FD,	/* send a registered fd to another ring */
+};
+
+/*
+ * IORING_OP_MSG_RING flags (sqe->msg_ring_flags)
+ *
+ * IORING_MSG_RING_CQE_SKIP	Don't post a CQE to the target ring. Not
+ *				applicable for IORING_MSG_DATA, obviously.
+ */
+#define IORING_MSG_RING_CQE_SKIP	(1U << 0)
 
 /*
  * IO completion data structure (Completion Queue Entry)
@@ -273,10 +352,13 @@ struct io_uring_cqe {
  * IORING_CQE_F_BUFFER	If set, the upper 16 bits are the buffer ID
  * IORING_CQE_F_MORE	If set, parent SQE will generate more CQE entries
  * IORING_CQE_F_SOCK_NONEMPTY	If set, more data to read after socket recv
+ * IORING_CQE_F_NOTIF	Set for notification CQEs. Can be used to distinct
+ * 			them from sends.
  */
 #define IORING_CQE_F_BUFFER		(1U << 0)
 #define IORING_CQE_F_MORE		(1U << 1)
 #define IORING_CQE_F_SOCK_NONEMPTY	(1U << 2)
+#define IORING_CQE_F_NOTIF		(1U << 3)
 
 enum {
 	IORING_CQE_BUFFER_SHIFT		= 16,
@@ -411,6 +493,12 @@ enum {
 	IORING_REGISTER_PBUF_RING		= 22,
 	IORING_UNREGISTER_PBUF_RING		= 23,
 
+	/* sync cancelation API */
+	IORING_REGISTER_SYNC_CANCEL		= 24,
+
+	/* register a range of fixed file slots for automatic slot allocation */
+	IORING_REGISTER_FILE_ALLOC_RANGE	= 25,
+
 	/* this goes last */
 	IORING_REGISTER_LAST
 };
@@ -457,6 +545,19 @@ struct io_uring_rsrc_update2 {
 	__u32 resv2;
 };
 
+struct io_uring_notification_slot {
+	__u64 tag;
+	__u64 resv[3];
+};
+
+struct io_uring_notification_register {
+	__u32 nr_slots;
+	__u32 resv;
+	__u64 resv2;
+	__u64 data;
+	__u64 resv3;
+};
+
 /* Skip updating fd indexes set to this value in the fd table */
 #define IORING_REGISTER_FILES_SKIP	(-2)
 
@@ -474,7 +575,7 @@ struct io_uring_probe {
 	__u8 ops_len;	/* length of ops[] array below */
 	__u16 resv;
 	__u32 resv2[3];
-	struct io_uring_probe_op ops[0];
+	struct io_uring_probe_op ops[];
 };
 
 struct io_uring_restriction {
@@ -547,9 +648,32 @@ struct io_uring_getevents_arg {
 };
 
 /*
- * accept flags stored in sqe->ioprio
+ * Argument for IORING_REGISTER_SYNC_CANCEL
  */
-#define IORING_ACCEPT_MULTISHOT	(1U << 0)
+struct io_uring_sync_cancel_reg {
+	__u64				addr;
+	__s32				fd;
+	__u32				flags;
+	struct __kernel_timespec	timeout;
+	__u64				pad[4];
+};
+
+/*
+ * Argument for IORING_REGISTER_FILE_ALLOC_RANGE
+ * The range is specified as [off, off + len)
+ */
+struct io_uring_file_index_range {
+	__u32	off;
+	__u32	len;
+	__u64	resv;
+};
+
+struct io_uring_recvmsg_out {
+	__u32 namelen;
+	__u32 controllen;
+	__u32 payloadlen;
+	__u32 flags;
+};
 
 #ifdef __cplusplus
 }

--- a/vendor/liburing/src/lib.h
+++ b/vendor/liburing/src/lib.h
@@ -6,32 +6,36 @@
 #include <string.h>
 #include <unistd.h>
 
-#define __INTERNAL__LIBURING_LIB_H
 #if defined(__x86_64__) || defined(__i386__)
-	#include "arch/x86/lib.h"
+#include "arch/x86/lib.h"
+#elif defined(__aarch64__)
+#include "arch/aarch64/lib.h"
 #else
-	/*
-	 * We don't have nolibc support for this arch. Must use libc!
-	 */
-	#ifdef CONFIG_NOLIBC
-		#error "This arch doesn't support building liburing without libc"
-	#endif
-	/* libc wrappers. */
-	#include "arch/generic/lib.h"
+/*
+ * We don't have nolibc support for this arch. Must use libc!
+ */
+#ifdef CONFIG_NOLIBC
+#error "This arch doesn't support building liburing without libc"
 #endif
-#undef __INTERNAL__LIBURING_LIB_H
+/* libc wrappers. */
+#include "arch/generic/lib.h"
+#endif
 
 
 #ifndef offsetof
-	#define offsetof(TYPE, FIELD) ((size_t) &((TYPE *)0)->FIELD)
+#define offsetof(TYPE, FIELD) ((size_t) &((TYPE *)0)->FIELD)
 #endif
 
 #ifndef container_of
-	#define container_of(PTR, TYPE, FIELD) ({			\
-		__typeof__(((TYPE *)0)->FIELD) *__FIELD_PTR = (PTR);	\
-		(TYPE *)((char *) __FIELD_PTR - offsetof(TYPE, FIELD));	\
-	})
+#define container_of(PTR, TYPE, FIELD) ({			\
+	__typeof__(((TYPE *)0)->FIELD) *__FIELD_PTR = (PTR);	\
+	(TYPE *)((char *) __FIELD_PTR - offsetof(TYPE, FIELD));	\
+})
 #endif
+
+#define __maybe_unused		__attribute__((__unused__))
+#define __hot			__attribute__((__hot__))
+#define __cold			__attribute__((__cold__))
 
 void *__uring_malloc(size_t len);
 void __uring_free(void *p);

--- a/vendor/liburing/src/liburing.map
+++ b/vendor/liburing/src/liburing.map
@@ -55,3 +55,15 @@ LIBURING_2.2 {
 		io_uring_register_buf_ring;
 		io_uring_unregister_buf_ring;
 } LIBURING_2.1;
+
+LIBURING_2.3 {
+	global:
+		io_uring_register_sync_cancel;
+		io_uring_register_file_alloc_range;
+		io_uring_enter;
+		io_uring_enter2;
+		io_uring_setup;
+		io_uring_register;
+		io_uring_get_events;
+		io_uring_submit_and_get_events;
+} LIBURING_2.2;

--- a/vendor/liburing/src/register.c
+++ b/vendor/liburing/src/register.c
@@ -20,8 +20,7 @@ int io_uring_register_buffers_update_tag(struct io_uring *ring, unsigned off,
 		.nr = nr,
 	};
 
-	return ____sys_io_uring_register(ring->ring_fd,
-					 IORING_REGISTER_BUFFERS_UPDATE, &up,
+	return __sys_io_uring_register(ring->ring_fd,IORING_REGISTER_BUFFERS_UPDATE, &up,
 					 sizeof(up));
 }
 
@@ -36,9 +35,9 @@ int io_uring_register_buffers_tags(struct io_uring *ring,
 		.tags = (unsigned long)tags,
 	};
 
-	return ____sys_io_uring_register(ring->ring_fd,
-					 IORING_REGISTER_BUFFERS2, &reg,
-					 sizeof(reg));
+	return __sys_io_uring_register(ring->ring_fd,
+				       IORING_REGISTER_BUFFERS2, &reg,
+				       sizeof(reg));
 }
 
 int io_uring_register_buffers_sparse(struct io_uring *ring, unsigned nr)
@@ -48,9 +47,8 @@ int io_uring_register_buffers_sparse(struct io_uring *ring, unsigned nr)
 		.nr = nr,
 	};
 
-	return ____sys_io_uring_register(ring->ring_fd,
-					 IORING_REGISTER_BUFFERS2, &reg,
-					 sizeof(reg));
+	return __sys_io_uring_register(ring->ring_fd, IORING_REGISTER_BUFFERS2,
+				       &reg, sizeof(reg));
 }
 
 int io_uring_register_buffers(struct io_uring *ring, const struct iovec *iovecs,
@@ -58,8 +56,8 @@ int io_uring_register_buffers(struct io_uring *ring, const struct iovec *iovecs,
 {
 	int ret;
 
-	ret = ____sys_io_uring_register(ring->ring_fd, IORING_REGISTER_BUFFERS,
-					iovecs, nr_iovecs);
+	ret = __sys_io_uring_register(ring->ring_fd, IORING_REGISTER_BUFFERS,
+				      iovecs, nr_iovecs);
 	return (ret < 0) ? ret : 0;
 }
 
@@ -67,8 +65,8 @@ int io_uring_unregister_buffers(struct io_uring *ring)
 {
 	int ret;
 
-	ret = ____sys_io_uring_register(ring->ring_fd,
-					IORING_UNREGISTER_BUFFERS, NULL, 0);
+	ret = __sys_io_uring_register(ring->ring_fd, IORING_UNREGISTER_BUFFERS,
+				      NULL, 0);
 	return (ret < 0) ? ret : 0;
 }
 
@@ -83,9 +81,9 @@ int io_uring_register_files_update_tag(struct io_uring *ring, unsigned off,
 		.nr = nr_files,
 	};
 
-	return ____sys_io_uring_register(ring->ring_fd,
-					 IORING_REGISTER_FILES_UPDATE2, &up,
-					 sizeof(up));
+	return __sys_io_uring_register(ring->ring_fd,
+				       IORING_REGISTER_FILES_UPDATE2, &up,
+				       sizeof(up));
 }
 
 /*
@@ -96,16 +94,16 @@ int io_uring_register_files_update_tag(struct io_uring *ring, unsigned off,
  * Returns number of files updated on success, -ERROR on failure.
  */
 int io_uring_register_files_update(struct io_uring *ring, unsigned off,
-				   int *files, unsigned nr_files)
+				   const int *files, unsigned nr_files)
 {
 	struct io_uring_files_update up = {
 		.offset	= off,
 		.fds	= (unsigned long) files,
 	};
 
-	return ____sys_io_uring_register(ring->ring_fd,
-					 IORING_REGISTER_FILES_UPDATE, &up,
-					 nr_files);
+	return __sys_io_uring_register(ring->ring_fd,
+				       IORING_REGISTER_FILES_UPDATE, &up,
+				       nr_files);
 }
 
 static int increase_rlimit_nofile(unsigned nr)
@@ -134,9 +132,9 @@ int io_uring_register_files_sparse(struct io_uring *ring, unsigned nr)
 	int ret, did_increase = 0;
 
 	do {
-		ret = ____sys_io_uring_register(ring->ring_fd,
-						IORING_REGISTER_FILES2, &reg,
-						sizeof(reg));
+		ret = __sys_io_uring_register(ring->ring_fd,
+					      IORING_REGISTER_FILES2, &reg,
+					      sizeof(reg));
 		if (ret >= 0)
 			break;
 		if (ret == -EMFILE && !did_increase) {
@@ -161,9 +159,9 @@ int io_uring_register_files_tags(struct io_uring *ring, const int *files,
 	int ret, did_increase = 0;
 
 	do {
-		ret = ____sys_io_uring_register(ring->ring_fd,
-						IORING_REGISTER_FILES2, &reg,
-						sizeof(reg));
+		ret = __sys_io_uring_register(ring->ring_fd,
+					      IORING_REGISTER_FILES2, &reg,
+					      sizeof(reg));
 		if (ret >= 0)
 			break;
 		if (ret == -EMFILE && !did_increase) {
@@ -183,9 +181,9 @@ int io_uring_register_files(struct io_uring *ring, const int *files,
 	int ret, did_increase = 0;
 
 	do {
-		ret = ____sys_io_uring_register(ring->ring_fd,
-						IORING_REGISTER_FILES, files,
-						nr_files);
+		ret = __sys_io_uring_register(ring->ring_fd,
+					      IORING_REGISTER_FILES, files,
+					      nr_files);
 		if (ret >= 0)
 			break;
 		if (ret == -EMFILE && !did_increase) {
@@ -203,8 +201,8 @@ int io_uring_unregister_files(struct io_uring *ring)
 {
 	int ret;
 
-	ret = ____sys_io_uring_register(ring->ring_fd, IORING_UNREGISTER_FILES,
-					NULL, 0);
+	ret = __sys_io_uring_register(ring->ring_fd, IORING_UNREGISTER_FILES,
+				      NULL, 0);
 	return (ret < 0) ? ret : 0;
 }
 
@@ -212,8 +210,8 @@ int io_uring_register_eventfd(struct io_uring *ring, int event_fd)
 {
 	int ret;
 
-	ret = ____sys_io_uring_register(ring->ring_fd, IORING_REGISTER_EVENTFD,
-					&event_fd, 1);
+	ret = __sys_io_uring_register(ring->ring_fd, IORING_REGISTER_EVENTFD,
+				      &event_fd, 1);
 	return (ret < 0) ? ret : 0;
 }
 
@@ -221,8 +219,8 @@ int io_uring_unregister_eventfd(struct io_uring *ring)
 {
 	int ret;
 
-	ret = ____sys_io_uring_register(ring->ring_fd,
-					IORING_UNREGISTER_EVENTFD, NULL, 0);
+	ret = __sys_io_uring_register(ring->ring_fd, IORING_UNREGISTER_EVENTFD,
+				      NULL, 0);
 	return (ret < 0) ? ret : 0;
 }
 
@@ -230,9 +228,9 @@ int io_uring_register_eventfd_async(struct io_uring *ring, int event_fd)
 {
 	int ret;
 
-	ret = ____sys_io_uring_register(ring->ring_fd,
-					IORING_REGISTER_EVENTFD_ASYNC,
-					&event_fd, 1);
+	ret = __sys_io_uring_register(ring->ring_fd,
+				      IORING_REGISTER_EVENTFD_ASYNC, &event_fd,
+				      1);
 	return (ret < 0) ? ret : 0;
 }
 
@@ -241,22 +239,21 @@ int io_uring_register_probe(struct io_uring *ring, struct io_uring_probe *p,
 {
 	int ret;
 
-	ret = ____sys_io_uring_register(ring->ring_fd, IORING_REGISTER_PROBE, p,
-					nr_ops);
+	ret = __sys_io_uring_register(ring->ring_fd, IORING_REGISTER_PROBE, p,
+				      nr_ops);
 	return (ret < 0) ? ret : 0;
 }
 
 int io_uring_register_personality(struct io_uring *ring)
 {
-	return ____sys_io_uring_register(ring->ring_fd,
-					 IORING_REGISTER_PERSONALITY, NULL, 0);
+	return __sys_io_uring_register(ring->ring_fd,
+				       IORING_REGISTER_PERSONALITY, NULL, 0);
 }
 
 int io_uring_unregister_personality(struct io_uring *ring, int id)
 {
-	return ____sys_io_uring_register(ring->ring_fd,
-					 IORING_UNREGISTER_PERSONALITY, NULL,
-					 id);
+	return __sys_io_uring_register(ring->ring_fd,
+				       IORING_UNREGISTER_PERSONALITY, NULL, id);
 }
 
 int io_uring_register_restrictions(struct io_uring *ring,
@@ -265,36 +262,39 @@ int io_uring_register_restrictions(struct io_uring *ring,
 {
 	int ret;
 
-	ret = ____sys_io_uring_register(ring->ring_fd,
-					IORING_REGISTER_RESTRICTIONS, res,
-					nr_res);
+	ret = __sys_io_uring_register(ring->ring_fd,
+				      IORING_REGISTER_RESTRICTIONS, res,
+				      nr_res);
 	return (ret < 0) ? ret : 0;
 }
 
 int io_uring_enable_rings(struct io_uring *ring)
 {
-	return ____sys_io_uring_register(ring->ring_fd,
-					 IORING_REGISTER_ENABLE_RINGS, NULL, 0);
+	return __sys_io_uring_register(ring->ring_fd,
+				       IORING_REGISTER_ENABLE_RINGS, NULL, 0);
 }
 
 int io_uring_register_iowq_aff(struct io_uring *ring, size_t cpusz,
 			       const cpu_set_t *mask)
 {
-	return ____sys_io_uring_register(ring->ring_fd,
-					 IORING_REGISTER_IOWQ_AFF, mask, cpusz);
+	if (cpusz >= (1U << 31))
+		return -EINVAL;
+
+	return __sys_io_uring_register(ring->ring_fd, IORING_REGISTER_IOWQ_AFF,
+					mask, (int) cpusz);
 }
 
 int io_uring_unregister_iowq_aff(struct io_uring *ring)
 {
-	return  ____sys_io_uring_register(ring->ring_fd,
-					  IORING_UNREGISTER_IOWQ_AFF, NULL, 0);
+	return __sys_io_uring_register(ring->ring_fd,
+				       IORING_UNREGISTER_IOWQ_AFF, NULL, 0);
 }
 
 int io_uring_register_iowq_max_workers(struct io_uring *ring, unsigned int *val)
 {
-	return ____sys_io_uring_register(ring->ring_fd,
-					 IORING_REGISTER_IOWQ_MAX_WORKERS, val,
-					 2);
+	return __sys_io_uring_register(ring->ring_fd,
+				       IORING_REGISTER_IOWQ_MAX_WORKERS, val,
+				       2);
 }
 
 int io_uring_register_ring_fd(struct io_uring *ring)
@@ -305,8 +305,8 @@ int io_uring_register_ring_fd(struct io_uring *ring)
 	};
 	int ret;
 
-	ret = ____sys_io_uring_register(ring->ring_fd, IORING_REGISTER_RING_FDS,
-					&up, 1);
+	ret = __sys_io_uring_register(ring->ring_fd, IORING_REGISTER_RING_FDS,
+				      &up, 1);
 	if (ret == 1) {
 		ring->enter_ring_fd = up.offset;
 		ring->int_flags |= INT_FLAG_REG_RING;
@@ -322,8 +322,8 @@ int io_uring_unregister_ring_fd(struct io_uring *ring)
 	};
 	int ret;
 
-	ret = ____sys_io_uring_register(ring->ring_fd,
-					IORING_UNREGISTER_RING_FDS, &up, 1);
+	ret = __sys_io_uring_register(ring->ring_fd, IORING_UNREGISTER_RING_FDS,
+				      &up, 1);
 	if (ret == 1) {
 		ring->enter_ring_fd = ring->ring_fd;
 		ring->int_flags &= ~INT_FLAG_REG_RING;
@@ -332,16 +332,38 @@ int io_uring_unregister_ring_fd(struct io_uring *ring)
 }
 
 int io_uring_register_buf_ring(struct io_uring *ring,
-			       struct io_uring_buf_reg *reg, unsigned int flags)
+			       struct io_uring_buf_reg *reg,
+			       unsigned int __maybe_unused flags)
 {
-	return ____sys_io_uring_register(ring->ring_fd,
-					 IORING_REGISTER_PBUF_RING, reg, 1);
+	return __sys_io_uring_register(ring->ring_fd, IORING_REGISTER_PBUF_RING,
+				       reg, 1);
 }
 
 int io_uring_unregister_buf_ring(struct io_uring *ring, int bgid)
 {
 	struct io_uring_buf_reg reg = { .bgid = bgid };
 
-	return ____sys_io_uring_register(ring->ring_fd,
-					 IORING_UNREGISTER_PBUF_RING, &reg, 1);
+	return __sys_io_uring_register(ring->ring_fd,
+				       IORING_UNREGISTER_PBUF_RING, &reg, 1);
+}
+
+int io_uring_register_sync_cancel(struct io_uring *ring,
+				  struct io_uring_sync_cancel_reg *reg)
+{
+	return __sys_io_uring_register(ring->ring_fd,
+				       IORING_REGISTER_SYNC_CANCEL, reg, 1);
+}
+
+int io_uring_register_file_alloc_range(struct io_uring *ring,
+					unsigned off, unsigned len)
+{
+	struct io_uring_file_index_range range;
+
+	memset(&range, 0, sizeof(range));
+	range.off = off;
+	range.len = len;
+
+	return __sys_io_uring_register(ring->ring_fd,
+				       IORING_REGISTER_FILE_ALLOC_RANGE, &range,
+				       0);
 }

--- a/vendor/liburing/src/syscall.c
+++ b/vendor/liburing/src/syscall.c
@@ -1,47 +1,29 @@
 /* SPDX-License-Identifier: MIT */
-#define _DEFAULT_SOURCE
 
-/*
- * Functions in this file require libc, only build them when we use libc.
- *
- * Note:
- * liburing's tests still need these functions.
- */
-#if defined(CONFIG_NOLIBC) && !defined(LIBURING_BUILD_TEST)
-#error "This file should only be compiled for libc build, or for liburing tests"
-#endif
-
-/*
- * Will go away once libc support is there
- */
-#include <unistd.h>
-#include <sys/syscall.h>
-#include <sys/uio.h>
-#include "liburing/compat.h"
-#include "liburing/io_uring.h"
 #include "syscall.h"
+#include <liburing.h>
 
-int __sys_io_uring_register(int fd, unsigned opcode, const void *arg,
-			    unsigned nr_args)
+int io_uring_enter(unsigned int fd, unsigned int to_submit,
+		   unsigned int min_complete, unsigned int flags, sigset_t *sig)
 {
-	return syscall(__NR_io_uring_register, fd, opcode, arg, nr_args);
+	return __sys_io_uring_enter(fd, to_submit, min_complete, flags, sig);
 }
 
-int __sys_io_uring_setup(unsigned entries, struct io_uring_params *p)
-{
-	return syscall(__NR_io_uring_setup, entries, p);
-}
-
-int __sys_io_uring_enter2(int fd, unsigned to_submit, unsigned min_complete,
-			  unsigned flags, sigset_t *sig, int sz)
-{
-	return syscall(__NR_io_uring_enter, fd, to_submit, min_complete, flags,
-		       sig, sz);
-}
-
-int __sys_io_uring_enter(int fd, unsigned to_submit, unsigned min_complete,
-			 unsigned flags, sigset_t *sig)
+int io_uring_enter2(unsigned int fd, unsigned int to_submit,
+		    unsigned int min_complete, unsigned int flags,
+		    sigset_t *sig, size_t sz)
 {
 	return __sys_io_uring_enter2(fd, to_submit, min_complete, flags, sig,
-				     _NSIG / 8);
+				     sz);
+}
+
+int io_uring_setup(unsigned int entries, struct io_uring_params *p)
+{
+	return __sys_io_uring_setup(entries, p);
+}
+
+int io_uring_register(unsigned int fd, unsigned int opcode, const void *arg,
+		      unsigned int nr_args)
+{
+	return __sys_io_uring_register(fd, opcode, arg, nr_args);
 }

--- a/vendor/liburing/src/syscall.h
+++ b/vendor/liburing/src/syscall.h
@@ -10,44 +10,7 @@
 #include <sys/mman.h>
 #include <sys/syscall.h>
 #include <sys/resource.h>
-
 #include <liburing.h>
-
-#ifdef __alpha__
-/*
- * alpha and mips are exception, other architectures have
- * common numbers for new system calls.
- */
-#ifndef __NR_io_uring_setup
-#define __NR_io_uring_setup		535
-#endif
-#ifndef __NR_io_uring_enter
-#define __NR_io_uring_enter		536
-#endif
-#ifndef __NR_io_uring_register
-#define __NR_io_uring_register	537
-#endif
-#elif defined __mips__
-#ifndef __NR_io_uring_setup
-#define __NR_io_uring_setup		(__NR_Linux + 425)
-#endif
-#ifndef __NR_io_uring_enter
-#define __NR_io_uring_enter		(__NR_Linux + 426)
-#endif
-#ifndef __NR_io_uring_register
-#define __NR_io_uring_register	(__NR_Linux + 427)
-#endif
-#else /* !__alpha__ and !__mips__ */
-#ifndef __NR_io_uring_setup
-#define __NR_io_uring_setup		425
-#endif
-#ifndef __NR_io_uring_enter
-#define __NR_io_uring_enter		426
-#endif
-#ifndef __NR_io_uring_register
-#define __NR_io_uring_register		427
-#endif
-#endif
 
 /*
  * Don't put this below the #include "arch/$arch/syscall.h", that
@@ -60,9 +23,9 @@ static inline void *ERR_PTR(intptr_t n)
 	return (void *) n;
 }
 
-static inline intptr_t PTR_ERR(const void *ptr)
+static inline int PTR_ERR(const void *ptr)
 {
-	return (intptr_t) ptr;
+	return (int) (intptr_t) ptr;
 }
 
 static inline bool IS_ERR(const void *ptr)
@@ -70,7 +33,6 @@ static inline bool IS_ERR(const void *ptr)
 	return uring_unlikely((uintptr_t) ptr >= (uintptr_t) -4095UL);
 }
 
-#define __INTERNAL__LIBURING_SYSCALL_H
 #if defined(__x86_64__) || defined(__i386__)
 #include "arch/x86/syscall.h"
 #elif defined(__aarch64__)
@@ -86,18 +48,4 @@ static inline bool IS_ERR(const void *ptr)
 /* libc syscall wrappers. */
 #include "arch/generic/syscall.h"
 #endif
-#undef __INTERNAL__LIBURING_SYSCALL_H
-
-/*
- * For backward compatibility.
- * (these __sys* functions always use libc, see syscall.c)
- */
-int __sys_io_uring_setup(unsigned entries, struct io_uring_params *p);
-int __sys_io_uring_enter(int fd, unsigned to_submit, unsigned min_complete,
-			 unsigned flags, sigset_t *sig);
-int __sys_io_uring_enter2(int fd, unsigned to_submit, unsigned min_complete,
-			  unsigned flags, sigset_t *sig, int sz);
-int __sys_io_uring_register(int fd, unsigned int opcode, const void *arg,
-			    unsigned int nr_args);
-
 #endif

--- a/vendor/liburing/test/35fa71a030ca.c
+++ b/vendor/liburing/test/35fa71a030ca.c
@@ -25,6 +25,7 @@
 #include <linux/futex.h>
 
 #include "liburing.h"
+#include "helpers.h"
 #include "../src/syscall.h"
 
 #if !defined(SYS_futex) && defined(SYS_futex_time64)
@@ -317,12 +318,12 @@ static void sig_int(int sig)
 int main(int argc, char *argv[])
 {
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 	signal(SIGINT, sig_int);
 	mmap((void *) 0x20000000, 0x1000000, 3, 0x32, -1, 0);
 	signal(SIGALRM, sig_int);
 	alarm(5);
 
 	loop();
-	return 0;
+	return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/500f9fbadef8.c
+++ b/vendor/liburing/test/500f9fbadef8.c
@@ -27,7 +27,7 @@ int main(int argc, char *argv[])
 	int ret, fd;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	t_posix_memalign(&iov.iov_base, 4096, 4096);
 	iov.iov_len = 4096;
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
 	ret = io_uring_queue_init(1, &ring, IORING_SETUP_IOPOLL);
 	if (ret) {
 		fprintf(stderr, "ring setup failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 
 	}
 
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
 	fd = mkostemp(buf, O_WRONLY | O_DIRECT | O_CREAT);
 	if (fd < 0) {
 		perror("mkostemp");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	offset = 0;
@@ -73,17 +73,17 @@ int main(int argc, char *argv[])
 		io_uring_cqe_seen(&ring, cqe);
 		offset += 4096;
 	} while (--blocks);
-		
+
 	close(fd);
 	unlink(buf);
-	return 0;
+	return T_EXIT_PASS;
 err:
 	close(fd);
 	unlink(buf);
-	return 1;
+	return T_EXIT_FAIL;
 skipped:
 	fprintf(stderr, "Polling not supported in current dir, test skipped\n");
 	close(fd);
 	unlink(buf);
-	return 0;
+	return T_EXIT_SKIP;
 }

--- a/vendor/liburing/test/8a9973408177.c
+++ b/vendor/liburing/test/8a9973408177.c
@@ -7,6 +7,7 @@
 #include <fcntl.h>
 
 #include "liburing.h"
+#include "helpers.h"
 
 static int register_file(struct io_uring *ring)
 {
@@ -85,12 +86,12 @@ int main(int argc, char *argv[])
 	int ret;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	ret = io_uring_queue_init(8, &ring, 0);
 	if (ret) {
 		printf("ring setup failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	ret = register_file(&ring);
@@ -102,5 +103,5 @@ int main(int argc, char *argv[])
 		return ret;
 	}
 
-	return 0;
+	return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/917257daa0fe.c
+++ b/vendor/liburing/test/917257daa0fe.c
@@ -11,12 +11,13 @@
 #include <unistd.h>
 
 #include "liburing.h"
+#include "helpers.h"
 #include "../src/syscall.h"
 
 int main(int argc, char *argv[])
 {
   if (argc > 1)
-    return 0;
+    return T_EXIT_SKIP;
 
   mmap((void *) 0x20000000, 0x1000000, 3, 0x32, -1, 0);
 
@@ -49,5 +50,5 @@ int main(int argc, char *argv[])
   *(uint32_t*)0x2000006c = 0;
   *(uint64_t*)0x20000070 = 0;
   __sys_io_uring_setup(0x7a6, (struct io_uring_params *) 0x20000000UL);
-  return 0;
+  return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/Makefile
+++ b/vendor/liburing/test/Makefile
@@ -15,7 +15,7 @@ override CPPFLAGS += \
 	-I../src/include/ \
 	-include ../config-host.h
 
-CFLAGS ?= -g -O2 -Wall -Wextra
+CFLAGS ?= -g -O3 -Wall -Wextra
 XCFLAGS = -Wno-unused-parameter -Wno-sign-compare
 
 ifdef CONFIG_HAVE_STRINGOP_OVERFLOW
@@ -62,6 +62,7 @@ test_srcs := \
 	d4ae271dfaae.c \
 	d77a67ed5f27.c \
 	defer.c \
+	defer-taskrun.c \
 	double-poll-crash.c \
 	drop-submit.c \
 	eeed8b54e0df.c \
@@ -75,6 +76,7 @@ test_srcs := \
 	fadvise.c \
 	fallocate.c \
 	fc2a85cb02ef.c \
+	fd-pass.c \
 	file-register.c \
 	files-exit-hang-poll.c \
 	files-exit-hang-timeout.c \
@@ -88,7 +90,9 @@ test_srcs := \
 	hardlink.c \
 	io-cancel.c \
 	iopoll.c \
+	iopoll-leak.c \
 	io_uring_enter.c \
+	io_uring_passthrough.c \
 	io_uring_register.c \
 	io_uring_setup.c \
 	lfs-openat.c \
@@ -100,6 +104,7 @@ test_srcs := \
 	mkdir.c \
 	msg-ring.c \
 	multicqes_drain.c \
+	nolibc.c \
 	nop-all-sizes.c \
 	nop.c \
 	openat2.c \
@@ -116,6 +121,7 @@ test_srcs := \
 	poll-link.c \
 	poll-many.c \
 	poll-mshot-update.c \
+	poll-mshot-overflow.c \
 	poll-ring.c \
 	poll-v-poll.c \
 	pollfree.c \
@@ -124,6 +130,7 @@ test_srcs := \
 	read-write.c \
 	recv-msgall.c \
 	recv-msgall-stream.c \
+	recv-multishot.c \
 	register-restrictions.c \
 	rename.c \
 	ringbuf-read.c \
@@ -156,8 +163,10 @@ test_srcs := \
 	sqpoll-sleep.c \
 	sq-space_left.c \
 	stdout.c \
+	submit-and-wait.c \
 	submit-link-fail.c \
 	submit-reuse.c \
+	sync-cancel.c \
 	symlink.c \
 	teardowns.c \
 	thread-exit.c \
@@ -169,6 +178,8 @@ test_srcs := \
 	wakeup-hang.c \
 	xattr.c \
 	skip-cqe.c \
+	single-issuer.c \
+	send-zerocopy.c \
 	# EOL
 
 all_targets :=
@@ -192,21 +203,9 @@ test_targets := $(patsubst %.cc,%,$(test_targets))
 run_test_targets := $(patsubst %,%.run_test,$(test_targets))
 test_targets := $(patsubst %,%.t,$(test_targets))
 all_targets += $(test_targets)
-
-#
-# Build ../src/syscall.c manually from test's Makefile to support
-# liburing nolibc.
-#
-# Functions in ../src/syscall.c require libc to work with, if we
-# build liburing without libc, we don't have those functions
-# in liburing.a. So build it manually here.
-#
-helpers = helpers.o ../src/syscall.o
+helpers = helpers.o
 
 all: $(test_targets)
-
-../src/syscall.o: ../src/syscall.c
-	$(QUIET_CC)$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ -c $<
 
 helpers.o: helpers.c
 	$(QUIET_CC)$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ -c $<

--- a/vendor/liburing/test/a0908ae19763.c
+++ b/vendor/liburing/test/a0908ae19763.c
@@ -11,6 +11,7 @@
 #include <unistd.h>
 
 #include "liburing.h"
+#include "helpers.h"
 #include "../src/syscall.h"
 
 uint64_t r[1] = {0xffffffffffffffff};
@@ -18,7 +19,7 @@ uint64_t r[1] = {0xffffffffffffffff};
 int main(int argc, char *argv[])
 {
   if (argc > 1)
-    return 0;
+    return T_EXIT_SKIP;
   mmap((void *) 0x20000000, 0x1000000, 3, 0x32, -1, 0);
   intptr_t res = 0;
   *(uint32_t*)0x20000080 = 0;
@@ -54,5 +55,5 @@ int main(int argc, char *argv[])
     r[0] = res;
   *(uint32_t*)0x20000280 = -1;
   __sys_io_uring_register(r[0], 2, (const void *) 0x20000280, 1);
-  return 0;
+  return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/a4c0b3decb33.c
+++ b/vendor/liburing/test/a4c0b3decb33.c
@@ -21,6 +21,7 @@
 #include <unistd.h>
 
 #include "liburing.h"
+#include "helpers.h"
 #include "../src/syscall.h"
 
 static void sleep_ms(uint64_t ms)
@@ -172,9 +173,9 @@ static void sig_int(int sig)
 int main(int argc, char *argv[])
 {
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 	signal(SIGINT, sig_int);
 	mmap((void *) 0x20000000, 0x1000000, 3, 0x32, -1, 0);
 	loop();
-	return 0;
+	return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/accept-link.c
+++ b/vendor/liburing/test/accept-link.c
@@ -14,6 +14,7 @@
 #include <arpa/inet.h>
 
 #include "liburing.h"
+#include "helpers.h"
 
 pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
@@ -239,16 +240,16 @@ static int test_accept_timeout(int do_connect, unsigned long timeout)
 int main(int argc, char *argv[])
 {
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 	if (test_accept_timeout(0, 200000000)) {
 		fprintf(stderr, "accept timeout 0 failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	if (test_accept_timeout(1, 1000000000)) {
 		fprintf(stderr, "accept and connect timeout 0 failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
-	return 0;
+	return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/accept-reuse.c
+++ b/vendor/liburing/test/accept-reuse.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include "liburing.h"
+#include "helpers.h"
 #include "../src/syscall.h"
 
 struct io_uring io_uring;
@@ -25,7 +26,7 @@ int submit_sqe(void)
 	struct io_uring_sq *sq = &io_uring.sq;
 	const unsigned tail = *sq->ktail;
 
-	sq->array[tail & *sq->kring_mask] = 0;
+	sq->array[tail & sq->ring_mask] = 0;
 	io_uring_smp_store_release(sq->ktail, tail + 1);
 
 	return sys_io_uring_enter(io_uring.ring_fd, 1, 0, 0, NULL);
@@ -43,17 +44,17 @@ int main(int argc, char **argv)
 	int ret, listen_fd, connect_fd, val, i;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	memset(&params, 0, sizeof(params));
 	ret = io_uring_queue_init_params(4, &io_uring, &params);
 	if (ret) {
 		fprintf(stderr, "io_uring_init_failed: %d\n", ret);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 	if (!(params.features & IORING_FEAT_SUBMIT_STABLE)) {
 		fprintf(stdout, "FEAT_SUBMIT_STABLE not there, skipping\n");
-		return 0;
+		return T_EXIT_SKIP;
 	}
 
 	memset(&hints, 0, sizeof(hints));
@@ -64,7 +65,7 @@ int main(int argc, char **argv)
 	ret = getaddrinfo(NULL, "12345", &hints, &addr_info_list);
 	if (ret < 0) {
 		perror("getaddrinfo");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	for (ai = addr_info_list; ai; ai = ai->ai_next) {
@@ -75,7 +76,7 @@ int main(int argc, char **argv)
 	}
 	if (!addr_info) {
 		fprintf(stderr, "addrinfo not found\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	sqe = &io_uring.sq.sqes[0];
@@ -85,7 +86,7 @@ int main(int argc, char **argv)
 			   addr_info->ai_protocol);
 	if (ret < 0) {
 		perror("socket");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 	listen_fd = ret;
 
@@ -96,13 +97,13 @@ int main(int argc, char **argv)
 	ret = bind(listen_fd, addr_info->ai_addr, addr_info->ai_addrlen);
 	if (ret < 0) {
 		perror("bind");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	ret = listen(listen_fd, SOMAXCONN);
 	if (ret < 0) {
 		perror("listen");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	memset(&sa, 0, sizeof(sa));
@@ -112,14 +113,14 @@ int main(int argc, char **argv)
 	ret = submit_sqe();
 	if (ret != 1) {
 		fprintf(stderr, "submit failed: %d\n", ret);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	connect_fd = -1;
 	ret = socket(addr_info->ai_family, SOCK_STREAM, addr_info->ai_protocol);
 	if (ret < 0) {
 		perror("socket");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 	connect_fd = ret;
 
@@ -129,7 +130,7 @@ int main(int argc, char **argv)
 	ret = submit_sqe();
 	if (ret != 1) {
 		fprintf(stderr, "submit failed: %d\n", ret);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	for (i = 0; i < 2; i++) {
@@ -138,20 +139,20 @@ int main(int argc, char **argv)
 		ret = io_uring_wait_cqe(&io_uring, &cqe);
 		if (ret) {
 			fprintf(stderr, "io_uring_wait_cqe: %d\n", ret);
-			return 1;
+			return T_EXIT_FAIL;
 		}
 
 		switch (cqe->user_data) {
 		case 1:
 			if (cqe->res < 0) {
 				fprintf(stderr, "accept failed: %d\n", cqe->res);
-				return 1;
+				return T_EXIT_FAIL;
 			}
 			break;
 		case 2:
 			if (cqe->res) {
 				fprintf(stderr, "connect failed: %d\n", cqe->res);
-				return 1;
+				return T_EXIT_FAIL;
 			}
 			break;
 		}
@@ -160,5 +161,5 @@ int main(int argc, char **argv)
 
 	freeaddrinfo(addr_info_list);
 	io_uring_queue_exit(&io_uring);
-	return 0;
+	return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/accept-test.c
+++ b/vendor/liburing/test/accept-test.c
@@ -8,6 +8,7 @@
 #include <sys/un.h>
 #include <assert.h>
 #include "liburing.h"
+#include "helpers.h"
 
 int main(int argc, char *argv[])
 {
@@ -23,11 +24,11 @@ int main(int argc, char *argv[])
 	};
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	if (io_uring_queue_init(4, &ring, 0) != 0) {
 		fprintf(stderr, "ring setup failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	fd = socket(AF_UNIX, SOCK_STREAM, 0);
@@ -45,7 +46,7 @@ int main(int argc, char *argv[])
 	sqe = io_uring_get_sqe(&ring);
 	if (!sqe) {
 		fprintf(stderr, "get sqe failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 	io_uring_prep_accept(sqe, fd, (struct sockaddr*)&addr, &addrlen, 0);
 	sqe->user_data = 1;
@@ -53,27 +54,30 @@ int main(int argc, char *argv[])
 	ret = io_uring_submit(&ring);
 	if (ret != 1) {
 		fprintf(stderr, "Got submit %d, expected 1\n", ret);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	ret = io_uring_wait_cqe_timeout(&ring, &cqe, &ts);
 	if (!ret) {
 		if (cqe->res == -EBADF || cqe->res == -EINVAL) {
 			fprintf(stdout, "Accept not supported, skipping\n");
-			goto out;
+			goto skip;
 		} else if (cqe->res < 0) {
 			fprintf(stderr, "cqe error %d\n", cqe->res);
 			goto err;
 		}
 	} else if (ret != -ETIME) {
 		fprintf(stderr, "accept() failed to use addr & addrlen parameters!\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
-out:
 	io_uring_queue_exit(&ring);
-	return 0;
+	return T_EXIT_PASS;
+
+skip:
+	io_uring_queue_exit(&ring);
+	return T_EXIT_SKIP;
 err:
 	io_uring_queue_exit(&ring);
-	return 1;
+	return T_EXIT_FAIL;
 }

--- a/vendor/liburing/test/across-fork.c
+++ b/vendor/liburing/test/across-fork.c
@@ -15,6 +15,7 @@
 #include <unistd.h>
 
 #include "liburing.h"
+#include "helpers.h"
 
 
 struct forktestmem
@@ -141,13 +142,13 @@ int main(int argc, char *argv[])
 	pid_t p;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	shmem = mmap(0, sizeof(struct forktestmem), PROT_READ|PROT_WRITE,
 		   MAP_SHARED | MAP_ANONYMOUS, 0, 0);
 	if (!shmem) {
 		fprintf(stderr, "mmap failed\n");
-		exit(1);
+		exit(T_EXIT_FAIL);
 	}
 
 	pthread_barrierattr_init(&shmem->barrierattr);
@@ -157,12 +158,12 @@ int main(int argc, char *argv[])
 	ret = io_uring_queue_init(10, &shmem->ring, 0);
 	if (ret < 0) {
 		fprintf(stderr, "queue init failed\n");
-		exit(1);
+		exit(T_EXIT_FAIL);
 	}
 
 	if (mkdtemp(tmpdir) == NULL) {
 		fprintf(stderr, "temp directory creation failed\n");
-		exit(1);
+		exit(T_EXIT_FAIL);
 	}
 
 	shared_fd = open_tempfile(tmpdir, "shared");
@@ -275,9 +276,9 @@ int main(int argc, char *argv[])
 		goto errcleanup;
 
 	cleanup(tmpdir);
-	exit(0);
+	exit(T_EXIT_PASS);
 
 errcleanup:
 	cleanup(tmpdir);
-	exit(1);
+	exit(T_EXIT_FAIL);
 }

--- a/vendor/liburing/test/b19062a56726.c
+++ b/vendor/liburing/test/b19062a56726.c
@@ -11,12 +11,13 @@
 #include <unistd.h>
 
 #include "liburing.h"
+#include "helpers.h"
 #include "../src/syscall.h"
 
 int main(int argc, char *argv[])
 {
   if (argc > 1)
-    return 0;
+    return T_EXIT_SKIP;
 
   mmap((void *) 0x20000000, 0x1000000, 3, 0x32, -1, 0);
 
@@ -49,5 +50,5 @@ int main(int argc, char *argv[])
   *(uint32_t*)0x2000026c = 0;
   *(uint64_t*)0x20000270 = 0;
   __sys_io_uring_setup(0xc9f, (struct io_uring_params *) 0x20000200);
-  return 0;
+  return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/b5837bd5311d.c
+++ b/vendor/liburing/test/b5837bd5311d.c
@@ -4,6 +4,7 @@
  */
 #include <stdio.h>
 #include "liburing.h"
+#include "helpers.h"
 
 int main(int argc, char *argv[])
 {
@@ -17,11 +18,11 @@ int main(int argc, char *argv[])
 	};
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	if (io_uring_queue_init(4, &ring, 0) != 0) {
 		fprintf(stderr, "ring setup failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	/*
@@ -31,14 +32,14 @@ int main(int argc, char *argv[])
 	sqe = io_uring_get_sqe(&ring);
 	if (!sqe) {
 		fprintf(stderr, "get sqe failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 	io_uring_prep_timeout(sqe, &ts, (unsigned)-1, 0);
 
 	ret = io_uring_submit(&ring);
 	if (ret != 1) {
 		fprintf(stderr, "Got submit %d, expected 1\n", ret);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	/*
@@ -50,28 +51,28 @@ int main(int argc, char *argv[])
 	sqe = io_uring_get_sqe(&ring);
 	if (!sqe) {
 		fprintf(stderr, "get sqe failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 	io_uring_prep_nop(sqe);
 
 	ret = io_uring_submit_and_wait(&ring, 2);
 	if (ret != 1) {
 		fprintf(stderr, "Got submit %d, expected 1\n", ret);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	if (io_uring_peek_cqe(&ring, &cqe) != 0) {
 		fprintf(stderr, "Unable to peek cqe!\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	io_uring_cqe_seen(&ring, cqe);
 
 	if (io_uring_peek_cqe(&ring, &cqe) != 0) {
 		fprintf(stderr, "Unable to peek cqe!\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	io_uring_queue_exit(&ring);
-	return 0;
+	return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/ce593a6c480a.c
+++ b/vendor/liburing/test/ce593a6c480a.c
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
 	pthread_t tid;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	/* Create an eventfd to be registered with the loop to be
 	 * notified of events being ready
@@ -54,14 +54,14 @@ int main(int argc, char *argv[])
 	loop_fd = eventfd(0, EFD_CLOEXEC);
 	if (loop_fd == -1) {
 		fprintf(stderr, "eventfd errno=%d\n", errno);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	/* Create an eventfd that can create events */
 	use_fd = other_fd = eventfd(0, EFD_CLOEXEC);
 	if (other_fd == -1) {
 		fprintf(stderr, "eventfd errno=%d\n", errno);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	if (use_sqpoll)
@@ -70,21 +70,21 @@ int main(int argc, char *argv[])
 	/* Setup the ring with a registered event fd to be notified on events */
 	ret = t_create_ring_params(8, &ring, &p);
 	if (ret == T_SETUP_SKIP)
-		return 0;
+		return T_EXIT_PASS;
 	else if (ret < 0)
 		return ret;
 
 	ret = io_uring_register_eventfd(&ring, loop_fd);
 	if (ret < 0) {
 		fprintf(stderr, "register_eventfd=%d\n", ret);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	if (use_sqpoll) {
 		ret = io_uring_register_files(&ring, &other_fd, 1);
 		if (ret < 0) {
 			fprintf(stderr, "register_files=%d\n", ret);
-			return 1;
+			return T_EXIT_FAIL;
 		}
 		use_fd = 0;
 	}
@@ -98,7 +98,7 @@ int main(int argc, char *argv[])
 	ret = io_uring_submit(&ring);
 	if (ret != 1) {
 		fprintf(stderr, "submit=%d\n", ret);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	/*
@@ -111,13 +111,16 @@ int main(int argc, char *argv[])
 			(void*) (intptr_t) other_fd);
 
 	/* Wait on the event fd for an event to be ready */
-	ret = read(loop_fd, buf, 8);
+	do {
+		ret = read(loop_fd, buf, 8);
+	} while (ret < 0 && errno == EINTR);
+
 	if (ret < 0) {
 		perror("read");
-		return 1;
+		return T_EXIT_FAIL;
 	} else if (ret != 8) {
 		fprintf(stderr, "Odd-sized eventfd read: %d\n", ret);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 
@@ -128,9 +131,9 @@ int main(int argc, char *argv[])
 	}
 	if (cqe->res < 0) {
 		fprintf(stderr, "cqe->res=%d\n", cqe->res);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	io_uring_cqe_seen(&ring, cqe);
-	return 0;
+	return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/connect.c
+++ b/vendor/liburing/test/connect.c
@@ -17,6 +17,7 @@
 #include <arpa/inet.h>
 
 #include "liburing.h"
+#include "helpers.h"
 
 static int no_connect;
 static unsigned short use_port;
@@ -360,12 +361,12 @@ int main(int argc, char *argv[])
 	int ret;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	ret = io_uring_queue_init(8, &ring, 0);
 	if (ret) {
 		fprintf(stderr, "io_uring_queue_setup() = %d\n", ret);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	srand(getpid());
@@ -376,23 +377,23 @@ int main(int argc, char *argv[])
 	ret = test_connect_with_no_peer(&ring);
 	if (ret == -1) {
 		fprintf(stderr, "test_connect_with_no_peer(): failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 	if (no_connect)
-		return 0;
+		return T_EXIT_SKIP;
 
 	ret = test_connect(&ring);
 	if (ret == -1) {
 		fprintf(stderr, "test_connect(): failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	ret = test_connect_timeout(&ring);
 	if (ret == -1) {
 		fprintf(stderr, "test_connect_timeout(): failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	io_uring_queue_exit(&ring);
-	return 0;
+	return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/cq-full.c
+++ b/vendor/liburing/test/cq-full.c
@@ -11,6 +11,7 @@
 #include <fcntl.h>
 
 #include "liburing.h"
+#include "helpers.h"
 
 static int queue_n_nops(struct io_uring *ring, int n)
 {
@@ -49,13 +50,13 @@ int main(int argc, char *argv[])
 	int i, ret;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	memset(&p, 0, sizeof(p));
 	ret = io_uring_queue_init_params(4, &ring, &p);
 	if (ret) {
 		printf("ring setup failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 
 	}
 
@@ -89,8 +90,8 @@ int main(int argc, char *argv[])
 	}
 
 	io_uring_queue_exit(&ring);
-	return 0;
+	return T_EXIT_PASS;
 err:
 	io_uring_queue_exit(&ring);
-	return 1;
+	return T_EXIT_FAIL;
 }

--- a/vendor/liburing/test/cq-overflow.c
+++ b/vendor/liburing/test/cq-overflow.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#include <assert.h>
 
 #include "helpers.h"
 #include "liburing.h"
@@ -21,6 +22,32 @@ static struct iovec *vecs;
 
 #define ENTRIES	8
 
+/*
+ * io_uring has rare cases where CQEs are lost.
+ * This happens when there is no space in the CQ ring, and also there is no
+ * GFP_ATOMIC memory available. In reality this probably means that the process
+ * is about to be killed as many other things might start failing, but we still
+ * want to test that liburing and the kernel deal with this properly. The fault
+ * injection framework allows us to test this scenario. Unfortunately this
+ * requires some system wide changes and so we do not enable this by default.
+ * The tests in this file should work in both cases (where overflows are queued
+ * and where they are dropped) on recent kernels.
+ *
+ * In order to test dropped CQEs you should enable fault injection in the kernel
+ * config:
+ *
+ * CONFIG_FAULT_INJECTION=y
+ * CONFIG_FAILSLAB=y
+ * CONFIG_FAULT_INJECTION_DEBUG_FS=y
+ *
+ * and then run the test as follows:
+ * echo Y > /sys/kernel/debug/failslab/task-filter
+ * echo 100 > /sys/kernel/debug/failslab/probability
+ * echo 0 > /sys/kernel/debug/failslab/verbose
+ * echo 100000 > /sys/kernel/debug/failslab/times
+ * bash -c "echo 1 > /proc/self/make-it-fail && exec ./cq-overflow.t"
+ */
+
 static int test_io(const char *file, unsigned long usecs, unsigned *drops, int fault)
 {
 	struct io_uring_sqe *sqe;
@@ -29,18 +56,20 @@ static int test_io(const char *file, unsigned long usecs, unsigned *drops, int f
 	unsigned reaped, total;
 	struct io_uring ring;
 	int nodrop, i, fd, ret;
+	bool cqe_dropped = false;
 
 	fd = open(file, O_RDONLY | O_DIRECT);
 	if (fd < 0) {
 		perror("file open");
-		goto err;
+		return 1;
 	}
 
 	memset(&p, 0, sizeof(p));
 	ret = io_uring_queue_init_params(ENTRIES, &ring, &p);
 	if (ret) {
+		close(fd);
 		fprintf(stderr, "ring create failed: %d\n", ret);
-		goto err;
+		return 1;
 	}
 	nodrop = 0;
 	if (p.features & IORING_FEAT_NODROP)
@@ -103,8 +132,8 @@ static int test_io(const char *file, unsigned long usecs, unsigned *drops, int f
 reap_it:
 	reaped = 0;
 	do {
-		if (nodrop) {
-			/* nodrop should never lose events */
+		if (nodrop && !cqe_dropped) {
+			/* nodrop should never lose events unless cqe_dropped */
 			if (reaped == total)
 				break;
 		} else {
@@ -112,7 +141,10 @@ reap_it:
 				break;
 		}
 		ret = io_uring_wait_cqe(&ring, &cqe);
-		if (ret) {
+		if (nodrop && ret == -EBADR) {
+			cqe_dropped = true;
+			continue;
+		} else if (ret) {
 			fprintf(stderr, "wait_cqe=%d\n", ret);
 			goto err;
 		}
@@ -132,7 +164,7 @@ reap_it:
 		goto err;
 	}
 
-	if (!nodrop) {
+	if (!nodrop || cqe_dropped) {
 		*drops = *ring.cq.koverflow;
 	} else if (*ring.cq.koverflow) {
 		fprintf(stderr, "Found %u overflows\n", *ring.cq.koverflow);
@@ -153,18 +185,29 @@ static int reap_events(struct io_uring *ring, unsigned nr_events, int do_wait)
 {
 	struct io_uring_cqe *cqe;
 	int i, ret = 0, seq = 0;
+	unsigned int start_overflow = *ring->cq.koverflow;
+	bool dropped = false;
 
 	for (i = 0; i < nr_events; i++) {
 		if (do_wait)
 			ret = io_uring_wait_cqe(ring, &cqe);
 		else
 			ret = io_uring_peek_cqe(ring, &cqe);
-		if (ret) {
+		if (do_wait && ret == -EBADR) {
+			unsigned int this_drop = *ring->cq.koverflow -
+				start_overflow;
+
+			dropped = true;
+			start_overflow = *ring->cq.koverflow;
+			assert(this_drop > 0);
+			i += (this_drop - 1);
+			continue;
+		} else if (ret) {
 			if (ret != -EAGAIN)
 				fprintf(stderr, "cqe peek failed: %d\n", ret);
 			break;
 		}
-		if (cqe->user_data != seq) {
+		if (!dropped && cqe->user_data != seq) {
 			fprintf(stderr, "cqe sequence out-of-order\n");
 			fprintf(stderr, "got %d, wanted %d\n", (int) cqe->user_data,
 					seq);
@@ -241,19 +284,206 @@ err:
 	return 1;
 }
 
+
+static void submit_one_nop(struct io_uring *ring, int ud)
+{
+	struct io_uring_sqe *sqe;
+	int ret;
+
+	sqe = io_uring_get_sqe(ring);
+	assert(sqe);
+	io_uring_prep_nop(sqe);
+	sqe->user_data = ud;
+	ret = io_uring_submit(ring);
+	assert(ret == 1);
+}
+
+/*
+ * Create an overflow condition and ensure that SQEs are still processed
+ */
+static int test_overflow_handling(bool batch, int cqe_multiple, bool poll,
+				  bool defer)
+{
+	struct io_uring ring;
+	struct io_uring_params p;
+	int ret, i, j, ud, cqe_count;
+	unsigned int count;
+	int const N = 8;
+	int const LOOPS = 128;
+	int const QUEUE_LENGTH = 1024;
+	int completions[N];
+	int queue[QUEUE_LENGTH];
+	int queued = 0;
+	int outstanding = 0;
+	bool cqe_dropped = false;
+
+	memset(&completions, 0, sizeof(int) * N);
+	memset(&p, 0, sizeof(p));
+	p.cq_entries = 2 * cqe_multiple;
+	p.flags |= IORING_SETUP_CQSIZE;
+
+	if (poll)
+		p.flags |= IORING_SETUP_IOPOLL;
+
+	if (defer)
+		p.flags |= IORING_SETUP_SINGLE_ISSUER |
+			   IORING_SETUP_DEFER_TASKRUN;
+
+	ret = io_uring_queue_init_params(2, &ring, &p);
+	if (ret) {
+		fprintf(stderr, "io_uring_queue_init failed %d\n", ret);
+		return 1;
+	}
+
+	assert(p.cq_entries < N);
+	/* submit N SQEs, some should overflow */
+	for (i = 0; i < N; i++) {
+		submit_one_nop(&ring, i);
+		outstanding++;
+	}
+
+	for (i = 0; i < LOOPS; i++) {
+		struct io_uring_cqe *cqes[N];
+
+		if (io_uring_cq_has_overflow(&ring)) {
+			/*
+			 * Flush any overflowed CQEs and process those. Actively
+			 * flush these to make sure CQEs arrive in vague order
+			 * of being sent.
+			 */
+			ret = io_uring_get_events(&ring);
+			if (ret != 0) {
+				fprintf(stderr,
+					"io_uring_get_events returned %d\n",
+					ret);
+				goto err;
+			}
+		} else if (!cqe_dropped) {
+			for (j = 0; j < queued; j++) {
+				submit_one_nop(&ring, queue[j]);
+				outstanding++;
+			}
+			queued = 0;
+		}
+
+		/* We have lost some random cqes, stop if no remaining. */
+		if (cqe_dropped && outstanding == *ring.cq.koverflow)
+			break;
+
+		ret = io_uring_wait_cqe(&ring, &cqes[0]);
+		if (ret == -EBADR) {
+			cqe_dropped = true;
+			fprintf(stderr, "CQE dropped\n");
+			continue;
+		} else if (ret != 0) {
+			fprintf(stderr, "io_uring_wait_cqes failed %d\n", ret);
+			goto err;
+		}
+		cqe_count = 1;
+		if (batch) {
+			ret = io_uring_peek_batch_cqe(&ring, &cqes[0], 2);
+			if (ret < 0) {
+				fprintf(stderr,
+					"io_uring_peek_batch_cqe failed %d\n",
+					ret);
+				goto err;
+			}
+			cqe_count = ret;
+		}
+		for (j = 0; j < cqe_count; j++) {
+			assert(cqes[j]->user_data < N);
+			ud = cqes[j]->user_data;
+			completions[ud]++;
+			assert(queued < QUEUE_LENGTH);
+			queue[queued++] = (int)ud;
+		}
+		io_uring_cq_advance(&ring, cqe_count);
+		outstanding -= cqe_count;
+	}
+
+	/* See if there were any drops by flushing the CQ ring *and* overflow */
+	do {
+		struct io_uring_cqe *cqe;
+
+		ret = io_uring_get_events(&ring);
+		if (ret < 0) {
+			if (ret == -EBADR) {
+				fprintf(stderr, "CQE dropped\n");
+				cqe_dropped = true;
+				break;
+			}
+			goto err;
+		}
+		if (outstanding && !io_uring_cq_ready(&ring))
+			ret = io_uring_wait_cqe_timeout(&ring, &cqe, NULL);
+
+		if (ret && ret != -ETIME) {
+			if (ret == -EBADR) {
+				fprintf(stderr, "CQE dropped\n");
+				cqe_dropped = true;
+				break;
+			}
+			fprintf(stderr, "wait_cqe_timeout = %d\n", ret);
+			goto err;
+		}
+		count = io_uring_cq_ready(&ring);
+		io_uring_cq_advance(&ring, count);
+		outstanding -= count;
+	} while (count);
+
+	io_uring_queue_exit(&ring);
+
+	/* Make sure that completions come back in the same order they were
+	 * sent. If they come back unfairly then this will concentrate on a
+	 * couple of indices.
+	 */
+	for (i = 1; !cqe_dropped && i < N; i++) {
+		if (abs(completions[i] - completions[i - 1]) > 1) {
+			fprintf(stderr, "bad completion size %d %d\n",
+				completions[i], completions[i - 1]);
+			goto err;
+		}
+	}
+	return 0;
+err:
+	io_uring_queue_exit(&ring);
+	return 1;
+}
+
 int main(int argc, char *argv[])
 {
 	const char *fname = ".cq-overflow";
 	unsigned iters, drops;
 	unsigned long usecs;
 	int ret;
+	int i;
+	bool can_defer;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
+
+	can_defer = t_probe_defer_taskrun();
+	for (i = 0; i < 16; i++) {
+		bool batch = i & 1;
+		int mult = (i & 2) ? 1 : 2;
+		bool poll = i & 4;
+		bool defer = i & 8;
+
+		if (defer && !can_defer)
+			continue;
+
+		ret = test_overflow_handling(batch, mult, poll, defer);
+		if (ret) {
+			fprintf(stderr, "test_overflow_handling("
+				"batch=%d, mult=%d, poll=%d, defer=%d) failed\n",
+				batch, mult, poll, defer);
+			goto err;
+		}
+	}
 
 	ret = test_overflow();
 	if (ret) {
-		printf("test_overflow failed\n");
+		fprintf(stderr, "test_overflow failed\n");
 		return ret;
 	}
 
@@ -287,8 +517,8 @@ int main(int argc, char *argv[])
 	}
 
 	unlink(fname);
-	return 0;
+	return T_EXIT_PASS;
 err:
 	unlink(fname);
-	return 1;
+	return T_EXIT_FAIL;
 }

--- a/vendor/liburing/test/cq-peek-batch.c
+++ b/vendor/liburing/test/cq-peek-batch.c
@@ -11,6 +11,7 @@
 #include <fcntl.h>
 
 #include "liburing.h"
+#include "helpers.h"
 
 static int queue_n_nops(struct io_uring *ring, int n, int offset)
 {
@@ -58,12 +59,12 @@ int main(int argc, char *argv[])
 	unsigned got;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	ret = io_uring_queue_init(4, &ring, 0);
 	if (ret) {
 		printf("ring setup failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 
 	}
 
@@ -95,8 +96,8 @@ int main(int argc, char *argv[])
 
 	io_uring_cq_advance(&ring, 8);
 	io_uring_queue_exit(&ring);
-	return 0;
+	return T_EXIT_PASS;
 err:
 	io_uring_queue_exit(&ring);
-	return 1;
+	return T_EXIT_FAIL;
 }

--- a/vendor/liburing/test/cq-ready.c
+++ b/vendor/liburing/test/cq-ready.c
@@ -11,6 +11,7 @@
 #include <fcntl.h>
 
 #include "liburing.h"
+#include "helpers.h"
 
 static int queue_n_nops(struct io_uring *ring, int n)
 {
@@ -56,12 +57,12 @@ int main(int argc, char *argv[])
 	unsigned ready;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	ret = io_uring_queue_init(4, &ring, 0);
 	if (ret) {
 		printf("ring setup failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 
 	}
 
@@ -87,8 +88,8 @@ int main(int argc, char *argv[])
 	CHECK_READY(&ring, 0);
 
 	io_uring_queue_exit(&ring);
-	return 0;
+	return T_EXIT_PASS;
 err:
 	io_uring_queue_exit(&ring);
-	return 1;
+	return T_EXIT_FAIL;
 }

--- a/vendor/liburing/test/cq-size.c
+++ b/vendor/liburing/test/cq-size.c
@@ -10,6 +10,7 @@
 #include <fcntl.h>
 
 #include "liburing.h"
+#include "helpers.h"
 
 int main(int argc, char *argv[])
 {
@@ -18,7 +19,7 @@ int main(int argc, char *argv[])
 	int ret;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	memset(&p, 0, sizeof(p));
 	p.flags = IORING_SETUP_CQSIZE;
@@ -31,7 +32,7 @@ int main(int argc, char *argv[])
 			goto done;
 		}
 		printf("ring setup failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	if (p.cq_entries < 64) {
@@ -58,7 +59,7 @@ int main(int argc, char *argv[])
 	}
 
 done:
-	return 0;
+	return T_EXIT_PASS;
 err:
-	return 1;
+	return T_EXIT_FAIL;
 }

--- a/vendor/liburing/test/d4ae271dfaae.c
+++ b/vendor/liburing/test/d4ae271dfaae.c
@@ -31,9 +31,9 @@ int main(int argc, char *argv[])
 	p.flags = IORING_SETUP_SQPOLL;
 	ret = t_create_ring_params(4, &ring, &p);
 	if (ret == T_SETUP_SKIP)
-		return 0;
+		return T_EXIT_SKIP;
 	else if (ret < 0)
-		return 1;
+		return T_EXIT_FAIL;
 
 	if (argc > 1) {
 		fname = argv[1];

--- a/vendor/liburing/test/d77a67ed5f27.c
+++ b/vendor/liburing/test/d77a67ed5f27.c
@@ -22,7 +22,7 @@ int main(int argc, char *argv[])
 	int ret, data;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	signal(SIGALRM, sig_alrm);
 
@@ -31,9 +31,9 @@ int main(int argc, char *argv[])
 	p.flags = IORING_SETUP_SQPOLL;
 	ret = t_create_ring_params(4, &ring, &p);
 	if (ret == T_SETUP_SKIP)
-		return 0;
+		return T_EXIT_SKIP;
 	else if (ret < 0)
-		return 1;
+		return T_EXIT_FAIL;
 
 	/* make sure sq thread is sleeping at this point */
 	usleep(150000);
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
 	sqe = io_uring_get_sqe(&ring);
 	if (!sqe) {
 		fprintf(stderr, "sqe get failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	io_uring_prep_nop(sqe);
@@ -58,8 +58,8 @@ int main(int argc, char *argv[])
 	data = (unsigned long) io_uring_cqe_get_data(cqe);
 	if (data != 42) {
 		fprintf(stderr, "invalid data: %d\n", data);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
-	return 0;
+	return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/defer-taskrun.c
+++ b/vendor/liburing/test/defer-taskrun.c
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: MIT
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <error.h>
+#include <sys/eventfd.h>
+#include <signal.h>
+#include <poll.h>
+#include <assert.h>
+#include <pthread.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include "liburing.h"
+#include "test.h"
+#include "helpers.h"
+
+#define EXEC_FILENAME ".defer-taskrun"
+#define EXEC_FILESIZE (1U<<20)
+
+static bool can_read_t(int fd, int time)
+{
+	int ret;
+	struct pollfd p = {
+		.fd = fd,
+		.events = POLLIN,
+	};
+
+	ret = poll(&p, 1, time);
+
+	return ret == 1;
+}
+
+static bool can_read(int fd)
+{
+	return can_read_t(fd, 0);
+}
+
+static void eventfd_clear(int fd)
+{
+	uint64_t val;
+	int ret;
+
+	assert(can_read(fd));
+	ret = read(fd, &val, 8);
+	assert(ret == 8);
+}
+
+static void eventfd_trigger(int fd)
+{
+	uint64_t val = 1;
+	int ret;
+
+	ret = write(fd, &val, sizeof(val));
+	assert(ret == sizeof(val));
+}
+
+#define CHECK(x) if (!(x)) { \
+		fprintf(stderr, "%s:%d %s failed\n", __FILE__, __LINE__, #x); \
+		return -1; }
+
+static int test_eventfd(void)
+{
+	struct io_uring ring;
+	int ret;
+	int fda, fdb;
+	struct io_uring_cqe *cqe;
+
+	ret = io_uring_queue_init(8, &ring, IORING_SETUP_SINGLE_ISSUER |
+					    IORING_SETUP_DEFER_TASKRUN);
+	if (ret)
+		return ret;
+
+	fda = eventfd(0, EFD_NONBLOCK);
+	fdb = eventfd(0, EFD_NONBLOCK);
+
+	CHECK(fda >= 0 && fdb >= 0);
+
+	ret = io_uring_register_eventfd(&ring, fda);
+	if (ret)
+		return ret;
+
+	CHECK(!can_read(fda));
+	CHECK(!can_read(fdb));
+
+	io_uring_prep_poll_add(io_uring_get_sqe(&ring), fdb, POLLIN);
+	io_uring_submit(&ring);
+	CHECK(!can_read(fda)); /* poll should not have completed */
+
+	io_uring_prep_nop(io_uring_get_sqe(&ring));
+	io_uring_submit(&ring);
+	CHECK(can_read(fda)); /* nop should have */
+
+	CHECK(io_uring_peek_cqe(&ring, &cqe) == 0);
+	CHECK(cqe->res == 0);
+	io_uring_cqe_seen(&ring, cqe);
+	eventfd_clear(fda);
+
+	eventfd_trigger(fdb);
+	/* can take time due to rcu_call */
+	CHECK(can_read_t(fda, 1000));
+
+	/* should not have processed the cqe yet */
+	CHECK(io_uring_cq_ready(&ring) == 0);
+
+	io_uring_get_events(&ring);
+	CHECK(io_uring_cq_ready(&ring) == 1);
+
+
+	io_uring_queue_exit(&ring);
+	return 0;
+}
+
+struct thread_data {
+	struct io_uring ring;
+	int efd;
+	char buff[8];
+};
+
+void *thread(void *t)
+{
+	struct thread_data *td = t;
+
+	io_uring_enable_rings(&td->ring);
+	io_uring_prep_read(io_uring_get_sqe(&td->ring), td->efd, td->buff, sizeof(td->buff), 0);
+	io_uring_submit(&td->ring);
+
+	return NULL;
+}
+
+static int test_thread_shutdown(void)
+{
+	pthread_t t1;
+	int ret;
+	struct thread_data td;
+	struct io_uring_cqe *cqe;
+	uint64_t val = 1;
+
+	ret = io_uring_queue_init(8, &td.ring, IORING_SETUP_SINGLE_ISSUER |
+					       IORING_SETUP_DEFER_TASKRUN |
+					       IORING_SETUP_R_DISABLED);
+	if (ret)
+		return ret;
+
+	CHECK(io_uring_get_events(&td.ring) == -EBADFD);
+
+	td.efd = eventfd(0, 0);
+	CHECK(td.efd >= 0);
+
+	CHECK(pthread_create(&t1, NULL, thread, &td) == 0);
+	CHECK(pthread_join(t1, NULL) == 0);
+
+	CHECK(io_uring_get_events(&td.ring) == -EEXIST);
+
+	CHECK(write(td.efd, &val, sizeof(val)) == sizeof(val));
+	CHECK(io_uring_wait_cqe(&td.ring, &cqe) == -EEXIST);
+
+	close(td.efd);
+	io_uring_queue_exit(&td.ring);
+	return 0;
+}
+
+static int test_exec(const char *filename)
+{
+	int ret;
+	int fd;
+	struct io_uring ring;
+	pid_t fork_pid;
+	static char * const new_argv[] = {"1", "2", "3", NULL};
+	static char * const new_env[] = {NULL};
+	char *buff;
+
+	fork_pid = fork();
+	CHECK(fork_pid >= 0);
+	if (fork_pid > 0) {
+		int wstatus;
+
+		CHECK(waitpid(fork_pid, &wstatus, 0) != (pid_t)-1);
+		if (!WIFEXITED(wstatus) || WEXITSTATUS(wstatus) != T_EXIT_SKIP) {
+			fprintf(stderr, "child failed %i\n", WEXITSTATUS(wstatus));
+			return -1;
+		}
+		return 0;
+	}
+
+	ret = io_uring_queue_init(8, &ring, IORING_SETUP_SINGLE_ISSUER |
+					    IORING_SETUP_DEFER_TASKRUN);
+	if (ret)
+		return ret;
+
+	if (filename) {
+		fd = open(filename, O_RDONLY | O_DIRECT);
+	} else {
+		t_create_file(EXEC_FILENAME, EXEC_FILESIZE);
+		fd = open(EXEC_FILENAME, O_RDONLY | O_DIRECT);
+		unlink(EXEC_FILENAME);
+	}
+	buff = (char*)malloc(EXEC_FILESIZE);
+	CHECK(posix_memalign((void **)&buff, 4096, EXEC_FILESIZE) == 0);
+	CHECK(buff);
+
+	CHECK(fd >= 0);
+	io_uring_prep_read(io_uring_get_sqe(&ring), fd, buff, EXEC_FILESIZE, 0);
+	io_uring_submit(&ring);
+	ret = execve("/proc/self/exe", new_argv, new_env);
+	/* if we get here it failed anyway */
+	fprintf(stderr, "execve failed %d\n", ret);
+	return -1;
+}
+
+static int test_flag(void)
+{
+	struct io_uring ring;
+	int ret;
+	int fd;
+	struct io_uring_cqe *cqe;
+
+	ret = io_uring_queue_init(8, &ring, IORING_SETUP_SINGLE_ISSUER |
+					    IORING_SETUP_DEFER_TASKRUN |
+					    IORING_SETUP_TASKRUN_FLAG);
+	CHECK(!ret);
+
+	fd = eventfd(0, EFD_NONBLOCK);
+	CHECK(fd >= 0);
+
+	io_uring_prep_poll_add(io_uring_get_sqe(&ring), fd, POLLIN);
+	io_uring_submit(&ring);
+	CHECK(!can_read(fd)); /* poll should not have completed */
+
+	eventfd_trigger(fd);
+	CHECK(can_read(fd));
+
+	/* should not have processed the poll cqe yet */
+	CHECK(io_uring_cq_ready(&ring) == 0);
+
+	/* flag should be set */
+	CHECK(IO_URING_READ_ONCE(*ring.sq.kflags) & IORING_SQ_TASKRUN);
+
+	/* Specifically peek, knowing we have only no cqe
+	 * but because the flag is set, liburing should try and get more
+	 */
+	ret = io_uring_peek_cqe(&ring, &cqe);
+
+	CHECK(ret == 0 && cqe);
+	CHECK(!(IO_URING_READ_ONCE(*ring.sq.kflags) & IORING_SQ_TASKRUN));
+
+	close(fd);
+	io_uring_queue_exit(&ring);
+	return 0;
+}
+
+static int test_ring_shutdown(void)
+{
+	struct io_uring ring;
+	int ret;
+	int fd[2];
+	char buff = '\0';
+	char send = 'X';
+
+	ret = io_uring_queue_init(8, &ring, IORING_SETUP_SINGLE_ISSUER |
+					    IORING_SETUP_DEFER_TASKRUN |
+					    IORING_SETUP_TASKRUN_FLAG);
+	CHECK(!ret);
+
+	ret = t_create_socket_pair(fd, true);
+	CHECK(!ret);
+
+	io_uring_prep_recv(io_uring_get_sqe(&ring), fd[0], &buff, 1, 0);
+	io_uring_submit(&ring);
+
+	ret = write(fd[1], &send, 1);
+	CHECK(ret == 1);
+
+	/* should not have processed the poll cqe yet */
+	CHECK(io_uring_cq_ready(&ring) == 0);
+	io_uring_queue_exit(&ring);
+
+	/* task work should have been processed by now */
+	CHECK(buff = 'X');
+
+	return 0;
+}
+
+int main(int argc, char *argv[])
+{
+	int ret;
+	const char *filename = NULL;
+
+	if (argc > 2)
+		return T_EXIT_SKIP;
+	if (argc == 2) {
+		/* This test exposes interesting behaviour with a null-blk
+		 * device configured like:
+		 * $ modprobe null-blk completion_nsec=100000000 irqmode=2
+		 * and then run with $ defer-taskrun.t /dev/nullb0
+		 */
+		filename = argv[1];
+	}
+
+	if (!t_probe_defer_taskrun())
+		return T_EXIT_SKIP;
+
+	ret = test_thread_shutdown();
+	if (ret) {
+		fprintf(stderr, "test_thread_shutdown failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	ret = test_exec(filename);
+	if (ret) {
+		fprintf(stderr, "test_exec failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	ret = test_eventfd();
+	if (ret) {
+		fprintf(stderr, "eventfd failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	ret = test_flag();
+	if (ret) {
+		fprintf(stderr, "flag failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	ret = test_ring_shutdown();
+	if (ret) {
+		fprintf(stderr, "test_ring_shutdown failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	return T_EXIT_PASS;
+}

--- a/vendor/liburing/test/defer.c
+++ b/vendor/liburing/test/defer.c
@@ -260,19 +260,19 @@ int main(int argc, char *argv[])
 	int ret;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	memset(&p, 0, sizeof(p));
 	ret = io_uring_queue_init_params(RING_SIZE, &ring, &p);
 	if (ret) {
 		printf("ring setup failed %i\n", ret);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	ret = io_uring_queue_init(RING_SIZE, &poll_ring, IORING_SETUP_IOPOLL);
 	if (ret) {
 		printf("poll_ring setup failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 
@@ -305,9 +305,9 @@ int main(int argc, char *argv[])
 	ret = t_create_ring(RING_SIZE, &sqthread_ring,
 				IORING_SETUP_SQPOLL | IORING_SETUP_IOPOLL);
 	if (ret == T_SETUP_SKIP)
-		return 0;
+		return T_EXIT_SKIP;
 	else if (ret < 0)
-		return 1;
+		return T_EXIT_FAIL;
 
 	ret = test_thread_link_cancel(&sqthread_ring);
 	if (ret) {
@@ -315,5 +315,5 @@ int main(int argc, char *argv[])
 		return ret;
 	}
 
-	return 0;
+	return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/double-poll-crash.c
+++ b/vendor/liburing/test/double-poll-crash.c
@@ -15,6 +15,7 @@
 #include <unistd.h>
 
 #include "liburing.h"
+#include "helpers.h"
 #include "../src/syscall.h"
 
 #define SIZEOF_IO_URING_SQE 64
@@ -114,18 +115,18 @@ int main(int argc, char *argv[])
 {
   void *mmap_ret;
 #if !defined(__i386) && !defined(__x86_64__)
-  return 0;
+  return T_EXIT_SKIP;
 #endif
 
   if (argc > 1)
-    return 0;
+    return T_EXIT_SKIP;
 
   mmap_ret = mmap((void *)0x20000000ul, 0x1000000ul, 7ul, 0x32ul, -1, 0ul);
   if (mmap_ret == MAP_FAILED)
-    return 0;
+    return T_EXIT_SKIP;
   mmap_ret = mmap((void *)0x21000000ul, 0x1000ul, 0ul, 0x32ul, -1, 0ul);
   if (mmap_ret == MAP_FAILED)
-    return 0;
+    return T_EXIT_SKIP;
   intptr_t res = 0;
   *(uint32_t*)0x20000484 = 0;
   *(uint32_t*)0x20000488 = 0;
@@ -190,5 +191,5 @@ int main(int argc, char *argv[])
                             "\xbd\x43\x7d\x16\x69\x3e\x05",
          19);
   ioctl(r[3], 0x5404, 0x20000080ul);
-  return 0;
+  return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/drop-submit.c
+++ b/vendor/liburing/test/drop-submit.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 
 #include "liburing.h"
+#include "helpers.h"
 
 static int test(struct io_uring *ring, int expect_drops)
 {
@@ -63,7 +64,7 @@ int main(int argc, char *argv[])
 	int ret;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	ret = io_uring_queue_init(8, &ring, IORING_SETUP_SUBMIT_ALL);
 	if (ret)
@@ -80,7 +81,7 @@ int main(int argc, char *argv[])
 	ret = io_uring_queue_init(8, &ring, 0);
 	if (ret) {
 		fprintf(stderr, "ring setup failed\n");
-		return 0;
+		return T_EXIT_FAIL;
 	}
 
 	ret = test(&ring, 1);
@@ -89,5 +90,5 @@ int main(int argc, char *argv[])
 		return ret;
 	}
 
-	return 0;
+	return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/eeed8b54e0df.c
+++ b/vendor/liburing/test/eeed8b54e0df.c
@@ -33,6 +33,7 @@ static int get_file_fd(void)
 	}
 
 	buf = t_malloc(BLOCK);
+	memset(buf, 0, BLOCK);
 	ret = write(fd, buf, BLOCK);
 	if (ret != BLOCK) {
 		if (ret < 0)
@@ -64,7 +65,7 @@ int main(int argc, char *argv[])
 	int ret, fd;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	iov.iov_base = t_malloc(4096);
 	iov.iov_len = 4096;
@@ -72,19 +73,19 @@ int main(int argc, char *argv[])
 	ret = io_uring_queue_init(2, &ring, 0);
 	if (ret) {
 		printf("ring setup failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 
 	}
 
 	sqe = io_uring_get_sqe(&ring);
 	if (!sqe) {
 		printf("get sqe failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	fd = get_file_fd();
 	if (fd < 0)
-		return 1;
+		return T_EXIT_FAIL;
 
 	io_uring_prep_readv(sqe, fd, &iov, 1, 0);
 	sqe->rw_flags = RWF_NOWAIT;
@@ -107,8 +108,8 @@ int main(int argc, char *argv[])
 	}
 
 	close(fd);
-	return 0;
+	return T_EXIT_PASS;
 err:
 	close(fd);
-	return 1;
+	return T_EXIT_FAIL;
 }

--- a/vendor/liburing/test/empty-eownerdead.c
+++ b/vendor/liburing/test/empty-eownerdead.c
@@ -17,14 +17,14 @@ int main(int argc, char *argv[])
 	int ret;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	p.flags = IORING_SETUP_SQPOLL;
 	p.sq_thread_idle = 100;
 
 	ret = t_create_ring_params(1, &ring, &p);
 	if (ret == T_SETUP_SKIP)
-		return 0;
+		return T_EXIT_SKIP;
 	else if (ret < 0)
 		goto err;
 
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
 		goto err;
 	}
 
-	return 0;
+	return T_EXIT_PASS;
 err:
-	return 1;
+	return T_EXIT_FAIL;
 }

--- a/vendor/liburing/test/exit-no-cleanup.c
+++ b/vendor/liburing/test/exit-no-cleanup.c
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
 	const uint64_t n = 0x42;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	cpus = get_nprocs();
 	res = pthread_barrier_init(&init_barrier, NULL, cpus);

--- a/vendor/liburing/test/fadvise.c
+++ b/vendor/liburing/test/fadvise.c
@@ -73,7 +73,7 @@ static int do_fadvise(struct io_uring *ring, int fd, off_t offset, off_t len,
 	if (ret == -EINVAL || ret == -EBADF) {
 		fprintf(stdout, "Fadvise not supported, skipping\n");
 		unlink(".fadvise.tmp");
-		exit(0);
+		exit(T_EXIT_SKIP);
 	} else if (ret) {
 		fprintf(stderr, "cqe->res=%d\n", cqe->res);
 	}
@@ -194,9 +194,9 @@ int main(int argc, char *argv[])
 	if (fname != argv[1])
 		unlink(fname);
 	io_uring_queue_exit(&ring);
-	return 0;
+	return T_EXIT_PASS;
 err:
 	if (fname != argv[1])
 		unlink(fname);
-	return 1;
+	return T_EXIT_FAIL;
 }

--- a/vendor/liburing/test/fallocate.c
+++ b/vendor/liburing/test/fallocate.c
@@ -14,6 +14,7 @@
 #include <fcntl.h>
 
 #include "liburing.h"
+#include "helpers.h"
 
 static int no_fallocate;
 
@@ -66,14 +67,15 @@ static int test_fallocate_rlimit(struct io_uring *ring)
 	if (cqe->res == -EINVAL) {
 		fprintf(stdout, "Fallocate not supported, skipping\n");
 		no_fallocate = 1;
-		goto out;
+		goto skip;
 	} else if (cqe->res != -EFBIG) {
 		fprintf(stderr, "Expected -EFBIG: %d\n", cqe->res);
 		goto err;
 	}
 	io_uring_cqe_seen(ring, cqe);
-out:
 	return 0;
+skip:
+	return T_EXIT_SKIP;
 err:
 	return 1;
 }
@@ -116,7 +118,7 @@ static int test_fallocate(struct io_uring *ring)
 	if (cqe->res == -EINVAL) {
 		fprintf(stdout, "Fallocate not supported, skipping\n");
 		no_fallocate = 1;
-		goto out;
+		goto skip;
 	}
 	if (cqe->res) {
 		fprintf(stderr, "cqe->res=%d\n", cqe->res);
@@ -135,8 +137,9 @@ static int test_fallocate(struct io_uring *ring)
 		goto err;
 	}
 
-out:
 	return 0;
+skip:
+	return T_EXIT_SKIP;
 err:
 	return 1;
 }
@@ -219,17 +222,19 @@ int main(int argc, char *argv[])
 	int ret;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	ret = io_uring_queue_init(8, &ring, 0);
 	if (ret) {
 		fprintf(stderr, "ring setup failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	ret = test_fallocate(&ring);
 	if (ret) {
-		fprintf(stderr, "test_fallocate failed\n");
+		if (ret != T_EXIT_SKIP) {
+			fprintf(stderr, "test_fallocate failed\n");
+		}
 		return ret;
 	}
 
@@ -241,9 +246,11 @@ int main(int argc, char *argv[])
 
 	ret = test_fallocate_rlimit(&ring);
 	if (ret) {
-		fprintf(stderr, "test_fallocate_rlimit failed\n");
+		if (ret != T_EXIT_SKIP) {
+			fprintf(stderr, "test_fallocate_rlimit failed\n");
+		}
 		return ret;
 	}
 
-	return 0;
+	return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/fc2a85cb02ef.c
+++ b/vendor/liburing/test/fc2a85cb02ef.c
@@ -16,6 +16,7 @@
 #include <unistd.h>
 
 #include "liburing.h"
+#include "helpers.h"
 #include "../src/syscall.h"
 
 static bool write_file(const char* file, const char* what, ...)
@@ -83,11 +84,11 @@ uint64_t r[2] = {0xffffffffffffffff, 0xffffffffffffffff};
 int main(int argc, char *argv[])
 {
   if (argc > 1)
-    return 0;
+    return T_EXIT_SKIP;
   mmap((void *) 0x20000000ul, 0x1000000ul, 3ul, 0x32ul, -1, 0);
   if (setup_fault()) {
     printf("Test needs failslab/fail_futex/fail_page_alloc enabled, skipped\n");
-    return 0;
+    return T_EXIT_SKIP;
   }
   intptr_t res = 0;
   *(uint32_t*)0x20000000 = 0;
@@ -127,5 +128,5 @@ int main(int argc, char *argv[])
   *(uint32_t*)0x20000080 = r[1];
   inject_fault(1);
   __sys_io_uring_register(r[0], 2ul, (const void *) 0x20000080ul, 1ul);
-  return 0;
+  return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/fd-pass.c
+++ b/vendor/liburing/test/fd-pass.c
@@ -1,0 +1,187 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Description: run various fixed file fd passing tests
+ *
+ */
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+
+#include "liburing.h"
+#include "helpers.h"
+
+#define FSIZE	128
+#define PAT	0x9a
+
+static int no_fd_pass;
+
+static int verify_fixed_read(struct io_uring *ring, int fixed_fd, int fail)
+{
+	struct io_uring_sqe *sqe;
+	struct io_uring_cqe *cqe;
+	unsigned char buf[FSIZE];
+	int i;
+	
+	sqe = io_uring_get_sqe(ring);
+	io_uring_prep_read(sqe, fixed_fd, buf, FSIZE, 0);
+	sqe->flags |= IOSQE_FIXED_FILE;
+	io_uring_submit(ring);
+
+	io_uring_wait_cqe(ring, &cqe);
+	if (cqe->res != FSIZE) {
+		if (fail && cqe->res == -EBADF)
+			return 0;
+		fprintf(stderr, "Read: %d\n", cqe->res);
+		return 1;
+	}
+	io_uring_cqe_seen(ring, cqe);
+
+	for (i = 0; i < FSIZE; i++) {
+		if (buf[i] != PAT) {
+			fprintf(stderr, "got %x, wanted %x\n", buf[i], PAT);
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+static int test(const char *filename)
+{
+	struct io_uring sring, dring;
+	struct io_uring_sqe *sqe;
+	struct io_uring_cqe *cqe;
+	int ret;
+
+	ret = io_uring_queue_init(8, &sring, 0);
+	if (ret) {
+		fprintf(stderr, "ring setup failed: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+	ret = io_uring_queue_init(8, &dring, 0);
+	if (ret) {
+		fprintf(stderr, "ring setup failed: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	ret = io_uring_register_files_sparse(&sring, 8);
+	if (ret) {
+		if (ret == -EINVAL)
+			return T_EXIT_SKIP;
+		fprintf(stderr, "register files failed %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+	ret = io_uring_register_files_sparse(&dring, 8);
+	if (ret) {
+		fprintf(stderr, "register files failed %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	/* open direct descriptor */
+	sqe = io_uring_get_sqe(&sring);
+	io_uring_prep_openat_direct(sqe, AT_FDCWD, filename, 0, 0644, 0);
+	io_uring_submit(&sring);
+	ret = io_uring_wait_cqe(&sring, &cqe);
+	if (ret) {
+		fprintf(stderr, "wait cqe failed %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+	if (cqe->res) {
+		fprintf(stderr, "cqe res %d\n", cqe->res);
+		return T_EXIT_FAIL;
+	}
+	io_uring_cqe_seen(&sring, cqe);
+
+	/* verify data is sane for source ring */
+	if (verify_fixed_read(&sring, 0, 0))
+		return T_EXIT_FAIL;
+
+	/* send direct descriptor to destination ring */
+	sqe = io_uring_get_sqe(&sring);
+	io_uring_prep_msg_ring(sqe, dring.ring_fd, 0, 0x89, 0);
+	sqe->addr = 1;
+	sqe->addr3 = 0;
+	sqe->file_index = 1;
+	io_uring_submit(&sring);
+
+	ret = io_uring_wait_cqe(&sring, &cqe);
+	if (ret) {
+		fprintf(stderr, "wait cqe failed %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+	if (cqe->res) {
+		if (cqe->res == -EINVAL && !no_fd_pass) {
+			no_fd_pass = 1;
+			return T_EXIT_SKIP;
+		}
+		fprintf(stderr, "msg_ring failed %d\n", cqe->res);
+		return T_EXIT_FAIL;
+	}
+	io_uring_cqe_seen(&sring, cqe);
+
+	/* get posted completion for the passing */
+	ret = io_uring_wait_cqe(&dring, &cqe);
+	if (ret) {
+		fprintf(stderr, "wait cqe failed %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+	if (cqe->user_data != 0x89) {
+		fprintf(stderr, "bad user_data %ld\n", (long) cqe->res);
+		return T_EXIT_FAIL;
+	}
+	io_uring_cqe_seen(&dring, cqe);
+
+	/* now verify we can read the sane data from the destination ring */
+	if (verify_fixed_read(&dring, 0, 0))
+		return T_EXIT_FAIL;
+
+	/* close descriptor in source ring */
+	sqe = io_uring_get_sqe(&sring);
+	io_uring_prep_close_direct(sqe, 0);
+	io_uring_submit(&sring);
+
+	ret = io_uring_wait_cqe(&sring, &cqe);
+	if (ret) {
+		fprintf(stderr, "wait cqe failed %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+	if (cqe->res) {
+		fprintf(stderr, "direct close failed %d\n", cqe->res);
+		return T_EXIT_FAIL;
+	}
+	io_uring_cqe_seen(&sring, cqe);
+
+	/* check that source ring fails after close */
+	if (verify_fixed_read(&sring, 0, 1))
+		return T_EXIT_FAIL;
+
+	/* check we can still read from destination ring */
+	if (verify_fixed_read(&dring, 0, 0))
+		return T_EXIT_FAIL;
+
+	return T_EXIT_PASS;
+}
+
+int main(int argc, char *argv[])
+{
+	char fname[80];
+	int ret;
+
+	if (argc > 1)
+		return T_EXIT_SKIP;
+
+	sprintf(fname, ".fd-pass.%d", getpid());
+	t_create_file_pattern(fname, FSIZE, PAT);
+
+	ret = test(fname);
+	if (ret == T_EXIT_FAIL) {
+		fprintf(stderr, "test failed\n");
+		ret = T_EXIT_FAIL;
+	}
+
+	unlink(fname);
+	return ret;
+}

--- a/vendor/liburing/test/file-update.c
+++ b/vendor/liburing/test/file-update.c
@@ -131,9 +131,59 @@ static int test_sqe_update(struct io_uring *ring)
 	free(fds);
 	if (ret == -EINVAL) {
 		fprintf(stdout, "IORING_OP_FILES_UPDATE not supported, skipping\n");
-		return 0;
+		return T_EXIT_SKIP;
 	}
 	return ret != 10;
+}
+
+static int test_update_no_table(void)
+{
+	int up_fd, fds[4] = {-1, 0, 1, 4};
+	struct io_uring_sqe *sqe;
+	struct io_uring_cqe *cqe;
+	struct io_uring ring;
+	int ret;
+
+	ret = t_create_ring(2, &ring, 0);
+	if (ret == T_SETUP_SKIP)
+		return T_EXIT_SKIP;
+	else if (ret != T_SETUP_OK)
+		return ret;
+
+	ret = io_uring_register_files(&ring, fds, 4);
+	/* ignore other failures */
+	if (ret && ret != -EBADF) {
+		fprintf(stderr, "Failed registering file table: %d\n", ret);
+		goto fail;
+	}
+
+	sqe = io_uring_get_sqe(&ring);
+	up_fd = ring.ring_fd;
+	io_uring_prep_files_update(sqe, &up_fd, 1, -1); //offset = -1
+	ret = io_uring_submit(&ring);
+	if (ret != 1) {
+		fprintf(stderr, "Failed submit: %d\n", ret);
+		goto fail;
+	}
+
+	ret = io_uring_wait_cqe(&ring, &cqe);
+	if (ret) {
+		fprintf(stderr, "Failed wait: %d\n", ret);
+		goto fail;
+	}
+	ret = cqe->res;
+	io_uring_cqe_seen(&ring, cqe);
+	if (ret != -EMFILE && ret != -EINVAL && ret != -EOVERFLOW &&
+	    ret != -ENXIO) {
+		fprintf(stderr, "Bad cqe res: %d\n", ret);
+		goto fail;
+	}
+
+	io_uring_queue_exit(&ring);
+	return T_EXIT_PASS;
+fail:
+	io_uring_queue_exit(&ring);
+	return T_EXIT_FAIL;
 }
 
 int main(int argc, char *argv[])
@@ -142,7 +192,7 @@ int main(int argc, char *argv[])
 	int ret;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	if (io_uring_queue_init(8, &r1, 0) ||
 	    io_uring_queue_init(8, &r2, 0) ||
@@ -165,9 +215,17 @@ int main(int argc, char *argv[])
 
 	ret = test_sqe_update(&r1);
 	if (ret) {
-		fprintf(stderr, "test_sqe_update failed\n");
+		if (ret != T_EXIT_SKIP)
+			fprintf(stderr, "test_sqe_update failed\n");
 		return ret;
 	}
 
-	return 0;
+	ret = test_update_no_table();
+	if (ret) {
+		if (ret != T_EXIT_SKIP)
+			fprintf(stderr, "test_sqe_update failed\n");
+		return ret;
+	}
+
+	return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/file-verify.c
+++ b/vendor/liburing/test/file-verify.c
@@ -430,6 +430,10 @@ static int test(struct io_uring *ring, const char *fname, int buffered,
 				fprintf(stderr, "bad read %d, read %d\n", cqe->res, i);
 				goto err;
 			}
+			if (cqe->res < CHUNK_SIZE) {
+				fprintf(stderr, "short read %d, read %d\n", cqe->res, i);
+				goto err;
+			}
 			if (cqe->flags & IORING_CQE_F_BUFFER)
 				index = cqe->flags >> 16;
 			else
@@ -621,9 +625,9 @@ int main(int argc, char *argv[])
 
 	if (buf == fname)
 		unlink(fname);
-	return 0;
+	return T_EXIT_PASS;
 err:
 	if (buf == fname)
 		unlink(fname);
-	return 1;
+	return T_EXIT_FAIL;
 }

--- a/vendor/liburing/test/files-exit-hang-poll.c
+++ b/vendor/liburing/test/files-exit-hang-poll.c
@@ -15,10 +15,9 @@
 #include <unistd.h>
 #include <poll.h>
 #include "liburing.h"
+#include "helpers.h"
 
 #define BACKLOG 512
-
-#define PORT 9100
 
 static struct io_uring ring;
 
@@ -63,15 +62,14 @@ int main(int argc, char *argv[])
 	struct io_uring_cqe *cqe;
 	int ret, sock_listen_fd;
 	const int val = 1;
-	int i;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	sock_listen_fd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
 	if (sock_listen_fd < 0) {
 		perror("socket");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	setsockopt(sock_listen_fd, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
@@ -80,29 +78,18 @@ int main(int argc, char *argv[])
 	serv_addr.sin_family = AF_INET;
 	serv_addr.sin_addr.s_addr = INADDR_ANY;
 
-	for (i = 0; i < 100; i++) {
-		serv_addr.sin_port = htons(PORT + i);
-
-		ret = bind(sock_listen_fd, (struct sockaddr *)&serv_addr, sizeof(serv_addr));
-		if (!ret)
-			break;
-		if (errno != EADDRINUSE) {
-			fprintf(stderr, "bind: %s\n", strerror(errno));
-			return 1;
-		}
-		if (i == 99) {
-			printf("Gave up on finding a port, skipping\n");
-			goto out;
-		}
+	if (t_bind_ephemeral_port(sock_listen_fd, &serv_addr)) {
+		perror("bind");
+		return T_EXIT_FAIL;
 	}
 
 	if (listen(sock_listen_fd, BACKLOG) < 0) {
 		perror("Error listening on socket\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	if (setup_io_uring())
-		return 1;
+		return T_EXIT_FAIL;
 
 	add_poll(&ring, sock_listen_fd);
 	add_accept(&ring, sock_listen_fd);
@@ -110,7 +97,7 @@ int main(int argc, char *argv[])
 	ret = io_uring_submit(&ring);
 	if (ret != 2) {
 		fprintf(stderr, "submit=%d\n", ret);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	signal(SIGALRM, alarm_sig);
@@ -119,10 +106,9 @@ int main(int argc, char *argv[])
 	ret = io_uring_wait_cqe(&ring, &cqe);
 	if (ret) {
 		fprintf(stderr, "wait_cqe=%d\n", ret);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
-out:
 	io_uring_queue_exit(&ring);
-	return 0;
+	return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/files-exit-hang-timeout.c
+++ b/vendor/liburing/test/files-exit-hang-timeout.c
@@ -15,6 +15,7 @@
 #include <unistd.h>
 #include <poll.h>
 #include "liburing.h"
+#include "helpers.h"
 
 #define BACKLOG 512
 
@@ -72,12 +73,12 @@ int main(int argc, char *argv[])
 	int i;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	sock_listen_fd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
 	if (sock_listen_fd < 0) {
 		perror("socket");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	setsockopt(sock_listen_fd, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
@@ -94,21 +95,21 @@ int main(int argc, char *argv[])
 			break;
 		if (errno != EADDRINUSE) {
 			fprintf(stderr, "bind: %s\n", strerror(errno));
-			return 1;
+			return T_EXIT_FAIL;
 		}
 		if (i == 99) {
 			printf("Gave up on finding a port, skipping\n");
-			goto out;
+			goto skip;
 		}
 	}
 
 	if (listen(sock_listen_fd, BACKLOG) < 0) {
 		perror("Error listening on socket\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	if (setup_io_uring())
-		return 1;
+		return T_EXIT_FAIL;
 
 	add_timeout(&ring, sock_listen_fd);
 	add_accept(&ring, sock_listen_fd);
@@ -116,7 +117,7 @@ int main(int argc, char *argv[])
 	ret = io_uring_submit(&ring);
 	if (ret != 2) {
 		fprintf(stderr, "submit=%d\n", ret);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	signal(SIGALRM, alarm_sig);
@@ -125,10 +126,12 @@ int main(int argc, char *argv[])
 	ret = io_uring_wait_cqe(&ring, &cqe);
 	if (ret) {
 		fprintf(stderr, "wait_cqe=%d\n", ret);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
-out:
 	io_uring_queue_exit(&ring);
-	return 0;
+	return T_EXIT_PASS;
+skip:
+	io_uring_queue_exit(&ring);
+	return T_EXIT_SKIP;
 }

--- a/vendor/liburing/test/fixed-buf-iter.c
+++ b/vendor/liburing/test/fixed-buf-iter.c
@@ -96,20 +96,20 @@ int main(int argc, char *argv[])
 	int ret;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	ret = t_create_ring(8, &ring, 0);
 	if (ret == T_SETUP_SKIP)
-		return 0;
+		return T_EXIT_SKIP;
 	else if (ret < 0)
-		return 1;
+		return T_EXIT_FAIL;
 
 	ret = test(&ring);
 	if (ret) {
 		fprintf(stderr, "Test failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	io_uring_queue_exit(&ring);
-	return 0;
+	return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/fixed-link.c
+++ b/vendor/liburing/test/fixed-link.c
@@ -19,18 +19,18 @@ int main(int argc, char *argv[])
 	int i, fd, ret;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	fd = open("/dev/zero", O_RDONLY);
 	if (fd < 0) {
 		fprintf(stderr, "Failed to open /dev/zero\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	if (io_uring_queue_init(32, &ring, 0) < 0) {
-		fprintf(stderr, "Faild to init io_uring\n");
+		fprintf(stderr, "Failed to init io_uring\n");
 		close(fd);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	for (i = 0; i < IOVECS_LEN; ++i) {
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
 	ret = io_uring_register_buffers(&ring, iovecs, IOVECS_LEN);
 	if (ret) {
 		fprintf(stderr, "Failed to register buffers\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	for (i = 0; i < IOVECS_LEN; ++i) {
@@ -58,10 +58,10 @@ int main(int argc, char *argv[])
 	ret = io_uring_submit_and_wait(&ring, IOVECS_LEN);
 	if (ret < 0) {
 		fprintf(stderr, "Failed to submit IO\n");
-		return 1;
+		return T_EXIT_FAIL;
 	} else if (ret < 2) {
 		fprintf(stderr, "Submitted %d, wanted %d\n", ret, IOVECS_LEN);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	for (i = 0; i < IOVECS_LEN; i++) {
@@ -70,12 +70,12 @@ int main(int argc, char *argv[])
 		ret = io_uring_wait_cqe(&ring, &cqe);
 		if (ret) {
 			fprintf(stderr, "wait_cqe=%d\n", ret);
-			return 1;
+			return T_EXIT_FAIL;
 		}
 		if (cqe->res != iovecs[i].iov_len) {
 			fprintf(stderr, "read: wanted %ld, got %d\n",
 					(long) iovecs[i].iov_len, cqe->res);
-			return 1;
+			return T_EXIT_FAIL;
 		}
 		io_uring_cqe_seen(&ring, cqe);
 	}
@@ -86,5 +86,5 @@ int main(int argc, char *argv[])
 	for (i = 0; i < IOVECS_LEN; ++i)
 		free(iovecs[i].iov_base);
 
-	return 0;
+	return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/fixed-reuse.c
+++ b/vendor/liburing/test/fixed-reuse.c
@@ -124,21 +124,21 @@ int main(int argc, char *argv[])
 	int ret, files[MAX_FILES];
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	ret = io_uring_queue_init_params(8, &ring, &p);
 	if (ret) {
 		fprintf(stderr, "ring setup failed: %d\n", ret);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 	if (!(p.features & IORING_FEAT_CQE_SKIP))
-		return 0;
+		return T_EXIT_SKIP;
 
 	memset(files, -1, sizeof(files));
 	ret = io_uring_register_files(&ring, files, ARRAY_SIZE(files));
 	if (ret) {
 		fprintf(stderr, "Failed registering files\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	t_create_file_pattern(FNAME1, 4096, PAT1);
@@ -152,9 +152,9 @@ int main(int argc, char *argv[])
 
 	unlink(FNAME1);
 	unlink(FNAME2);
-	return 0;
+	return T_EXIT_PASS;
 err:
 	unlink(FNAME1);
 	unlink(FNAME2);
-	return 1;
+	return T_EXIT_FAIL;
 }

--- a/vendor/liburing/test/fpos.c
+++ b/vendor/liburing/test/fpos.c
@@ -52,6 +52,9 @@ static int test_read(struct io_uring *ring, bool async, int blocksize)
 	unsigned char buff[QUEUE_SIZE * blocksize];
 	unsigned char reordered[QUEUE_SIZE * blocksize];
 
+	memset(buff, 0, QUEUE_SIZE * blocksize);
+	memset(reordered, 0, QUEUE_SIZE * blocksize);
+
 	create_file(".test_fpos_read", FILE_SIZE);
 	fd = open(".test_fpos_read", O_RDONLY);
 	unlink(".test_fpos_read");
@@ -225,12 +228,12 @@ int main(int argc, char *argv[])
 	int ret;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	ret = io_uring_queue_init(QUEUE_SIZE, &ring, 0);
 	if (ret) {
 		fprintf(stderr, "ring setup failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	for (int test = 0; test < 8; test++) {
@@ -248,5 +251,5 @@ int main(int argc, char *argv[])
 			return -1;
 		}
 	}
-	return 0;
+	return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/fsync.c
+++ b/vendor/liburing/test/fsync.c
@@ -193,12 +193,12 @@ int main(int argc, char *argv[])
 	int ret;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	ret = io_uring_queue_init(8, &ring, 0);
 	if (ret) {
 		fprintf(stderr, "ring setup failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 
 	}
 
@@ -220,5 +220,5 @@ int main(int argc, char *argv[])
 		return ret;
 	}
 
-	return 0;
+	return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/helpers.h
+++ b/vendor/liburing/test/helpers.h
@@ -10,11 +10,25 @@ extern "C" {
 #endif
 
 #include "liburing.h"
+#include <arpa/inet.h>
 
 enum t_setup_ret {
 	T_SETUP_OK	= 0,
 	T_SETUP_SKIP,
 };
+
+enum t_test_result {
+	T_EXIT_PASS   = 0,
+	T_EXIT_FAIL   = 1,
+	T_EXIT_SKIP   = 77,
+};
+
+/*
+ * Helper for binding socket to an ephemeral port.
+ * The port number to be bound is returned in @addr->sin_port.
+ */
+int t_bind_ephemeral_port(int fd, struct sockaddr_in *addr);
+
 
 /*
  * Helper for allocating memory in tests.
@@ -53,6 +67,11 @@ void t_create_file_pattern(const char *file, size_t size, char pattern);
 struct iovec *t_create_buffers(size_t buf_num, size_t buf_size);
 
 /*
+ * Helper for creating connected socket pairs
+ */
+int t_create_socket_pair(int fd[2], bool stream);
+
+/*
  * Helper for setting up a ring and checking for user privs
  */
 enum t_setup_ret t_create_ring_params(int depth, struct io_uring *ring,
@@ -63,6 +82,8 @@ enum t_setup_ret t_create_ring(int depth, struct io_uring *ring,
 enum t_setup_ret t_register_buffers(struct io_uring *ring,
 				    const struct iovec *iovecs,
 				    unsigned nr_iovecs);
+
+bool t_probe_defer_taskrun(void);
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 

--- a/vendor/liburing/test/io-cancel.c
+++ b/vendor/liburing/test/io-cancel.c
@@ -365,8 +365,13 @@ static int test_cancel_req_across_fork(void)
 		exit(0);
 	} else {
 		int wstatus;
+		pid_t childpid;
 
-		if (waitpid(p, &wstatus, 0) == (pid_t)-1) {
+		do {
+			childpid = waitpid(p, &wstatus, 0);
+		} while (childpid == (pid_t)-1 && errno == EINTR);
+
+		if (childpid == (pid_t)-1) {
 			perror("waitpid()");
 			return 1;
 		}
@@ -503,26 +508,26 @@ int main(int argc, char *argv[])
 	int i, ret;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	if (test_dont_cancel_another_ring()) {
 		fprintf(stderr, "test_dont_cancel_another_ring() failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	if (test_cancel_req_across_fork()) {
 		fprintf(stderr, "test_cancel_req_across_fork() failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	if (test_cancel_inflight_exit()) {
 		fprintf(stderr, "test_cancel_inflight_exit() failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	if (test_sqpoll_cancel_iowq_requests()) {
 		fprintf(stderr, "test_sqpoll_cancel_iowq_requests() failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	t_create_file(fname, FILE_SIZE);
@@ -543,8 +548,8 @@ int main(int argc, char *argv[])
 	}
 
 	unlink(fname);
-	return 0;
+	return T_EXIT_PASS;
 err:
 	unlink(fname);
-	return 1;
+	return T_EXIT_FAIL;
 }

--- a/vendor/liburing/test/io_uring_passthrough.c
+++ b/vendor/liburing/test/io_uring_passthrough.c
@@ -1,0 +1,451 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Description: basic read/write tests for io_uring passthrough commands
+ */
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "helpers.h"
+#include "liburing.h"
+#include "../src/syscall.h"
+#include "nvme.h"
+
+#define FILE_SIZE	(256 * 1024)
+#define BS		8192
+#define BUFFERS		(FILE_SIZE / BS)
+
+static struct iovec *vecs;
+
+/*
+ * Each offset in the file has the ((test_case / 2) * FILE_SIZE)
+ * + (offset / sizeof(int)) stored for every
+ * sizeof(int) address.
+ */
+static int verify_buf(int tc, void *buf, off_t off)
+{
+	int i, u_in_buf = BS / sizeof(unsigned int);
+	unsigned int *ptr;
+
+	off /= sizeof(unsigned int);
+	off += (tc / 2) * FILE_SIZE;
+	ptr = buf;
+	for (i = 0; i < u_in_buf; i++) {
+		if (off != *ptr) {
+			fprintf(stderr, "Found %u, wanted %lu\n", *ptr, off);
+			return 1;
+		}
+		ptr++;
+		off++;
+	}
+
+	return 0;
+}
+
+static int fill_pattern(int tc)
+{
+	unsigned int val, *ptr;
+	int i, j;
+	int u_in_buf = BS / sizeof(val);
+
+	val = (tc / 2) * FILE_SIZE;
+	for (i = 0; i < BUFFERS; i++) {
+		ptr = vecs[i].iov_base;
+		for (j = 0; j < u_in_buf; j++) {
+			*ptr = val;
+			val++;
+			ptr++;
+		}
+	}
+
+	return 0;
+}
+
+static int __test_io(const char *file, struct io_uring *ring, int tc, int read,
+		     int sqthread, int fixed, int nonvec)
+{
+	struct io_uring_sqe *sqe;
+	struct io_uring_cqe *cqe;
+	struct nvme_uring_cmd *cmd;
+	int open_flags;
+	int do_fixed;
+	int i, ret, fd = -1;
+	off_t offset;
+	__u64 slba;
+	__u32 nlb;
+
+	if (read)
+		open_flags = O_RDONLY;
+	else
+		open_flags = O_WRONLY;
+
+	if (fixed) {
+		ret = t_register_buffers(ring, vecs, BUFFERS);
+		if (ret == T_SETUP_SKIP)
+			return 0;
+		if (ret != T_SETUP_OK) {
+			fprintf(stderr, "buffer reg failed: %d\n", ret);
+			goto err;
+		}
+	}
+
+	fd = open(file, open_flags);
+	if (fd < 0) {
+		perror("file open");
+		goto err;
+	}
+
+	if (sqthread) {
+		ret = io_uring_register_files(ring, &fd, 1);
+		if (ret) {
+			fprintf(stderr, "file reg failed: %d\n", ret);
+			goto err;
+		}
+	}
+
+	if (!read)
+		fill_pattern(tc);
+
+	offset = 0;
+	for (i = 0; i < BUFFERS; i++) {
+		sqe = io_uring_get_sqe(ring);
+		if (!sqe) {
+			fprintf(stderr, "sqe get failed\n");
+			goto err;
+		}
+		if (read) {
+			int use_fd = fd;
+
+			do_fixed = fixed;
+
+			if (sqthread)
+				use_fd = 0;
+			if (fixed && (i & 1))
+				do_fixed = 0;
+			if (do_fixed) {
+				io_uring_prep_read_fixed(sqe, use_fd, vecs[i].iov_base,
+								vecs[i].iov_len,
+								offset, i);
+				sqe->cmd_op = NVME_URING_CMD_IO;
+			} else if (nonvec) {
+				io_uring_prep_read(sqe, use_fd, vecs[i].iov_base,
+							vecs[i].iov_len, offset);
+				sqe->cmd_op = NVME_URING_CMD_IO;
+			} else {
+				io_uring_prep_readv(sqe, use_fd, &vecs[i], 1,
+								offset);
+				sqe->cmd_op = NVME_URING_CMD_IO_VEC;
+			}
+		} else {
+			int use_fd = fd;
+
+			do_fixed = fixed;
+
+			if (sqthread)
+				use_fd = 0;
+			if (fixed && (i & 1))
+				do_fixed = 0;
+			if (do_fixed) {
+				io_uring_prep_write_fixed(sqe, use_fd, vecs[i].iov_base,
+								vecs[i].iov_len,
+								offset, i);
+				sqe->cmd_op = NVME_URING_CMD_IO;
+			} else if (nonvec) {
+				io_uring_prep_write(sqe, use_fd, vecs[i].iov_base,
+							vecs[i].iov_len, offset);
+				sqe->cmd_op = NVME_URING_CMD_IO;
+			} else {
+				io_uring_prep_writev(sqe, use_fd, &vecs[i], 1,
+								offset);
+				sqe->cmd_op = NVME_URING_CMD_IO_VEC;
+			}
+		}
+		sqe->opcode = IORING_OP_URING_CMD;
+		sqe->user_data = ((uint64_t)offset << 32) | i;
+		if (sqthread)
+			sqe->flags |= IOSQE_FIXED_FILE;
+
+		cmd = (struct nvme_uring_cmd *)sqe->cmd;
+		memset(cmd, 0, sizeof(struct nvme_uring_cmd));
+
+		cmd->opcode = read ? nvme_cmd_read : nvme_cmd_write;
+
+		slba = offset >> lba_shift;
+		nlb = (BS >> lba_shift) - 1;
+
+		/* cdw10 and cdw11 represent starting lba */
+		cmd->cdw10 = slba & 0xffffffff;
+		cmd->cdw11 = slba >> 32;
+		/* cdw12 represent number of lba's for read/write */
+		cmd->cdw12 = nlb;
+		if (do_fixed || nonvec) {
+			cmd->addr = (__u64)(uintptr_t)vecs[i].iov_base;
+			cmd->data_len = vecs[i].iov_len;
+		} else {
+			cmd->addr = (__u64)(uintptr_t)&vecs[i];
+			cmd->data_len = 1;
+		}
+		cmd->nsid = nsid;
+
+		offset += BS;
+	}
+
+	ret = io_uring_submit(ring);
+	if (ret != BUFFERS) {
+		fprintf(stderr, "submit got %d, wanted %d\n", ret, BUFFERS);
+		goto err;
+	}
+
+	for (i = 0; i < BUFFERS; i++) {
+		ret = io_uring_wait_cqe(ring, &cqe);
+		if (ret) {
+			fprintf(stderr, "wait_cqe=%d\n", ret);
+			goto err;
+		}
+		if (cqe->res != 0) {
+			fprintf(stderr, "cqe res %d, wanted 0\n", cqe->res);
+			goto err;
+		}
+		io_uring_cqe_seen(ring, cqe);
+		if (read) {
+			int index = cqe->user_data & 0xffffffff;
+			void *buf = vecs[index].iov_base;
+			off_t voff = cqe->user_data >> 32;
+
+			if (verify_buf(tc, buf, voff))
+				goto err;
+		}
+	}
+
+	if (fixed) {
+		ret = io_uring_unregister_buffers(ring);
+		if (ret) {
+			fprintf(stderr, "buffer unreg failed: %d\n", ret);
+			goto err;
+		}
+	}
+	if (sqthread) {
+		ret = io_uring_unregister_files(ring);
+		if (ret) {
+			fprintf(stderr, "file unreg failed: %d\n", ret);
+			goto err;
+		}
+	}
+
+	close(fd);
+	return 0;
+err:
+	if (fd != -1)
+		close(fd);
+	return 1;
+}
+
+static int test_io(const char *file, int tc, int read, int sqthread,
+		   int fixed, int nonvec)
+{
+	struct io_uring ring;
+	int ret, ring_flags = 0;
+
+	ring_flags |= IORING_SETUP_SQE128;
+	ring_flags |= IORING_SETUP_CQE32;
+
+	if (sqthread)
+		ring_flags |= IORING_SETUP_SQPOLL;
+
+	ret = t_create_ring(64, &ring, ring_flags);
+	if (ret == T_SETUP_SKIP)
+		return 0;
+	if (ret != T_SETUP_OK) {
+		fprintf(stderr, "ring create failed: %d\n", ret);
+		return 1;
+	}
+
+	ret = __test_io(file, &ring, tc, read, sqthread, fixed, nonvec);
+	io_uring_queue_exit(&ring);
+
+	return ret;
+}
+
+extern unsigned __io_uring_flush_sq(struct io_uring *ring);
+
+/*
+ * Send a passthrough command that nvme will fail during submission.
+ * This comes handy for testing error handling.
+ */
+static int test_invalid_passthru_submit(const char *file)
+{
+	struct io_uring ring;
+	int fd, ret, ring_flags, open_flags;
+	struct io_uring_cqe *cqe;
+	struct io_uring_sqe *sqe;
+	struct nvme_uring_cmd *cmd;
+
+	ring_flags = IORING_SETUP_IOPOLL | IORING_SETUP_SQE128;
+	ring_flags |= IORING_SETUP_CQE32;
+
+	ret = t_create_ring(1, &ring, ring_flags);
+	if (ret != T_SETUP_OK) {
+		fprintf(stderr, "ring create failed: %d\n", ret);
+		return 1;
+	}
+
+	open_flags = O_RDONLY;
+	fd = open(file, open_flags);
+	if (fd < 0) {
+		perror("file open");
+		goto err;
+	}
+
+	sqe = io_uring_get_sqe(&ring);
+	io_uring_prep_read(sqe, fd, vecs[0].iov_base, vecs[0].iov_len, 0);
+	sqe->cmd_op = NVME_URING_CMD_IO;
+	sqe->opcode = IORING_OP_URING_CMD;
+	sqe->user_data = 1;
+	cmd = (struct nvme_uring_cmd *)sqe->cmd;
+	memset(cmd, 0, sizeof(struct nvme_uring_cmd));
+	cmd->opcode = nvme_cmd_read;
+	cmd->addr = (__u64)(uintptr_t)&vecs[0].iov_base;
+	cmd->data_len = vecs[0].iov_len;
+	/* populate wrong nsid to force failure */
+	cmd->nsid = nsid + 1;
+
+	ret = io_uring_submit(&ring);
+	if (ret != 1) {
+		fprintf(stderr, "submit got %d, wanted %d\n", ret, 1);
+		goto err;
+	}
+	ret = io_uring_wait_cqe(&ring, &cqe);
+	if (ret) {
+		fprintf(stderr, "wait_cqe=%d\n", ret);
+		goto err;
+	}
+	if (cqe->res == 0) {
+		fprintf(stderr, "cqe res %d, wanted failure\n", cqe->res);
+		goto err;
+	}
+	io_uring_cqe_seen(&ring, cqe);
+	close(fd);
+	io_uring_queue_exit(&ring);
+	return 0;
+err:
+	if (fd != -1)
+		close(fd);
+	io_uring_queue_exit(&ring);
+	return 1;
+}
+
+/*
+ * if we are polling io_uring_submit needs to always enter the
+ * kernel to fetch events
+ */
+static int test_io_uring_submit_enters(const char *file)
+{
+	struct io_uring ring;
+	int fd, i, ret, ring_flags, open_flags;
+	unsigned head;
+	struct io_uring_cqe *cqe;
+
+	ring_flags = IORING_SETUP_IOPOLL;
+	ring_flags |= IORING_SETUP_SQE128;
+	ring_flags |= IORING_SETUP_CQE32;
+
+	ret = io_uring_queue_init(64, &ring, ring_flags);
+	if (ret) {
+		fprintf(stderr, "ring create failed: %d\n", ret);
+		return 1;
+	}
+
+	open_flags = O_WRONLY;
+	fd = open(file, open_flags);
+	if (fd < 0) {
+		perror("file open");
+		goto err;
+	}
+
+	for (i = 0; i < BUFFERS; i++) {
+		struct io_uring_sqe *sqe;
+		off_t offset = BS * (rand() % BUFFERS);
+
+		sqe = io_uring_get_sqe(&ring);
+		io_uring_prep_writev(sqe, fd, &vecs[i], 1, offset);
+		sqe->user_data = 1;
+	}
+
+	/* submit manually to avoid adding IORING_ENTER_GETEVENTS */
+	ret = __sys_io_uring_enter(ring.ring_fd, __io_uring_flush_sq(&ring), 0,
+						0, NULL);
+	if (ret < 0)
+		goto err;
+
+	for (i = 0; i < 500; i++) {
+		ret = io_uring_submit(&ring);
+		if (ret != 0) {
+			fprintf(stderr, "still had %d sqes to submit\n", ret);
+			goto err;
+		}
+
+		io_uring_for_each_cqe(&ring, head, cqe) {
+			if (cqe->res == -EOPNOTSUPP)
+				fprintf(stdout, "Device doesn't support polled IO\n");
+			goto ok;
+		}
+		usleep(10000);
+	}
+err:
+	ret = 1;
+	if (fd != -1)
+		close(fd);
+
+ok:
+	io_uring_queue_exit(&ring);
+	return ret;
+}
+
+int main(int argc, char *argv[])
+{
+	int i, ret;
+	char *fname;
+
+	if (argc < 2)
+		return T_EXIT_SKIP;
+
+	fname = argv[1];
+	ret = nvme_get_info(fname);
+
+	if (ret)
+		return T_EXIT_SKIP;
+
+	vecs = t_create_buffers(BUFFERS, BS);
+
+	for (i = 0; i < 16; i++) {
+		int read = (i & 1) != 0;
+		int sqthread = (i & 2) != 0;
+		int fixed = (i & 4) != 0;
+		int nonvec = (i & 8) != 0;
+
+		ret = test_io(fname, i, read, sqthread, fixed, nonvec);
+		if (ret) {
+			fprintf(stderr, "test_io failed %d/%d/%d/%d\n",
+				read, sqthread, fixed, nonvec);
+			goto err;
+		}
+	}
+
+	ret = test_io_uring_submit_enters(fname);
+	if (ret) {
+		fprintf(stderr, "test_io_uring_submit_enters failed\n");
+		goto err;
+	}
+
+	ret = test_invalid_passthru_submit(fname);
+	if (ret) {
+		fprintf(stderr, "test_invalid_passthru_submit failed\n");
+		goto err;
+	}
+
+	return T_EXIT_PASS;
+err:
+	return T_EXIT_FAIL;
+}

--- a/vendor/liburing/test/iopoll-leak.c
+++ b/vendor/liburing/test/iopoll-leak.c
@@ -1,0 +1,85 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Description: test a mem leak with IOPOLL
+ */
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include "helpers.h"
+#include "liburing.h"
+
+#define FILE_SIZE	(128 * 1024)
+#define BS		4096
+#define BUFFERS		(FILE_SIZE / BS)
+
+static int do_iopoll(const char *fname)
+{
+	struct io_uring_sqe *sqe;
+	struct io_uring ring;
+	struct iovec *iov;
+	int fd;
+
+	fd = open(fname, O_RDONLY | O_DIRECT);
+	if (fd < 0) {
+		perror("open");
+		return T_EXIT_SKIP;
+	}
+
+	iov = t_create_buffers(1, 4096);
+
+	t_create_ring(2, &ring, IORING_SETUP_IOPOLL);
+
+	sqe = io_uring_get_sqe(&ring);
+	io_uring_prep_read(sqe, fd, iov->iov_base, iov->iov_len, 0);
+	io_uring_submit(&ring);
+
+	close(fd);
+	return T_EXIT_PASS;
+}
+
+static int test(const char *fname)
+{
+	if (fork()) {
+		int stat;
+
+		wait(&stat);
+		return WEXITSTATUS(stat);
+	} else {
+		int ret;
+
+		ret = do_iopoll(fname);
+		exit(ret);
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	char buf[256];
+	char *fname;
+	int i, ret;
+
+	if (argc > 1) {
+		fname = argv[1];
+	} else {
+		srand((unsigned)time(NULL));
+		snprintf(buf, sizeof(buf), ".iopoll-leak-%u-%u",
+			(unsigned)rand(), (unsigned)getpid());
+		fname = buf;
+		t_create_file(fname, FILE_SIZE);
+	}
+
+	for (i = 0; i < 16; i++) {
+		ret = test(fname);
+		if (ret == T_EXIT_SKIP || ret == T_EXIT_FAIL)
+			break;
+	}
+
+	if (fname != argv[1])
+		unlink(fname);
+	return ret;
+}

--- a/vendor/liburing/test/lfs-openat-write.c
+++ b/vendor/liburing/test/lfs-openat-write.c
@@ -14,6 +14,8 @@
 #include <sys/resource.h>
 #include <unistd.h>
 
+#include "helpers.h"
+
 static const int RSIZE = 2;
 static const int OPEN_FLAGS = O_RDWR | O_CREAT;
 static const mode_t OPEN_MODE = S_IRUSR | S_IWUSR;
@@ -100,7 +102,7 @@ int main(int argc, char *argv[])
 	int dfd, ret;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	dfd = open("/tmp", O_RDONLY | O_DIRECTORY);
 	if (dfd < 0)

--- a/vendor/liburing/test/link-timeout.c
+++ b/vendor/liburing/test/link-timeout.c
@@ -12,6 +12,7 @@
 #include <poll.h>
 
 #include "liburing.h"
+#include "helpers.h"
 
 static int test_fail_lone_link_timeouts(struct io_uring *ring)
 {
@@ -1011,12 +1012,12 @@ int main(int argc, char *argv[])
 	int ret;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	ret = io_uring_queue_init(8, &ring, 0);
 	if (ret) {
 		printf("ring setup failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	ret = test_timeout_link_chain1(&ring);
@@ -1103,5 +1104,5 @@ int main(int argc, char *argv[])
 		return ret;
 	}
 
-	return 0;
+	return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/link.c
+++ b/vendor/liburing/test/link.c
@@ -11,6 +11,7 @@
 #include <fcntl.h>
 
 #include "liburing.h"
+#include "helpers.h"
 
 static int no_hardlink;
 
@@ -435,19 +436,19 @@ int main(int argc, char *argv[])
 	int ret;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	ret = io_uring_queue_init(8, &ring, 0);
 	if (ret) {
 		printf("ring setup failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 
 	}
 
 	ret = io_uring_queue_init(8, &poll_ring, IORING_SETUP_IOPOLL);
 	if (ret) {
 		printf("poll_ring setup failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	ret = test_single_link(&ring);
@@ -492,5 +493,5 @@ int main(int argc, char *argv[])
 		return ret;
 	}
 
-	return 0;
+	return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/madvise.c
+++ b/vendor/liburing/test/madvise.c
@@ -187,9 +187,9 @@ int main(int argc, char *argv[])
 	if (fname != argv[1])
 		unlink(fname);
 	io_uring_queue_exit(&ring);
-	return 0;
+	return T_EXIT_PASS;
 err:
 	if (fname != argv[1])
 		unlink(fname);
-	return 1;
+	return T_EXIT_FAIL;
 }

--- a/vendor/liburing/test/multicqes_drain.c
+++ b/vendor/liburing/test/multicqes_drain.c
@@ -17,6 +17,7 @@
 #include <poll.h>
 
 #include "liburing.h"
+#include "helpers.h"
 
 enum {
 	multi,
@@ -116,7 +117,7 @@ __u8 generate_flags(int sqe_op)
 	/*
 	 * avoid below case:
 	 * sqe0(multishot, link)->sqe1(nop, link)->sqe2(nop)->sqe3(cancel_sqe0)
-	 * sqe3 may excute before sqe0 so that sqe0 isn't cancelled
+	 * sqe3 may execute before sqe0 so that sqe0 isn't cancelled
 	 */
 	if (sqe_op == multi)
 		flags &= ~IOSQE_IO_LINK;
@@ -232,6 +233,8 @@ static int test_generic_drain(struct io_uring *ring)
 
 		if (trigger_event(pipes[i]))
 			goto err;
+
+		io_uring_get_events(ring);
 	}
 	sleep(1);
 	i = 0;
@@ -245,7 +248,7 @@ static int test_generic_drain(struct io_uring *ring)
 	 * compl_bits is a bit map to record completions.
 	 * eg. sqe[0], sqe[1], sqe[2] fully completed
 	 * then compl_bits is 000...00111b
-	 * 
+	 *
 	 */
 	unsigned long long compl_bits = 0;
 	for (j = 0; j < i; j++) {
@@ -294,7 +297,12 @@ static int test_simple_drain(struct io_uring *ring)
 	io_uring_prep_poll_add(sqe[1], pipe2[0], POLLIN);
 	sqe[1]->user_data = 1;
 
-	ret = io_uring_submit(ring);
+	/* This test relies on multishot poll to trigger events continually.
+	 * however with IORING_SETUP_DEFER_TASKRUN this will only happen when
+	 * triggered with a get_events. Hence we sprinkle get_events whenever
+	 * there might be work to process in order to get the same result
+	 */
+	ret = io_uring_submit_and_get_events(ring);
 	if (ret < 0) {
 		printf("sqe submit failed\n");
 		goto err;
@@ -306,9 +314,11 @@ static int test_simple_drain(struct io_uring *ring)
 	for (i = 0; i < 2; i++) {
 		if (trigger_event(pipe1))
 			goto err;
+		io_uring_get_events(ring);
 	}
 	if (trigger_event(pipe2))
 			goto err;
+	io_uring_get_events(ring);
 
 	for (i = 0; i < 2; i++) {
 		sqe[i] = io_uring_get_sqe(ring);
@@ -354,25 +364,27 @@ err:
 	return 1;
 }
 
-int main(int argc, char *argv[])
+static int test(bool defer_taskrun)
 {
 	struct io_uring ring;
 	int i, ret;
+	unsigned int flags = 0;
 
-	if (argc > 1)
-		return 0;
+	if (defer_taskrun)
+		flags = IORING_SETUP_SINGLE_ISSUER |
+			IORING_SETUP_DEFER_TASKRUN;
 
-	ret = io_uring_queue_init(1024, &ring, 0);
+	ret = io_uring_queue_init(1024, &ring, flags);
 	if (ret) {
 		printf("ring setup failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	for (i = 0; i < 5; i++) {
 		ret = test_simple_drain(&ring);
 		if (ret) {
 			fprintf(stderr, "test_simple_drain failed\n");
-			break;
+			return T_EXIT_FAIL;
 		}
 	}
 
@@ -380,8 +392,35 @@ int main(int argc, char *argv[])
 		ret = test_generic_drain(&ring);
 		if (ret) {
 			fprintf(stderr, "test_generic_drain failed\n");
-			break;
+			return T_EXIT_FAIL;
 		}
 	}
+
+	io_uring_queue_exit(&ring);
+
+	return T_EXIT_PASS;
+}
+
+int main(int argc, char *argv[])
+{
+	int ret;
+
+	if (argc > 1)
+		return T_EXIT_SKIP;
+
+	ret = test(false);
+	if (ret != T_EXIT_PASS) {
+		fprintf(stderr, "%s: test(false) failed\n", argv[0]);
+		return ret;
+	}
+
+	if (t_probe_defer_taskrun()) {
+		ret = test(true);
+		if (ret != T_EXIT_PASS) {
+			fprintf(stderr, "%s: test(true) failed\n", argv[0]);
+			return ret;
+		}
+	}
+
 	return ret;
 }

--- a/vendor/liburing/test/nolibc.c
+++ b/vendor/liburing/test/nolibc.c
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Test liburing nolibc functionality.
+ *
+ * Currently, supported architectures are:
+ *   1) x86
+ *   2) x86-64
+ *   3) aarch64
+ *
+ */
+#include "helpers.h"
+
+#if !defined(__x86_64__) && !defined(__i386__) && !defined(__aarch64__)
+
+/*
+ * This arch doesn't support nolibc.
+ */
+int main(void)
+{
+	return T_EXIT_SKIP;
+}
+
+#else /* #if !defined(__x86_64__) && !defined(__i386__) && !defined(__aarch64__) */
+
+#ifndef CONFIG_NOLIBC
+#define CONFIG_NOLIBC
+#endif
+
+#include <stdio.h>
+#include <unistd.h>
+#include "../src/lib.h"
+
+static int test_get_page_size(void)
+{
+	long a, b;
+
+	a = sysconf(_SC_PAGESIZE);
+	b = get_page_size();
+	if (a != b) {
+		fprintf(stderr, "get_page_size() fails, %ld != %ld", a, b);
+		return -1;
+	}
+	return 0;
+}
+
+int main(int argc, char *argv[])
+{
+	int ret;
+
+	if (argc > 1)
+		return T_EXIT_SKIP;
+
+	ret = test_get_page_size();
+	if (ret)
+		return T_EXIT_FAIL;
+
+	return T_EXIT_PASS;
+}
+
+#endif /* #if !defined(__x86_64__) && !defined(__i386__) && !defined(__aarch64__) */

--- a/vendor/liburing/test/nvme.h
+++ b/vendor/liburing/test/nvme.h
@@ -1,0 +1,168 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Description: Helpers for NVMe uring passthrough commands
+ */
+#ifndef LIBURING_NVME_H
+#define LIBURING_NVME_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <sys/ioctl.h>
+#include <linux/nvme_ioctl.h>
+
+/*
+ * If the uapi headers installed on the system lacks nvme uring command
+ * support, use the local version to prevent compilation issues.
+ */
+#ifndef CONFIG_HAVE_NVME_URING
+struct nvme_uring_cmd {
+	__u8	opcode;
+	__u8	flags;
+	__u16	rsvd1;
+	__u32	nsid;
+	__u32	cdw2;
+	__u32	cdw3;
+	__u64	metadata;
+	__u64	addr;
+	__u32	metadata_len;
+	__u32	data_len;
+	__u32	cdw10;
+	__u32	cdw11;
+	__u32	cdw12;
+	__u32	cdw13;
+	__u32	cdw14;
+	__u32	cdw15;
+	__u32	timeout_ms;
+	__u32   rsvd2;
+};
+
+#define NVME_URING_CMD_IO	_IOWR('N', 0x80, struct nvme_uring_cmd)
+#define NVME_URING_CMD_IO_VEC	_IOWR('N', 0x81, struct nvme_uring_cmd)
+#endif /* CONFIG_HAVE_NVME_URING */
+
+#define NVME_DEFAULT_IOCTL_TIMEOUT 0
+#define NVME_IDENTIFY_DATA_SIZE 4096
+#define NVME_IDENTIFY_CSI_SHIFT 24
+#define NVME_IDENTIFY_CNS_NS 0
+#define NVME_CSI_NVM 0
+
+enum nvme_admin_opcode {
+	nvme_admin_identify		= 0x06,
+};
+
+enum nvme_io_opcode {
+	nvme_cmd_write			= 0x01,
+	nvme_cmd_read			= 0x02,
+};
+
+int nsid;
+__u32 lba_shift;
+
+struct nvme_lbaf {
+	__le16			ms;
+	__u8			ds;
+	__u8			rp;
+};
+
+struct nvme_id_ns {
+	__le64			nsze;
+	__le64			ncap;
+	__le64			nuse;
+	__u8			nsfeat;
+	__u8			nlbaf;
+	__u8			flbas;
+	__u8			mc;
+	__u8			dpc;
+	__u8			dps;
+	__u8			nmic;
+	__u8			rescap;
+	__u8			fpi;
+	__u8			dlfeat;
+	__le16			nawun;
+	__le16			nawupf;
+	__le16			nacwu;
+	__le16			nabsn;
+	__le16			nabo;
+	__le16			nabspf;
+	__le16			noiob;
+	__u8			nvmcap[16];
+	__le16			npwg;
+	__le16			npwa;
+	__le16			npdg;
+	__le16			npda;
+	__le16			nows;
+	__le16			mssrl;
+	__le32			mcl;
+	__u8			msrc;
+	__u8			rsvd81[11];
+	__le32			anagrpid;
+	__u8			rsvd96[3];
+	__u8			nsattr;
+	__le16			nvmsetid;
+	__le16			endgid;
+	__u8			nguid[16];
+	__u8			eui64[8];
+	struct nvme_lbaf	lbaf[16];
+	__u8			rsvd192[192];
+	__u8			vs[3712];
+};
+
+static inline int ilog2(uint32_t i)
+{
+	int log = -1;
+
+	while (i) {
+		i >>= 1;
+		log++;
+	}
+	return log;
+}
+
+int nvme_get_info(const char *file)
+{
+	struct nvme_id_ns ns;
+	int fd, err;
+	__u32 lba_size;
+
+	fd = open(file, O_RDONLY);
+	if (fd < 0) {
+		perror("file open");
+		return -errno;
+	}
+
+	nsid = ioctl(fd, NVME_IOCTL_ID);
+	if (nsid < 0) {
+		close(fd);
+		return -errno;
+	}
+
+	struct nvme_passthru_cmd cmd = {
+		.opcode         = nvme_admin_identify,
+		.nsid           = nsid,
+		.addr           = (__u64)(uintptr_t)&ns,
+		.data_len       = NVME_IDENTIFY_DATA_SIZE,
+		.cdw10          = NVME_IDENTIFY_CNS_NS,
+		.cdw11          = NVME_CSI_NVM << NVME_IDENTIFY_CSI_SHIFT,
+		.timeout_ms     = NVME_DEFAULT_IOCTL_TIMEOUT,
+	};
+
+	err = ioctl(fd, NVME_IOCTL_ADMIN_CMD, &cmd);
+	if (err) {
+		close(fd);
+		return err;
+	}
+
+	lba_size = 1 << ns.lbaf[(ns.flbas & 0x0f)].ds;
+	lba_shift = ilog2(lba_size);
+
+	close(fd);
+	return 0;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/vendor/liburing/test/open-direct-pick.c
+++ b/vendor/liburing/test/open-direct-pick.c
@@ -158,7 +158,7 @@ int main(int argc, char *argv[])
 		return 0;
 	}
 
-	path = "/tmp/.open.close";
+	path = "/tmp/.open.direct.pick";
 	t_create_file(path, 4096);
 
 	ret = test_openat(&ring, path);

--- a/vendor/liburing/test/poll-link.c
+++ b/vendor/liburing/test/poll-link.c
@@ -13,6 +13,7 @@
 #include <poll.h>
 #include <arpa/inet.h>
 
+#include "helpers.h"
 #include "liburing.h"
 
 pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -50,14 +51,14 @@ struct data {
 
 static void *send_thread(void *arg)
 {
+	struct sockaddr_in addr;
 	struct data *data = arg;
+	int s0;
 
 	wait_for_var(&recv_thread_ready);
 
-	int s0 = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+	s0 = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
 	assert(s0 != -1);
-
-	struct sockaddr_in addr;
 
 	addr.sin_family = AF_INET;
 	addr.sin_port = data->port;
@@ -72,6 +73,7 @@ static void *send_thread(void *arg)
 
 void *recv_thread(void *arg)
 {
+	struct sockaddr_in addr = { };
 	struct data *data = arg;
 	struct io_uring_sqe *sqe;
 	struct io_uring ring;
@@ -89,27 +91,17 @@ void *recv_thread(void *arg)
 	ret = setsockopt(s0, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
 	assert(ret != -1);
 
-	struct sockaddr_in addr;
-
 	addr.sin_family = AF_INET;
 	data->addr = inet_addr("127.0.0.1");
 	addr.sin_addr.s_addr = data->addr;
 
-	i = 0;
-	do {
-		data->port = htons(1025 + (rand() % 64510));
-		addr.sin_port = data->port;
-
-		if (bind(s0, (struct sockaddr*)&addr, sizeof(addr)) != -1)
-			break;
-	} while (++i < 100);
-
-	if (i >= 100) {
-		fprintf(stderr, "Can't find good port, skipped\n");
+	if (t_bind_ephemeral_port(s0, &addr)) {
+		perror("bind");
 		data->stop = 1;
 		signal_var(&recv_thread_ready);
-		goto out;
+		goto err;
 	}
+	data->port = addr.sin_port;
 
 	ret = listen(s0, 128);
 	assert(ret != -1);
@@ -158,7 +150,6 @@ void *recv_thread(void *arg)
 		io_uring_cqe_seen(&ring, cqe);
 	}
 
-out:
 	signal_var(&recv_thread_done);
 	close(s0);
 	io_uring_queue_exit(&ring);

--- a/vendor/liburing/test/poll-mshot-overflow.c
+++ b/vendor/liburing/test/poll-mshot-overflow.c
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: MIT
+
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <poll.h>
+#include <sys/wait.h>
+
+#include "liburing.h"
+#include "helpers.h"
+
+int check_final_cqe(struct io_uring *ring)
+{
+	struct io_uring_cqe *cqe;
+	int count = 0;
+	bool signalled_no_more = false;
+
+	while (!io_uring_peek_cqe(ring, &cqe)) {
+		if (cqe->user_data == 1) {
+			count++;
+			if (signalled_no_more) {
+				fprintf(stderr, "signalled no more!\n");
+				return T_EXIT_FAIL;
+			}
+			if (!(cqe->flags & IORING_CQE_F_MORE))
+				signalled_no_more = true;
+		} else if (cqe->user_data != 3) {
+			fprintf(stderr, "%d: got unexpected %d\n", count, (int)cqe->user_data);
+			return T_EXIT_FAIL;
+		}
+		io_uring_cqe_seen(ring, cqe);
+	}
+
+	if (!count) {
+		fprintf(stderr, "no cqe\n");
+		return T_EXIT_FAIL;
+	}
+
+	return T_EXIT_PASS;
+}
+
+static int test(bool defer_taskrun)
+{
+	struct io_uring_cqe *cqe;
+	struct io_uring_sqe *sqe;
+	struct io_uring ring;
+	int pipe1[2];
+	int ret, i;
+
+	if (pipe(pipe1) != 0) {
+		perror("pipe");
+		return T_EXIT_FAIL;
+	}
+
+	struct io_uring_params params = {
+		/* cheat using SINGLE_ISSUER existence to know if this behaviour
+		 * is updated
+		 */
+		.flags = IORING_SETUP_CQSIZE | IORING_SETUP_SINGLE_ISSUER,
+		.cq_entries = 2
+	};
+
+	if (defer_taskrun)
+		params.flags |= IORING_SETUP_SINGLE_ISSUER |
+				IORING_SETUP_DEFER_TASKRUN;
+
+	ret = io_uring_queue_init_params(2, &ring, &params);
+	if (ret)
+		return T_EXIT_SKIP;
+
+	sqe = io_uring_get_sqe(&ring);
+	if (!sqe) {
+		fprintf(stderr, "get sqe failed\n");
+		return T_EXIT_FAIL;
+	}
+	io_uring_prep_poll_multishot(sqe, pipe1[0], POLLIN);
+	io_uring_sqe_set_data64(sqe, 1);
+
+	if (io_uring_cq_ready(&ring)) {
+		fprintf(stderr, "unexpected cqe\n");
+		return T_EXIT_FAIL;
+	}
+
+	for (i = 0; i < 2; i++) {
+		sqe = io_uring_get_sqe(&ring);
+		io_uring_prep_nop(sqe);
+		io_uring_sqe_set_data64(sqe, 2);
+		io_uring_submit(&ring);
+	}
+
+	do {
+		errno = 0;
+		ret = write(pipe1[1], "foo", 3);
+	} while (ret == -1 && errno == EINTR);
+
+	if (ret <= 0) {
+		fprintf(stderr, "write failed: %d\n", errno);
+		return T_EXIT_FAIL;
+	}
+
+	/* should have 2 cqe + 1 overflow now, so take out two cqes */
+	for (i = 0; i < 2; i++) {
+		if (io_uring_peek_cqe(&ring, &cqe)) {
+			fprintf(stderr, "unexpectedly no cqe\n");
+			return T_EXIT_FAIL;
+		}
+		if (cqe->user_data != 2) {
+			fprintf(stderr, "unexpected user_data\n");
+			return T_EXIT_FAIL;
+		}
+		io_uring_cqe_seen(&ring, cqe);
+	}
+
+	/* make sure everything is processed */
+	io_uring_get_events(&ring);
+
+	/* now remove the poll */
+	sqe = io_uring_get_sqe(&ring);
+	io_uring_prep_poll_remove(sqe, 1);
+	io_uring_sqe_set_data64(sqe, 3);
+	ret = io_uring_submit(&ring);
+
+	if (ret != 1) {
+		fprintf(stderr, "bad poll remove\n");
+		return T_EXIT_FAIL;
+	}
+
+	ret = check_final_cqe(&ring);
+
+	close(pipe1[0]);
+	close(pipe1[1]);
+	io_uring_queue_exit(&ring);
+
+	return ret;
+}
+
+int main(int argc, char *argv[])
+{
+	int ret;
+
+	if (argc > 1)
+		return T_EXIT_SKIP;
+
+	ret = test(false);
+	if (ret != T_EXIT_PASS) {
+		fprintf(stderr, "%s: test(false) failed\n", argv[0]);
+		return ret;
+	}
+
+	if (t_probe_defer_taskrun()) {
+		ret = test(true);
+		if (ret != T_EXIT_PASS) {
+			fprintf(stderr, "%s: test(true) failed\n", argv[0]);
+			return ret;
+		}
+	}
+
+	return ret;
+}

--- a/vendor/liburing/test/recv-multishot.c
+++ b/vendor/liburing/test/recv-multishot.c
@@ -1,0 +1,505 @@
+// SPDX-License-Identifier: MIT
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <pthread.h>
+
+#include "liburing.h"
+#include "helpers.h"
+
+#define ENORECVMULTISHOT 9999
+
+enum early_error_t {
+	ERROR_NONE  = 0,
+	ERROR_NOT_ENOUGH_BUFFERS,
+	ERROR_EARLY_CLOSE_SENDER,
+	ERROR_EARLY_CLOSE_RECEIVER,
+	ERROR_EARLY_OVERFLOW,
+	ERROR_EARLY_LAST
+};
+
+struct args {
+	bool stream;
+	bool wait_each;
+	bool recvmsg;
+	enum early_error_t early_error;
+	bool defer;
+};
+
+static int check_sockaddr(struct sockaddr_in *in)
+{
+	struct in_addr expected;
+
+	inet_pton(AF_INET, "127.0.0.1", &expected);
+	if (in->sin_family != AF_INET) {
+		fprintf(stderr, "bad family %d\n", (int)htons(in->sin_family));
+		return -1;
+	}
+	if (memcmp(&expected, &in->sin_addr, sizeof(in->sin_addr))) {
+		char buff[256];
+		const char *addr = inet_ntop(AF_INET, &in->sin_addr, buff, sizeof(buff));
+
+		fprintf(stderr, "unexpected address %s\n", addr ? addr : "INVALID");
+		return -1;
+	}
+	return 0;
+}
+
+static int test(struct args *args)
+{
+	int const N = 8;
+	int const N_BUFFS = N * 64;
+	int const N_CQE_OVERFLOW = 4;
+	int const min_cqes = 2;
+	int const NAME_LEN = sizeof(struct sockaddr_storage);
+	int const CONTROL_LEN = CMSG_ALIGN(sizeof(struct sockaddr_storage))
+					+ sizeof(struct cmsghdr);
+	struct io_uring ring;
+	struct io_uring_cqe *cqe;
+	struct io_uring_sqe *sqe;
+	int fds[2], ret, i, j;
+	int total_sent_bytes = 0, total_recv_bytes = 0, total_dropped_bytes = 0;
+	int send_buff[256];
+	int *sent_buffs[N_BUFFS];
+	int *recv_buffs[N_BUFFS];
+	int *at;
+	struct io_uring_cqe recv_cqe[N_BUFFS];
+	int recv_cqes = 0;
+	bool early_error = false;
+	bool early_error_started = false;
+	struct __kernel_timespec timeout = {
+		.tv_sec = 1,
+	};
+	struct msghdr msg;
+	struct io_uring_params params = { };
+	int n_sqe = 32;
+
+	memset(recv_buffs, 0, sizeof(recv_buffs));
+
+	if (args->defer)
+		params.flags |= IORING_SETUP_SINGLE_ISSUER |
+				IORING_SETUP_DEFER_TASKRUN;
+
+	if (args->early_error == ERROR_EARLY_OVERFLOW) {
+		params.flags |= IORING_SETUP_CQSIZE;
+		params.cq_entries = N_CQE_OVERFLOW;
+		n_sqe = N_CQE_OVERFLOW;
+	}
+
+	ret = io_uring_queue_init_params(n_sqe, &ring, &params);
+	if (ret) {
+		fprintf(stderr, "queue init failed: %d\n", ret);
+		return ret;
+	}
+
+	ret = t_create_socket_pair(fds, args->stream);
+	if (ret) {
+		fprintf(stderr, "t_create_socket_pair failed: %d\n", ret);
+		return ret;
+	}
+
+	if (!args->stream) {
+		bool val = true;
+
+		/* force some cmsgs to come back to us */
+		ret = setsockopt(fds[0], IPPROTO_IP, IP_RECVORIGDSTADDR, &val,
+				 sizeof(val));
+		if (ret) {
+			fprintf(stderr, "setsockopt failed %d\n", errno);
+			goto cleanup;
+		}
+	}
+
+	for (i = 0; i < ARRAY_SIZE(send_buff); i++)
+		send_buff[i] = i;
+
+	for (i = 0; i < ARRAY_SIZE(recv_buffs); i++) {
+		/* prepare some different sized buffers */
+		int buffer_size = (i % 2 == 0 && (args->stream || args->recvmsg)) ? 1 : N;
+
+		buffer_size *= sizeof(int);
+		if (args->recvmsg) {
+			buffer_size +=
+				sizeof(struct io_uring_recvmsg_out) +
+				NAME_LEN +
+				CONTROL_LEN;
+		}
+
+		recv_buffs[i] = malloc(buffer_size);
+
+		if (i > 2 && args->early_error == ERROR_NOT_ENOUGH_BUFFERS)
+			continue;
+
+		sqe = io_uring_get_sqe(&ring);
+		io_uring_prep_provide_buffers(sqe, recv_buffs[i],
+					buffer_size, 1, 7, i);
+		io_uring_sqe_set_data64(sqe, 0x999);
+		memset(recv_buffs[i], 0xcc, buffer_size);
+		if (io_uring_submit_and_wait_timeout(&ring, &cqe, 1, &timeout, NULL) < 0) {
+			fprintf(stderr, "provide buffers failed: %d\n", ret);
+			ret = -1;
+			goto cleanup;
+		}
+		io_uring_cqe_seen(&ring, cqe);
+	}
+
+	sqe = io_uring_get_sqe(&ring);
+	if (args->recvmsg) {
+		unsigned int flags = 0;
+
+		if (!args->stream)
+			flags |= MSG_TRUNC;
+
+		memset(&msg, 0, sizeof(msg));
+		msg.msg_namelen = NAME_LEN;
+		msg.msg_controllen = CONTROL_LEN;
+		io_uring_prep_recvmsg_multishot(sqe, fds[0], &msg, flags);
+	} else {
+		io_uring_prep_recv_multishot(sqe, fds[0], NULL, 0, 0);
+	}
+	sqe->flags |= IOSQE_BUFFER_SELECT;
+	sqe->buf_group = 7;
+	io_uring_sqe_set_data64(sqe, 1234);
+	io_uring_submit(&ring);
+
+	at = &send_buff[0];
+	total_sent_bytes = 0;
+	for (i = 0; i < N; i++) {
+		int to_send = sizeof(*at) * (i+1);
+
+		total_sent_bytes += to_send;
+		sent_buffs[i] = at;
+		if (send(fds[1], at, to_send, 0) != to_send) {
+			if (early_error_started)
+				break;
+			fprintf(stderr, "send failed %d\n", errno);
+			ret = -1;
+			goto cleanup;
+		}
+
+		if (i == 2) {
+			if (args->early_error == ERROR_EARLY_CLOSE_RECEIVER) {
+				/* allow previous sends to complete */
+				usleep(1000);
+				io_uring_get_events(&ring);
+
+				sqe = io_uring_get_sqe(&ring);
+				io_uring_prep_recv(sqe, fds[0], NULL, 0, 0);
+				io_uring_prep_cancel64(sqe, 1234, 0);
+				io_uring_sqe_set_data64(sqe, 0x888);
+				sqe->flags |= IOSQE_CQE_SKIP_SUCCESS;
+				io_uring_submit(&ring);
+				early_error_started = true;
+
+				/* allow the cancel to complete */
+				usleep(1000);
+				io_uring_get_events(&ring);
+			}
+			if (args->early_error == ERROR_EARLY_CLOSE_SENDER) {
+				early_error_started = true;
+				shutdown(fds[1], SHUT_RDWR);
+				close(fds[1]);
+			}
+		}
+		at += (i+1);
+
+		if (args->wait_each) {
+			ret = io_uring_wait_cqes(&ring, &cqe, 1, &timeout, NULL);
+			if (ret) {
+				fprintf(stderr, "wait_each failed: %d\n", ret);
+				ret = -1;
+				goto cleanup;
+			}
+			while (io_uring_peek_cqe(&ring, &cqe) == 0) {
+				recv_cqe[recv_cqes++] = *cqe;
+				if (cqe->flags & IORING_CQE_F_MORE) {
+					io_uring_cqe_seen(&ring, cqe);
+				} else {
+					early_error = true;
+					io_uring_cqe_seen(&ring, cqe);
+				}
+			}
+			if (early_error)
+				break;
+		}
+	}
+
+	close(fds[1]);
+
+	/* allow sends to finish */
+	usleep(1000);
+
+	if ((args->stream && !early_error) || recv_cqes < min_cqes) {
+		ret = io_uring_wait_cqes(&ring, &cqe, 1, &timeout, NULL);
+		if (ret && ret != -ETIME) {
+			fprintf(stderr, "wait final failed: %d\n", ret);
+			ret = -1;
+			goto cleanup;
+		}
+	}
+
+	while (io_uring_peek_cqe(&ring, &cqe) == 0) {
+		recv_cqe[recv_cqes++] = *cqe;
+		io_uring_cqe_seen(&ring, cqe);
+	}
+
+	ret = -1;
+	at = &send_buff[0];
+	if (recv_cqes < min_cqes) {
+		if (recv_cqes > 0 && recv_cqe[0].res == -EINVAL) {
+			return -ENORECVMULTISHOT;
+		}
+		/* some kernels apparently don't check ->ioprio, skip */
+		ret = -ENORECVMULTISHOT;
+		goto cleanup;
+	}
+	for (i = 0; i < recv_cqes; i++) {
+		cqe = &recv_cqe[i];
+
+		bool const is_last = i == recv_cqes - 1;
+
+		bool const should_be_last =
+			(cqe->res <= 0) ||
+			(args->stream && is_last) ||
+			(args->early_error == ERROR_EARLY_OVERFLOW &&
+			 !args->wait_each && i == N_CQE_OVERFLOW);
+		int *this_recv;
+		int orig_payload_size = cqe->res;
+
+
+		if (should_be_last) {
+			int used_res = cqe->res;
+
+			if (!is_last) {
+				fprintf(stderr, "not last cqe had error %d\n", i);
+				goto cleanup;
+			}
+
+			switch (args->early_error) {
+			case ERROR_NOT_ENOUGH_BUFFERS:
+				if (cqe->res != -ENOBUFS) {
+					fprintf(stderr,
+						"ERROR_NOT_ENOUGH_BUFFERS: res %d\n", cqe->res);
+					goto cleanup;
+				}
+				break;
+			case ERROR_EARLY_OVERFLOW:
+				if (cqe->res < 0) {
+					fprintf(stderr,
+						"ERROR_EARLY_OVERFLOW: res %d\n", cqe->res);
+					goto cleanup;
+				}
+				break;
+			case ERROR_EARLY_CLOSE_RECEIVER:
+				if (cqe->res != -ECANCELED) {
+					fprintf(stderr,
+						"ERROR_EARLY_CLOSE_RECEIVER: res %d\n", cqe->res);
+					goto cleanup;
+				}
+				break;
+			case ERROR_NONE:
+			case ERROR_EARLY_CLOSE_SENDER:
+				if (args->recvmsg && (cqe->flags & IORING_CQE_F_BUFFER)) {
+					void *buff = recv_buffs[cqe->flags >> 16];
+					struct io_uring_recvmsg_out *o =
+						io_uring_recvmsg_validate(buff, cqe->res, &msg);
+
+					if (!o) {
+						fprintf(stderr, "invalid buff\n");
+						goto cleanup;
+					}
+					if (o->payloadlen != 0) {
+						fprintf(stderr, "expected 0 payloadlen, got %u\n",
+							o->payloadlen);
+						goto cleanup;
+					}
+					used_res = 0;
+				} else if (cqe->res != 0) {
+					fprintf(stderr, "early error: res %d\n", cqe->res);
+					goto cleanup;
+				}
+				break;
+			case ERROR_EARLY_LAST:
+				fprintf(stderr, "bad error_early\n");
+				goto cleanup;
+			};
+
+			if (cqe->res <= 0 && cqe->flags & IORING_CQE_F_BUFFER) {
+				fprintf(stderr, "final BUFFER flag set\n");
+				goto cleanup;
+			}
+
+			if (cqe->flags & IORING_CQE_F_MORE) {
+				fprintf(stderr, "final MORE flag set\n");
+				goto cleanup;
+			}
+
+			if (used_res <= 0)
+				continue;
+		} else {
+			if (!(cqe->flags & IORING_CQE_F_MORE)) {
+				fprintf(stderr, "MORE flag not set\n");
+				goto cleanup;
+			}
+		}
+
+		if (!(cqe->flags & IORING_CQE_F_BUFFER)) {
+			fprintf(stderr, "BUFFER flag not set\n");
+			goto cleanup;
+		}
+
+		this_recv = recv_buffs[cqe->flags >> 16];
+
+		if (args->recvmsg) {
+			struct io_uring_recvmsg_out *o = io_uring_recvmsg_validate(
+				this_recv, cqe->res, &msg);
+
+			if (!o) {
+				fprintf(stderr, "bad recvmsg\n");
+				goto cleanup;
+			}
+			orig_payload_size = o->payloadlen;
+
+			if (!args->stream) {
+				orig_payload_size = o->payloadlen;
+
+				struct cmsghdr *cmsg;
+
+				if (o->namelen < sizeof(struct sockaddr_in)) {
+					fprintf(stderr, "bad addr len %d",
+						o->namelen);
+					goto cleanup;
+				}
+				if (check_sockaddr((struct sockaddr_in *)io_uring_recvmsg_name(o)))
+					goto cleanup;
+
+				cmsg = io_uring_recvmsg_cmsg_firsthdr(o, &msg);
+				if (!cmsg ||
+				    cmsg->cmsg_level != IPPROTO_IP ||
+				    cmsg->cmsg_type != IP_RECVORIGDSTADDR) {
+					fprintf(stderr, "bad cmsg");
+					goto cleanup;
+				}
+				if (check_sockaddr((struct sockaddr_in *)CMSG_DATA(cmsg)))
+					goto cleanup;
+				cmsg = io_uring_recvmsg_cmsg_nexthdr(o, &msg, cmsg);
+				if (cmsg) {
+					fprintf(stderr, "unexpected extra cmsg\n");
+					goto cleanup;
+				}
+
+			}
+
+			this_recv = (int *)io_uring_recvmsg_payload(o, &msg);
+			cqe->res = io_uring_recvmsg_payload_length(o, cqe->res, &msg);
+			if (o->payloadlen != cqe->res) {
+				if (!(o->flags & MSG_TRUNC)) {
+					fprintf(stderr, "expected truncated flag\n");
+					goto cleanup;
+				}
+				total_dropped_bytes += (o->payloadlen - cqe->res);
+			}
+		}
+
+		total_recv_bytes += cqe->res;
+
+		if (cqe->res % 4 != 0) {
+			/*
+			 * doesn't seem to happen in practice, would need some
+			 * work to remove this requirement
+			 */
+			fprintf(stderr, "unexpectedly aligned buffer cqe->res=%d\n", cqe->res);
+			goto cleanup;
+		}
+
+		/*
+		 * for tcp: check buffer arrived in order
+		 * for udp: based on size validate data based on size
+		 */
+		if (!args->stream) {
+			int sent_idx = orig_payload_size / sizeof(*at) - 1;
+
+			if (sent_idx < 0 || sent_idx > N) {
+				fprintf(stderr, "Bad sent idx: %d\n", sent_idx);
+				goto cleanup;
+			}
+			at = sent_buffs[sent_idx];
+		}
+		for (j = 0; j < cqe->res / 4; j++) {
+			int sent = *at++;
+			int recv = *this_recv++;
+
+			if (sent != recv) {
+				fprintf(stderr, "recv=%d sent=%d\n", recv, sent);
+				goto cleanup;
+			}
+		}
+	}
+
+	if (args->early_error == ERROR_NONE &&
+	    total_recv_bytes + total_dropped_bytes < total_sent_bytes) {
+		fprintf(stderr,
+			"missing recv: recv=%d dropped=%d sent=%d\n",
+			total_recv_bytes, total_sent_bytes, total_dropped_bytes);
+		goto cleanup;
+	}
+
+	ret = 0;
+cleanup:
+	for (i = 0; i < ARRAY_SIZE(recv_buffs); i++)
+		free(recv_buffs[i]);
+	close(fds[0]);
+	close(fds[1]);
+	io_uring_queue_exit(&ring);
+
+	return ret;
+}
+
+int main(int argc, char *argv[])
+{
+	int ret;
+	int loop;
+	int early_error = 0;
+	bool has_defer;
+
+	if (argc > 1)
+		return T_EXIT_SKIP;
+
+	has_defer = t_probe_defer_taskrun();
+
+	for (loop = 0; loop < 16; loop++) {
+		struct args a = {
+			.stream = loop & 0x01,
+			.wait_each = loop & 0x2,
+			.recvmsg = loop & 0x04,
+			.defer = loop & 0x08,
+		};
+		if (a.defer && !has_defer)
+			continue;
+		for (early_error = 0; early_error < ERROR_EARLY_LAST; early_error++) {
+			a.early_error = (enum early_error_t)early_error;
+			ret = test(&a);
+			if (ret) {
+				if (ret == -ENORECVMULTISHOT) {
+					if (loop == 0)
+						return T_EXIT_SKIP;
+					fprintf(stderr,
+						"ENORECVMULTISHOT received but loop>0\n");
+				}
+				fprintf(stderr,
+					"test stream=%d wait_each=%d recvmsg=%d early_error=%d "
+					" defer=%d failed\n",
+					a.stream, a.wait_each, a.recvmsg, a.early_error, a.defer);
+				return T_EXIT_FAIL;
+			}
+		}
+	}
+
+	return T_EXIT_PASS;
+}

--- a/vendor/liburing/test/ring-leak.c
+++ b/vendor/liburing/test/ring-leak.c
@@ -135,6 +135,17 @@ static int test_iowq_request_cancel(void)
 	return 0;
 }
 
+static void trigger_unix_gc(void)
+{
+	int fd;
+
+	fd = socket(AF_UNIX, SOCK_DGRAM, 0);
+	if (fd < 0)
+		perror("socket dgram");
+	else
+		close(fd);
+}
+
 static int test_scm_cycles(bool update)
 {
 	char buffer[128];
@@ -192,6 +203,8 @@ static int test_scm_cycles(bool update)
 
 	/* should unregister files and close the write fd */
 	io_uring_queue_exit(&ring);
+
+	trigger_unix_gc();
 
 	/*
 	 * We're trying to wait for the ring to "really" exit, that will be

--- a/vendor/liburing/test/ringbuf-read.c
+++ b/vendor/liburing/test/ringbuf-read.c
@@ -156,6 +156,7 @@ int main(int argc, char *argv[])
 		ret = write(fd, buf, BUF_SIZE);
 		if (ret != BUF_SIZE) {
 			fprintf(stderr, "bad file prep write\n");
+			close(fd);
 			goto err;
 		}
 	}
@@ -164,32 +165,36 @@ int main(int argc, char *argv[])
 	ret = test(fname, 1, 0);
 	if (ret) {
 		fprintf(stderr, "dio test failed\n");
-		return ret;
+		goto err;
 	}
 	if (no_buf_ring)
-		return 0;
+		goto pass;
 
 	ret = test(fname, 0, 0);
 	if (ret) {
 		fprintf(stderr, "buffered test failed\n");
-		return ret;
+		goto err;
 	}
 
 	ret = test(fname, 1, 1);
 	if (ret) {
 		fprintf(stderr, "dio async test failed\n");
-		return ret;
+		goto err;
 	}
 
 	ret = test(fname, 0, 1);
 	if (ret) {
 		fprintf(stderr, "buffered async test failed\n");
-		return ret;
+		goto err;
 	}
 
-	return 0;
+pass:
+	ret = T_EXIT_PASS;
+	goto out;
 err:
+	ret = T_EXIT_FAIL;
+out:
 	if (do_unlink)
 		unlink(fname);
-	return 1;
+	return ret;
 }

--- a/vendor/liburing/test/runtests.sh
+++ b/vendor/liburing/test/runtests.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 
 TESTS=("$@")
-RET=0
 TIMEOUT=60
 DMESG_FILTER="cat"
 TEST_DIR=$(dirname "$0")
-FAILED=""
-SKIPPED=""
-TIMED_OUT=""
+FAILED=()
+SKIPPED=()
+TIMED_OUT=()
 TEST_FILES=""
 declare -A TEST_MAP
 
@@ -94,7 +93,7 @@ run_test()
 	# shellcheck disable=SC2181
 	if [ $? -eq 0 ]; then
 		echo "Test skipped"
-		SKIPPED="$SKIPPED <$test_string>"
+		SKIPPED+=("<$test_string>")
 		return
 	fi
 
@@ -111,15 +110,16 @@ run_test()
 	# Check test status
 	if [ "$status" -eq 124 ]; then
 		echo "Test $test_name timed out (may not be a failure)"
-		TIMED_OUT="$TIMED_OUT <$test_string>"
+		TIMED_OUT+=("<$test_string>")
+	elif [ "$status" -eq 77 ]; then
+		echo "Skipped"
+		SKIPPED+=("<$test_string>")
 	elif [ "$status" -ne 0 ]; then
 		echo "Test $test_name failed with ret $status"
-		FAILED="$FAILED <$test_string>"
-		RET=1
+		FAILED+=("<$test_string>")
 	elif ! _check_dmesg "$dmesg_marker" "$test_name"; then
 		echo "Test $test_name failed dmesg check"
-		FAILED="$FAILED <$test_string>"
-		RET=1
+		FAILED+=("<$test_string>")
 	else
 		if [ -f "output/$out_name" ]; then
 			T_PREV=$(cat "output/$out_name")
@@ -153,17 +153,15 @@ for tst in "${TESTS[@]}"; do
 	fi
 done
 
-if [ -n "$SKIPPED" ]; then
-	echo "Tests skipped: $SKIPPED"
+if [ "${#TIMED_OUT[*]}" -ne 0 ]; then
+	echo "Tests timed out (${#TIMED_OUT[*]}): ${TIMED_OUT[*]}"
 fi
 
-if [ -n "$TIMED_OUT" ]; then
-	echo "Tests timed out: $TIMED_OUT"
-fi
-
-if [ "${RET}" -ne 0 ]; then
-	echo "Tests failed: $FAILED"
-	exit $RET
+if [ "${#FAILED[*]}" -ne 0 ]; then
+	echo "Tests failed (${#FAILED[*]}): ${FAILED[*]}"
+	exit 1
+elif [ "${#SKIPPED[*]}" -ne 0 ] && [ -n "$TEST_GNU_EXITCODE" ]; then
+	exit 77
 else
 	echo "All tests passed"
 	exit 0

--- a/vendor/liburing/test/rw_merge_test.c
+++ b/vendor/liburing/test/rw_merge_test.c
@@ -79,7 +79,7 @@ int main(int argc, char *argv[])
 	assert(ret == 1);
 
 	/*
-	 * Read may stuck because of bug there request was be incorrecly
+	 * Read may stuck because of bug there request was be incorrectly
 	 * merged with <REQ1> request
 	 */
 	ret = io_uring_wait_cqe_timeout(&ring, &cqe, &ts);

--- a/vendor/liburing/test/send-zerocopy.c
+++ b/vendor/liburing/test/send-zerocopy.c
@@ -1,0 +1,684 @@
+/* SPDX-License-Identifier: MIT */
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <assert.h>
+#include <errno.h>
+#include <error.h>
+#include <limits.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include <arpa/inet.h>
+#include <linux/errqueue.h>
+#include <linux/if_packet.h>
+#include <linux/ipv6.h>
+#include <linux/socket.h>
+#include <linux/sockios.h>
+#include <net/ethernet.h>
+#include <net/if.h>
+#include <netinet/ip.h>
+#include <netinet/in.h>
+#include <netinet/ip6.h>
+#include <netinet/tcp.h>
+#include <netinet/udp.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+#include <sys/un.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include "liburing.h"
+#include "helpers.h"
+
+#define MAX_MSG	128
+
+#define PORT	10200
+#define HOST	"127.0.0.1"
+#define HOSTV6	"::1"
+
+#define CORK_REQS 5
+#define RX_TAG 10000
+#define BUFFER_OFFSET 41
+
+#ifndef ARRAY_SIZE
+	#define ARRAY_SIZE(a) (sizeof(a)/sizeof((a)[0]))
+#endif
+
+enum {
+	BUF_T_NORMAL,
+	BUF_T_SMALL,
+	BUF_T_NONALIGNED,
+	BUF_T_LARGE,
+};
+
+static char *tx_buffer, *rx_buffer;
+static struct iovec buffers_iov[4];
+static bool has_sendmsg;
+
+static bool check_cq_empty(struct io_uring *ring)
+{
+	struct io_uring_cqe *cqe = NULL;
+	int ret;
+
+	ret = io_uring_peek_cqe(ring, &cqe); /* nothing should be there */
+	return ret == -EAGAIN;
+}
+
+static int test_basic_send(struct io_uring *ring, int sock_tx, int sock_rx)
+{
+	struct io_uring_sqe *sqe;
+	struct io_uring_cqe *cqe;
+	int msg_flags = 0;
+	unsigned zc_flags = 0;
+	int payload_size = 100;
+	int ret;
+
+	sqe = io_uring_get_sqe(ring);
+	io_uring_prep_send_zc(sqe, sock_tx, tx_buffer, payload_size,
+			      msg_flags, zc_flags);
+	sqe->user_data = 1;
+
+	ret = io_uring_submit(ring);
+	assert(ret == 1);
+
+	ret = io_uring_wait_cqe(ring, &cqe);
+	assert(!ret && cqe->user_data == 1);
+	if (cqe->res == -EINVAL) {
+		assert(!(cqe->flags & IORING_CQE_F_MORE));
+		return T_EXIT_SKIP;
+	} else if (cqe->res != payload_size) {
+		fprintf(stderr, "send failed %i\n", cqe->res);
+		return T_EXIT_FAIL;
+	}
+
+	assert(cqe->flags & IORING_CQE_F_MORE);
+	io_uring_cqe_seen(ring, cqe);
+
+	ret = io_uring_wait_cqe(ring, &cqe);
+	assert(!ret);
+	assert(cqe->user_data == 1);
+	assert(cqe->flags & IORING_CQE_F_NOTIF);
+	assert(!(cqe->flags & IORING_CQE_F_MORE));
+	io_uring_cqe_seen(ring, cqe);
+	assert(check_cq_empty(ring));
+
+	ret = recv(sock_rx, rx_buffer, payload_size, MSG_TRUNC);
+	assert(ret == payload_size);
+	return T_EXIT_PASS;
+}
+
+static int test_send_faults(struct io_uring *ring, int sock_tx, int sock_rx)
+{
+	struct io_uring_sqe *sqe;
+	struct io_uring_cqe *cqe;
+	int msg_flags = 0;
+	unsigned zc_flags = 0;
+	int payload_size = 100;
+	int ret, i, nr_cqes = 2;
+
+	sqe = io_uring_get_sqe(ring);
+	io_uring_prep_send_zc(sqe, sock_tx, (void *)1UL, payload_size,
+			      msg_flags, zc_flags);
+	sqe->user_data = 1;
+
+	sqe = io_uring_get_sqe(ring);
+	io_uring_prep_send_zc(sqe, sock_tx, tx_buffer, payload_size,
+			      msg_flags, zc_flags);
+	sqe->user_data = 2;
+	io_uring_prep_send_set_addr(sqe, (const struct sockaddr *)1UL,
+				    sizeof(struct sockaddr_in6));
+
+	ret = io_uring_submit(ring);
+	assert(ret == 2);
+
+	for (i = 0; i < nr_cqes; i++) {
+		ret = io_uring_wait_cqe(ring, &cqe);
+		assert(!ret);
+		assert(cqe->user_data <= 2);
+
+		if (!(cqe->flags & IORING_CQE_F_NOTIF)) {
+			assert(cqe->res == -EFAULT);
+			if (cqe->flags & IORING_CQE_F_MORE)
+				nr_cqes++;
+		}
+		io_uring_cqe_seen(ring, cqe);
+	}
+	assert(check_cq_empty(ring));
+	return T_EXIT_PASS;
+}
+
+static int create_socketpair_ip(struct sockaddr_storage *addr,
+				int *sock_client, int *sock_server,
+				bool ipv6, bool client_connect,
+				bool msg_zc, bool tcp)
+{
+	int family, addr_size;
+	int ret, val;
+	int listen_sock = -1;
+	int sock;
+
+	memset(addr, 0, sizeof(*addr));
+	if (ipv6) {
+		struct sockaddr_in6 *saddr = (struct sockaddr_in6 *)addr;
+
+		family = AF_INET6;
+		saddr->sin6_family = family;
+		saddr->sin6_port = htons(PORT);
+		addr_size = sizeof(*saddr);
+	} else {
+		struct sockaddr_in *saddr = (struct sockaddr_in *)addr;
+
+		family = AF_INET;
+		saddr->sin_family = family;
+		saddr->sin_port = htons(PORT);
+		saddr->sin_addr.s_addr = htonl(INADDR_ANY);
+		addr_size = sizeof(*saddr);
+	}
+
+	/* server sock setup */
+	if (tcp) {
+		sock = listen_sock = socket(family, SOCK_STREAM, IPPROTO_TCP);
+	} else {
+		sock = *sock_server = socket(family, SOCK_DGRAM, 0);
+	}
+	if (sock < 0) {
+		perror("socket");
+		return 1;
+	}
+	val = 1;
+	setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
+	val = 1;
+	setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &val, sizeof(val));
+
+	ret = bind(sock, (struct sockaddr *)addr, addr_size);
+	if (ret < 0) {
+		perror("bind");
+		return 1;
+	}
+	if (tcp) {
+		ret = listen(sock, 128);
+		assert(ret != -1);
+	}
+
+	if (ipv6) {
+		struct sockaddr_in6 *saddr = (struct sockaddr_in6 *)addr;
+
+		inet_pton(AF_INET6, HOSTV6, &(saddr->sin6_addr));
+	} else {
+		struct sockaddr_in *saddr = (struct sockaddr_in *)addr;
+
+		inet_pton(AF_INET, HOST, &saddr->sin_addr);
+	}
+
+	/* client sock setup */
+	if (tcp) {
+		*sock_client = socket(family, SOCK_STREAM, IPPROTO_TCP);
+		assert(client_connect);
+	} else {
+		*sock_client = socket(family, SOCK_DGRAM, 0);
+	}
+	if (*sock_client < 0) {
+		perror("socket");
+		return 1;
+	}
+	if (client_connect) {
+		ret = connect(*sock_client, (struct sockaddr *)addr, addr_size);
+		if (ret < 0) {
+			perror("connect");
+			return 1;
+		}
+	}
+	if (msg_zc) {
+		val = 1;
+		if (setsockopt(*sock_client, SOL_SOCKET, SO_ZEROCOPY, &val, sizeof(val))) {
+			perror("setsockopt zc");
+			return 1;
+		}
+	}
+	if (tcp) {
+		*sock_server = accept(listen_sock, NULL, NULL);
+		if (!*sock_server) {
+			fprintf(stderr, "can't accept\n");
+			return 1;
+		}
+		close(listen_sock);
+	}
+	return 0;
+}
+
+static int do_test_inet_send(struct io_uring *ring, int sock_client, int sock_server,
+			     bool fixed_buf, struct sockaddr_storage *addr,
+			     bool cork, bool mix_register,
+			     int buf_idx, bool force_async, bool use_sendmsg)
+{
+	struct iovec iov[CORK_REQS];
+	struct msghdr msghdr[CORK_REQS];
+	const unsigned zc_flags = 0;
+	struct io_uring_sqe *sqe;
+	struct io_uring_cqe *cqe;
+	int nr_reqs = cork ? CORK_REQS : 1;
+	int i, ret, nr_cqes, addr_len = 0;
+	size_t send_size = buffers_iov[buf_idx].iov_len;
+	size_t chunk_size = send_size / nr_reqs;
+	size_t chunk_size_last = send_size - chunk_size * (nr_reqs - 1);
+	char *buf = buffers_iov[buf_idx].iov_base;
+
+	if (addr) {
+		sa_family_t fam = ((struct sockaddr_in *)addr)->sin_family;
+
+		addr_len = (fam == AF_INET) ? sizeof(struct sockaddr_in) :
+					      sizeof(struct sockaddr_in6);
+	}
+
+	memset(rx_buffer, 0, send_size);
+
+	for (i = 0; i < nr_reqs; i++) {
+		bool real_fixed_buf = fixed_buf;
+		size_t cur_size = chunk_size;
+		int msg_flags = MSG_WAITALL;
+
+		if (mix_register)
+			real_fixed_buf = rand() & 1;
+
+		if (cork && i != nr_reqs - 1)
+			msg_flags |= MSG_MORE;
+		if (i == nr_reqs - 1)
+			cur_size = chunk_size_last;
+
+		sqe = io_uring_get_sqe(ring);
+
+		if (!use_sendmsg) {
+			io_uring_prep_send_zc(sqe, sock_client, buf + i * chunk_size,
+					      cur_size, msg_flags, zc_flags);
+			if (real_fixed_buf) {
+				sqe->ioprio |= IORING_RECVSEND_FIXED_BUF;
+				sqe->buf_index = buf_idx;
+			}
+			if (addr)
+				io_uring_prep_send_set_addr(sqe, (const struct sockaddr *)addr,
+							    addr_len);
+		} else {
+			io_uring_prep_sendmsg_zc(sqe, sock_client, &msghdr[i], msg_flags);
+
+			memset(&msghdr[i], 0, sizeof(msghdr[i]));
+			iov[i].iov_len = cur_size;
+			iov[i].iov_base = buf + i * chunk_size;
+			msghdr[i].msg_iov = &iov[i];
+			msghdr[i].msg_iovlen = 1;
+			if (addr) {
+				msghdr[i].msg_name = addr;
+				msghdr[i].msg_namelen = addr_len;
+			}
+		}
+		sqe->user_data = i;
+		if (force_async)
+			sqe->flags |= IOSQE_ASYNC;
+		if (i != nr_reqs - 1)
+			sqe->flags |= IOSQE_IO_LINK;
+	}
+
+	sqe = io_uring_get_sqe(ring);
+	io_uring_prep_recv(sqe, sock_server, rx_buffer, send_size, MSG_WAITALL);
+	sqe->user_data = RX_TAG;
+
+	ret = io_uring_submit(ring);
+	if (ret != nr_reqs + 1) {
+		fprintf(stderr, "submit failed, got %i expected %i\n", ret, nr_reqs);
+		return 1;
+	}
+
+	nr_cqes = 2 * nr_reqs + 1;
+	for (i = 0; i < nr_cqes; i++) {
+		int expected = chunk_size;
+
+		ret = io_uring_wait_cqe(ring, &cqe);
+		if (ret) {
+			fprintf(stderr, "io_uring_wait_cqe failed %i\n", ret);
+			return 1;
+		}
+		if (cqe->user_data == RX_TAG) {
+			if (cqe->res != send_size) {
+				fprintf(stderr, "rx failed %i\n", cqe->res);
+				return 1;
+			}
+			io_uring_cqe_seen(ring, cqe);
+			continue;
+		}
+
+		if (cqe->user_data >= nr_reqs) {
+			fprintf(stderr, "invalid user_data %lu\n",
+					(unsigned long)cqe->user_data);
+			return 1;
+		}
+		if (!(cqe->flags & IORING_CQE_F_NOTIF)) {
+			if (cqe->user_data == nr_reqs - 1)
+				expected = chunk_size_last;
+			if (cqe->res != expected) {
+				fprintf(stderr, "invalid cqe->res %d expected %d\n",
+						 cqe->res, expected);
+				return 1;
+			}
+		}
+		if ((cqe->flags & IORING_CQE_F_MORE) ==
+		    (cqe->flags & IORING_CQE_F_NOTIF)) {
+			fprintf(stderr, "unexpected cflags %i res %i\n",
+					cqe->flags, cqe->res);
+			return 1;
+		}
+		io_uring_cqe_seen(ring, cqe);
+	}
+
+	for (i = 0; i < send_size; i++) {
+		if (buf[i] != rx_buffer[i]) {
+			fprintf(stderr, "botched data, first mismated byte %i, "
+				"%u vs %u\n", i, buf[i], rx_buffer[i]);
+			return 1;
+		}
+	}
+	return 0;
+}
+
+static int test_inet_send(struct io_uring *ring)
+{
+	struct sockaddr_storage addr;
+	int sock_client = -1, sock_server = -1;
+	int ret, j, i;
+
+	for (j = 0; j < 16; j++) {
+		bool ipv6 = j & 1;
+		bool client_connect = j & 2;
+		bool msg_zc_set = j & 4;
+		bool tcp = j & 8;
+
+		if (tcp && !client_connect)
+			continue;
+
+		ret = create_socketpair_ip(&addr, &sock_client, &sock_server, ipv6,
+				 client_connect, msg_zc_set, tcp);
+		if (ret) {
+			fprintf(stderr, "sock prep failed %d\n", ret);
+			return 1;
+		}
+
+		for (i = 0; i < 256; i++) {
+			int buf_flavour = i & 3;
+			bool fixed_buf = i & 4;
+			struct sockaddr_storage *addr_arg = (i & 8) ? &addr : NULL;
+			bool cork = i & 16;
+			bool mix_register = i & 32;
+			bool force_async = i & 64;
+			bool use_sendmsg = i & 128;
+
+			if (buf_flavour == BUF_T_LARGE && !tcp)
+				continue;
+			if (!buffers_iov[buf_flavour].iov_base)
+				continue;
+			if (tcp && (cork || addr_arg))
+				continue;
+			if (mix_register && (!cork || fixed_buf))
+				continue;
+			if (!client_connect && addr_arg == NULL)
+				continue;
+			if (use_sendmsg && (mix_register || fixed_buf || !has_sendmsg))
+				continue;
+
+			ret = do_test_inet_send(ring, sock_client, sock_server, fixed_buf,
+						addr_arg, cork, mix_register,
+						buf_flavour, force_async, use_sendmsg);
+			if (ret) {
+				fprintf(stderr, "send failed fixed buf %i, conn %i, addr %i, "
+					"cork %i\n",
+					fixed_buf, client_connect, !!addr_arg,
+					cork);
+				return 1;
+			}
+		}
+
+		close(sock_client);
+		close(sock_server);
+	}
+	return 0;
+}
+
+static int test_async_addr(struct io_uring *ring)
+{
+	struct io_uring_sqe *sqe;
+	struct io_uring_cqe *cqe;
+	struct sockaddr_storage addr;
+	int sock_tx = -1, sock_rx = -1;
+	struct __kernel_timespec ts;
+	int ret;
+
+	ts.tv_sec = 1;
+	ts.tv_nsec = 0;
+	ret = create_socketpair_ip(&addr, &sock_tx, &sock_rx, true, false, false, false);
+	if (ret) {
+		fprintf(stderr, "sock prep failed %d\n", ret);
+		return 1;
+	}
+
+	sqe = io_uring_get_sqe(ring);
+	io_uring_prep_timeout(sqe, &ts, 0, IORING_TIMEOUT_ETIME_SUCCESS);
+	sqe->user_data = 1;
+	sqe->flags |= IOSQE_IO_LINK;
+
+	sqe = io_uring_get_sqe(ring);
+	io_uring_prep_send_zc(sqe, sock_tx, tx_buffer, 1, 0, 0);
+	sqe->user_data = 2;
+	io_uring_prep_send_set_addr(sqe, (const struct sockaddr *)&addr,
+				    sizeof(struct sockaddr_in6));
+
+	ret = io_uring_submit(ring);
+	assert(ret == 2);
+	memset(&addr, 0, sizeof(addr));
+
+	ret = io_uring_wait_cqe(ring, &cqe);
+	if (ret) {
+		fprintf(stderr, "io_uring_wait_cqe failed %i\n", ret);
+		return 1;
+	}
+	if (cqe->user_data != 1 || cqe->res != -ETIME) {
+		fprintf(stderr, "invalid timeout res %i %i\n",
+			(int)cqe->user_data, cqe->res);
+		return 1;
+	}
+	io_uring_cqe_seen(ring, cqe);
+
+	ret = io_uring_wait_cqe(ring, &cqe);
+	if (ret) {
+		fprintf(stderr, "io_uring_wait_cqe failed %i\n", ret);
+		return 1;
+	}
+	if (cqe->user_data != 2 || cqe->res != 1) {
+		fprintf(stderr, "invalid send %i %i\n",
+			(int)cqe->user_data, cqe->res);
+		return 1;
+	}
+	io_uring_cqe_seen(ring, cqe);
+	ret = recv(sock_rx, rx_buffer, 1, MSG_TRUNC);
+	assert(ret == 1);
+
+	ret = io_uring_wait_cqe(ring, &cqe);
+	if (ret) {
+		fprintf(stderr, "io_uring_wait_cqe failed %i\n", ret);
+		return 1;
+	}
+	assert(cqe->flags & IORING_CQE_F_NOTIF);
+	io_uring_cqe_seen(ring, cqe);
+
+	close(sock_tx);
+	close(sock_rx);
+	return 0;
+}
+
+static bool io_check_zc_sendmsg(struct io_uring *ring)
+{
+	struct io_uring_probe *p;
+	int ret;
+
+	p = t_calloc(1, sizeof(*p) + 256 * sizeof(struct io_uring_probe_op));
+	if (!p) {
+		fprintf(stderr, "probe allocation failed\n");
+		return false;
+	}
+	ret = io_uring_register_probe(ring, p, 256);
+	if (ret)
+		return false;
+	return p->ops_len > IORING_OP_SENDMSG_ZC;
+}
+
+/* see also send_recv.c:test_invalid */
+static int test_invalid_zc(int fds[2])
+{
+	struct io_uring ring;
+	int ret;
+	struct io_uring_cqe *cqe;
+	struct io_uring_sqe *sqe;
+	bool notif = false;
+
+	if (!has_sendmsg)
+		return 0;
+
+	ret = t_create_ring(8, &ring, 0);
+	if (ret)
+		return ret;
+
+	sqe = io_uring_get_sqe(&ring);
+	io_uring_prep_sendmsg(sqe, fds[0], NULL, MSG_WAITALL);
+	sqe->opcode = IORING_OP_SENDMSG_ZC;
+	sqe->flags |= IOSQE_ASYNC;
+
+	ret = io_uring_submit(&ring);
+	if (ret != 1) {
+		fprintf(stderr, "submit failed %i\n", ret);
+		return ret;
+	}
+	ret = io_uring_wait_cqe(&ring, &cqe);
+	if (ret)
+		return 1;
+	if (cqe->flags & IORING_CQE_F_MORE)
+		notif = true;
+	io_uring_cqe_seen(&ring, cqe);
+
+	if (notif) {
+		ret = io_uring_wait_cqe(&ring, &cqe);
+		if (ret)
+			return 1;
+		io_uring_cqe_seen(&ring, cqe);
+	}
+	io_uring_queue_exit(&ring);
+	return 0;
+}
+
+int main(int argc, char *argv[])
+{
+	struct sockaddr_storage addr;
+	struct io_uring ring;
+	int i, ret, sp[2];
+	size_t len;
+
+	if (argc > 1)
+		return T_EXIT_SKIP;
+
+	/* create TCP IPv6 pair */
+	ret = create_socketpair_ip(&addr, &sp[0], &sp[1], true, true, false, true);
+	if (ret) {
+		fprintf(stderr, "sock prep failed %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	len = 1U << 25; /* 32MB, should be enough to trigger a short send */
+	tx_buffer = aligned_alloc(4096, len);
+	rx_buffer = aligned_alloc(4096, len);
+	if (tx_buffer && rx_buffer) {
+		buffers_iov[BUF_T_LARGE].iov_base = tx_buffer;
+		buffers_iov[BUF_T_LARGE].iov_len = len;
+	} else {
+		printf("skip large buffer tests, can't alloc\n");
+
+		len = 8192;
+		tx_buffer = aligned_alloc(4096, len);
+		rx_buffer = aligned_alloc(4096, len);
+	}
+	if (!tx_buffer || !rx_buffer) {
+		fprintf(stderr, "can't allocate buffers\n");
+		return T_EXIT_FAIL;
+	}
+
+	buffers_iov[BUF_T_NORMAL].iov_base = tx_buffer + 4096;
+	buffers_iov[BUF_T_NORMAL].iov_len = 4096;
+	buffers_iov[BUF_T_SMALL].iov_base = tx_buffer;
+	buffers_iov[BUF_T_SMALL].iov_len = 137;
+	buffers_iov[BUF_T_NONALIGNED].iov_base = tx_buffer + BUFFER_OFFSET;
+	buffers_iov[BUF_T_NONALIGNED].iov_len = 8192 - BUFFER_OFFSET - 13;
+
+	ret = io_uring_queue_init(32, &ring, 0);
+	if (ret) {
+		fprintf(stderr, "queue init failed: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	srand((unsigned)time(NULL));
+	for (i = 0; i < len; i++)
+		tx_buffer[i] = i;
+	memset(rx_buffer, 0, len);
+
+	ret = test_basic_send(&ring, sp[0], sp[1]);
+	if (ret == T_EXIT_SKIP)
+		return ret;
+	if (ret) {
+		fprintf(stderr, "test_basic_send() failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	has_sendmsg = io_check_zc_sendmsg(&ring);
+
+	ret = test_send_faults(&ring, sp[0], sp[1]);
+	if (ret) {
+		fprintf(stderr, "test_send_faults() failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	ret = test_invalid_zc(sp);
+	if (ret) {
+		fprintf(stderr, "test_invalid_zc() failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	close(sp[0]);
+	close(sp[1]);
+
+	ret = test_async_addr(&ring);
+	if (ret) {
+		fprintf(stderr, "test_async_addr() failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	ret = t_register_buffers(&ring, buffers_iov, ARRAY_SIZE(buffers_iov));
+	if (ret == T_SETUP_SKIP) {
+		fprintf(stderr, "can't register bufs, skip\n");
+		goto out;
+	} else if (ret != T_SETUP_OK) {
+		fprintf(stderr, "buffer registration failed %i\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	ret = test_inet_send(&ring);
+	if (ret) {
+		fprintf(stderr, "test_inet_send() failed\n");
+		return T_EXIT_FAIL;
+	}
+out:
+	io_uring_queue_exit(&ring);
+	close(sp[0]);
+	close(sp[1]);
+	return T_EXIT_PASS;
+}

--- a/vendor/liburing/test/shutdown.c
+++ b/vendor/liburing/test/shutdown.c
@@ -19,6 +19,7 @@
 #include <arpa/inet.h>
 
 #include "liburing.h"
+#include "helpers.h"
 
 static void sig_pipe(int sig)
 {
@@ -29,7 +30,7 @@ int main(int argc, char *argv[])
 	int p_fd[2], ret;
 	int32_t recv_s0;
 	int32_t val = 1;
-	struct sockaddr_in addr;
+	struct sockaddr_in addr = { };
 
 	if (argc > 1)
 		return 0;
@@ -44,11 +45,9 @@ int main(int argc, char *argv[])
 	assert(ret != -1);
 
 	addr.sin_family = AF_INET;
-	addr.sin_port = htons((rand() % 61440) + 4096);
 	addr.sin_addr.s_addr = inet_addr("127.0.0.1");
 
-	ret = bind(recv_s0, (struct sockaddr*)&addr, sizeof(addr));
-	assert(ret != -1);
+	assert(!t_bind_ephemeral_port(recv_s0, &addr));
 	ret = listen(recv_s0, 128);
 	assert(ret != -1);
 

--- a/vendor/liburing/test/single-issuer.c
+++ b/vendor/liburing/test/single-issuer.c
@@ -1,0 +1,171 @@
+/* SPDX-License-Identifier: MIT */
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <error.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include "liburing.h"
+#include "test.h"
+#include "helpers.h"
+
+static pid_t pid;
+
+static pid_t fork_t(void)
+{
+	pid = fork();
+	if (pid == -1) {
+		fprintf(stderr, "fork failed\n");
+		exit(T_EXIT_FAIL);
+	}
+	return pid;
+}
+
+static void wait_child_t(void)
+{
+	int wstatus;
+
+	if (waitpid(pid, &wstatus, 0) == (pid_t)-1) {
+		perror("waitpid()");
+		exit(T_EXIT_FAIL);
+	}
+	if (!WIFEXITED(wstatus)) {
+		fprintf(stderr, "child failed %i\n", WEXITSTATUS(wstatus));
+		exit(T_EXIT_FAIL);
+	}
+	if (WEXITSTATUS(wstatus))
+		exit(T_EXIT_FAIL);
+}
+
+static int try_submit(struct io_uring *ring)
+{
+	struct io_uring_cqe *cqe;
+	struct io_uring_sqe *sqe;
+	int ret;
+
+	sqe = io_uring_get_sqe(ring);
+	io_uring_prep_nop(sqe);
+	sqe->user_data = 42;
+
+	ret = io_uring_submit(ring);
+	if (ret < 0)
+		return ret;
+
+	if (ret != 1)
+		error(1, ret, "submit %i", ret);
+	ret = io_uring_wait_cqe(ring, &cqe);
+	if (ret)
+		error(1, ret, "wait fail %i", ret);
+
+	if (cqe->res || cqe->user_data != 42)
+		error(1, ret, "invalid cqe");
+
+	io_uring_cqe_seen(ring, cqe);
+	return 0;
+}
+
+int main(int argc, char *argv[])
+{
+	struct io_uring ring;
+	int ret;
+
+	if (argc > 1)
+		return T_EXIT_SKIP;
+
+	ret = io_uring_queue_init(8, &ring, IORING_SETUP_SINGLE_ISSUER);
+	if (ret == -EINVAL) {
+		fprintf(stderr, "SETUP_SINGLE_ISSUER is not supported, skip\n");
+		return T_EXIT_SKIP;
+	} else if (ret) {
+		fprintf(stderr, "io_uring_queue_init() failed %i\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	/* test that the creator iw allowed to submit */
+	ret = try_submit(&ring);
+	if (ret) {
+		fprintf(stderr, "the creator can't submit %i\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	/* test that a second submitter doesn't succeed */
+	if (!fork_t()) {
+		ret = try_submit(&ring);
+		if (ret != -EEXIST)
+			fprintf(stderr, "1: not owner child could submit %i\n", ret);
+		return ret != -EEXIST;
+	}
+	wait_child_t();
+	io_uring_queue_exit(&ring);
+
+	/* test that the first submitter but not creator can submit */
+	ret = io_uring_queue_init(8, &ring, IORING_SETUP_SINGLE_ISSUER |
+					    IORING_SETUP_R_DISABLED);
+	if (ret)
+		error(1, ret, "ring init (2) %i", ret);
+
+	if (!fork_t()) {
+		io_uring_enable_rings(&ring);
+		ret = try_submit(&ring);
+		if (ret)
+			fprintf(stderr, "2: not owner child could submit %i\n", ret);
+		return !!ret;
+	}
+	wait_child_t();
+	io_uring_queue_exit(&ring);
+
+	/* test that only the first enabler can submit */
+	ret = io_uring_queue_init(8, &ring, IORING_SETUP_SINGLE_ISSUER |
+					    IORING_SETUP_R_DISABLED);
+	if (ret)
+		error(1, ret, "ring init (3) %i", ret);
+
+	io_uring_enable_rings(&ring);
+	if (!fork_t()) {
+		ret = try_submit(&ring);
+		if (ret != -EEXIST)
+			fprintf(stderr, "3: not owner child could submit %i\n", ret);
+		return ret != -EEXIST;
+	}
+	wait_child_t();
+	io_uring_queue_exit(&ring);
+
+	/* test that anyone can submit to a SQPOLL|SINGLE_ISSUER ring */
+	ret = io_uring_queue_init(8, &ring, IORING_SETUP_SINGLE_ISSUER|IORING_SETUP_SQPOLL);
+	if (ret)
+		error(1, ret, "ring init (4) %i", ret);
+
+	ret = try_submit(&ring);
+	if (ret) {
+		fprintf(stderr, "SQPOLL submit failed (creator) %i\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	if (!fork_t()) {
+		ret = try_submit(&ring);
+		if (ret)
+			fprintf(stderr, "SQPOLL submit failed (child) %i\n", ret);
+		return !!ret;
+	}
+	wait_child_t();
+	io_uring_queue_exit(&ring);
+
+	/* test that IORING_ENTER_REGISTERED_RING doesn't break anything */
+	ret = io_uring_queue_init(8, &ring, IORING_SETUP_SINGLE_ISSUER);
+	if (ret)
+		error(1, ret, "ring init (5) %i", ret);
+
+	if (!fork_t()) {
+		ret = try_submit(&ring);
+		if (ret != -EEXIST)
+			fprintf(stderr, "4: not owner child could submit %i\n", ret);
+		return ret != -EEXIST;
+	}
+	wait_child_t();
+	io_uring_queue_exit(&ring);
+	return T_EXIT_PASS;
+}

--- a/vendor/liburing/test/socket-rw-eagain.c
+++ b/vendor/liburing/test/socket-rw-eagain.c
@@ -18,6 +18,7 @@
 #include <arpa/inet.h>
 
 #include "liburing.h"
+#include "helpers.h"
 
 int main(int argc, char *argv[])
 {
@@ -41,18 +42,7 @@ int main(int argc, char *argv[])
 
 	addr.sin_family = AF_INET;
 	addr.sin_addr.s_addr = inet_addr("127.0.0.1");
-
-	do {
-		addr.sin_port = htons((rand() % 61440) + 4096);
-		ret = bind(recv_s0, (struct sockaddr*)&addr, sizeof(addr));
-		if (!ret)
-			break;
-		if (errno != EADDRINUSE) {
-			perror("bind");
-			exit(1);
-		}
-	} while (1);
-
+	assert(!t_bind_ephemeral_port(recv_s0, &addr));
 	ret = listen(recv_s0, 128);
 	assert(ret != -1);
 

--- a/vendor/liburing/test/socket-rw-offset.c
+++ b/vendor/liburing/test/socket-rw-offset.c
@@ -20,6 +20,7 @@
 #include <arpa/inet.h>
 
 #include "liburing.h"
+#include "helpers.h"
 
 int main(int argc, char *argv[])
 {
@@ -43,17 +44,7 @@ int main(int argc, char *argv[])
 
 	addr.sin_family = AF_INET;
 	addr.sin_addr.s_addr = inet_addr("127.0.0.1");
-
-	do {
-		addr.sin_port = htons((rand() % 61440) + 4096);
-		ret = bind(recv_s0, (struct sockaddr*)&addr, sizeof(addr));
-		if (!ret)
-			break;
-		if (errno != EADDRINUSE) {
-			perror("bind");
-			exit(1);
-		}
-	} while (1);
+	assert(!t_bind_ephemeral_port(recv_s0, &addr));
 	ret = listen(recv_s0, 128);
 	assert(ret != -1);
 

--- a/vendor/liburing/test/socket-rw.c
+++ b/vendor/liburing/test/socket-rw.c
@@ -20,6 +20,7 @@
 #include <arpa/inet.h>
 
 #include "liburing.h"
+#include "helpers.h"
 
 int main(int argc, char *argv[])
 {
@@ -43,17 +44,7 @@ int main(int argc, char *argv[])
 
 	addr.sin_family = AF_INET;
 	addr.sin_addr.s_addr = inet_addr("127.0.0.1");
-
-	do {
-		addr.sin_port = htons((rand() % 61440) + 4096);
-		ret = bind(recv_s0, (struct sockaddr*)&addr, sizeof(addr));
-		if (!ret)
-			break;
-		if (errno != EADDRINUSE) {
-			perror("bind");
-			exit(1);
-		}
-	} while (1);
+	assert(!t_bind_ephemeral_port(recv_s0, &addr));
 	ret = listen(recv_s0, 128);
 	assert(ret != -1);
 

--- a/vendor/liburing/test/statx.c
+++ b/vendor/liburing/test/statx.c
@@ -40,7 +40,7 @@ static int test_statx(struct io_uring *ring, const char *path)
 {
 	struct io_uring_cqe *cqe;
 	struct io_uring_sqe *sqe;
-	struct statx x1, x2;
+	struct statx x1 = { }, x2 = { };
 	int ret;
 
 	sqe = io_uring_get_sqe(ring);

--- a/vendor/liburing/test/submit-and-wait.c
+++ b/vendor/liburing/test/submit-and-wait.c
@@ -1,0 +1,108 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Description: Test that io_uring_submit_and_wait_timeout() returns the
+ * right value (submit count) and that it doesn't end up waiting twice.
+ *
+ */
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/time.h>
+
+#include "liburing.h"
+#include "test.h"
+
+static unsigned long long mtime_since(const struct timeval *s,
+				      const struct timeval *e)
+{
+	long long sec, usec;
+
+	sec = e->tv_sec - s->tv_sec;
+	usec = (e->tv_usec - s->tv_usec);
+	if (sec > 0 && usec < 0) {
+		sec--;
+		usec += 1000000;
+	}
+
+	sec *= 1000;
+	usec /= 1000;
+	return sec + usec;
+}
+
+static unsigned long long mtime_since_now(struct timeval *tv)
+{
+	struct timeval end;
+
+	gettimeofday(&end, NULL);
+	return mtime_since(tv, &end);
+}
+
+static int test(struct io_uring *ring)
+{
+	struct io_uring_cqe *cqe;
+	struct io_uring_sqe *sqe;
+	struct __kernel_timespec ts;
+	struct timeval tv;
+	int ret, i;
+
+	for (i = 0; i < 1; i++) {
+		sqe = io_uring_get_sqe(ring);
+		if (!sqe) {
+			fprintf(stderr, "get sqe failed at %d\n", i);
+			goto err;
+		}
+		io_uring_prep_nop(sqe);
+	}
+
+	ts.tv_sec = 1;
+	ts.tv_nsec = 0;
+	gettimeofday(&tv, NULL);
+	ret = io_uring_submit_and_wait_timeout(ring, &cqe, 2, &ts, NULL);
+	if (ret < 0) {
+		fprintf(stderr, "submit_and_wait_timeout: %d\n", ret);
+		goto err;
+	}
+	ret = mtime_since_now(&tv);
+	/* allow some slack, should be around 1s */
+	if (ret > 1200) {
+		fprintf(stderr, "wait took too long: %d\n", ret);
+		goto err;
+	}
+	return 0;
+err:
+	return 1;
+}
+
+static int test_ring(void)
+{
+	struct io_uring ring;
+	struct io_uring_params p = { };
+	int ret;
+
+	p.flags = 0;
+	ret = io_uring_queue_init_params(8, &ring, &p);
+	if (ret) {
+		fprintf(stderr, "ring setup failed: %d\n", ret);
+		return 1;
+	}
+
+	ret = test(&ring);
+	if (ret) {
+		fprintf(stderr, "test failed\n");
+		goto err;
+	}
+err:
+	io_uring_queue_exit(&ring);
+	return ret;
+}
+
+int main(int argc, char *argv[])
+{
+	if (argc > 1)
+		return 0;
+
+	return test_ring();
+}

--- a/vendor/liburing/test/submit-link-fail.c
+++ b/vendor/liburing/test/submit-link-fail.c
@@ -23,7 +23,7 @@ static int test_underprep_fail(bool hardlink, bool drain, bool link_last,
 	struct io_uring ring;
 	struct io_uring_sqe *sqe;
 	struct io_uring_cqe *cqe;
-	char buffer[1];
+	char buffer[1] = { };
 	int i, ret, fds[2];
 
 	if (drain)

--- a/vendor/liburing/test/sync-cancel.c
+++ b/vendor/liburing/test/sync-cancel.c
@@ -1,0 +1,235 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Description: test io_uring_register_sync_cancel()
+ *
+ */
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+
+#include "liburing.h"
+#include "helpers.h"
+
+static int no_sync_cancel;
+
+static int test_sync_cancel_timeout(struct io_uring *ring, int async)
+{
+	struct io_uring_sync_cancel_reg reg = { };
+	struct io_uring_sqe *sqe;
+	struct io_uring_cqe *cqe;
+	int ret, fds[2], to_prep;
+	char buf[32];
+
+	if (pipe(fds) < 0) {
+		perror("pipe");
+		return 1;
+	}
+
+	to_prep = 1;
+	sqe = io_uring_get_sqe(ring);
+	io_uring_prep_read(sqe, fds[0], buf, sizeof(buf), 0);
+	sqe->user_data = 0x89;
+	if (async)
+		sqe->flags |= IOSQE_ASYNC;
+
+	ret = io_uring_submit(ring);
+	if (ret != to_prep) {
+		fprintf(stderr, "submit=%d\n", ret);
+		return 1;
+	}
+
+	usleep(10000);
+
+	reg.addr = 0x89;
+	reg.timeout.tv_nsec = 1;
+	ret = io_uring_register_sync_cancel(ring, &reg);
+	if (async) {
+		/* we expect -ETIME here, but can race and get 0 */
+		if (ret != -ETIME && ret != 0) {
+			fprintf(stderr, "sync_cancel=%d\n", ret);
+			return 1;
+		}
+	} else {
+		if (ret < 0) {
+			fprintf(stderr, "sync_cancel=%d\n", ret);
+			return 1;
+		}
+	}
+
+	/*
+	 * we could _almost_ use peek_cqe() here, but there is still
+	 * a small gap where io-wq is done with the request and on
+	 * its way to posting a completion, but hasn't done it just
+	 * yet. the request is canceled and won't be doing any IO
+	 * to buffers etc, but the cqe may not have quite arrived yet.
+	 */
+	ret = io_uring_wait_cqe(ring, &cqe);
+	if (ret) {
+		fprintf(stderr, "peek=%d\n", ret);
+		return 1;
+	}
+	if (cqe->res >= 0) {
+		fprintf(stderr, "cqe->res=%d\n", cqe->res);
+		return 1;
+	}
+	io_uring_cqe_seen(ring, cqe);
+	return 0;
+}
+
+static int test_sync_cancel(struct io_uring *ring, int async, int nr_all,
+			    int use_fd)
+{
+	struct io_uring_sync_cancel_reg reg = { };
+	struct io_uring_sqe *sqe;
+	struct io_uring_cqe *cqe;
+	int ret, fds[2], to_prep, i;
+	char buf[32];
+
+	if (pipe(fds) < 0) {
+		perror("pipe");
+		return 1;
+	}
+
+	to_prep = 1;
+	if (nr_all)
+		to_prep = 4;
+	for (i = 0; i < to_prep; i++) {
+		sqe = io_uring_get_sqe(ring);
+		io_uring_prep_read(sqe, fds[0], buf, sizeof(buf), 0);
+		sqe->user_data = 0x89;
+		if (async)
+			sqe->flags |= IOSQE_ASYNC;
+	}
+
+	ret = io_uring_submit(ring);
+	if (ret != to_prep) {
+		fprintf(stderr, "submit=%d\n", ret);
+		return 1;
+	}
+
+	usleep(10000);
+
+	if (!use_fd)
+		reg.addr = 0x89;
+	else
+		reg.fd = fds[0];
+	reg.timeout.tv_sec = 200;
+	if (nr_all)
+		reg.flags |= IORING_ASYNC_CANCEL_ALL;
+	if (use_fd)
+		reg.flags |= IORING_ASYNC_CANCEL_FD;
+	ret = io_uring_register_sync_cancel(ring, &reg);
+	if (ret < 0) {
+		if (ret == -EINVAL && !no_sync_cancel) {
+			no_sync_cancel = 1;
+			return 0;
+		}
+		fprintf(stderr, "sync_cancel=%d\n", ret);
+		return 1;
+	}
+
+	for (i = 0; i < to_prep; i++) {
+		/*
+		 * we could _almost_ use peek_cqe() here, but there is still
+		 * a small gap where io-wq is done with the request and on
+		 * its way to posting a completion, but hasn't done it just
+		 * yet. the request is canceled and won't be doing any IO
+		 * to buffers etc, but the cqe may not have quite arrived yet.
+		 */
+		ret = io_uring_wait_cqe(ring, &cqe);
+		if (ret) {
+			fprintf(stderr, "peek=%d\n", ret);
+			return 1;
+		}
+		if (cqe->res >= 0) {
+			fprintf(stderr, "cqe->res=%d\n", cqe->res);
+			return 1;
+		}
+		io_uring_cqe_seen(ring, cqe);
+	}
+
+	return 0;
+}
+
+int main(int argc, char *argv[])
+{
+	struct io_uring ring;
+	int ret;
+
+	if (argc > 1)
+		return T_EXIT_SKIP;
+
+	ret = t_create_ring(7, &ring, 0);
+	if (ret == T_SETUP_SKIP)
+		return T_EXIT_SKIP;
+	else if (ret != T_SETUP_OK)
+		return ret;
+
+	ret = test_sync_cancel(&ring, 0, 0, 0);
+	if (ret) {
+		fprintf(stderr, "test_sync_cancel 0 0 0 failed\n");
+		return T_EXIT_FAIL;
+	}
+	if (no_sync_cancel)
+		return T_EXIT_SKIP;
+
+	ret = test_sync_cancel(&ring, 1, 0, 0);
+	if (ret) {
+		fprintf(stderr, "test_sync_cancel 1 0 0 failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	ret = test_sync_cancel(&ring, 0, 1, 0);
+	if (ret) {
+		fprintf(stderr, "test_sync_cancel 0 1 0 failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	ret = test_sync_cancel(&ring, 1, 1, 0);
+	if (ret) {
+		fprintf(stderr, "test_sync_cancel 1 1 0 failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	ret = test_sync_cancel(&ring, 0, 0, 1);
+	if (ret) {
+		fprintf(stderr, "test_sync_cancel 0 0 1 failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	ret = test_sync_cancel(&ring, 1, 0, 1);
+	if (ret) {
+		fprintf(stderr, "test_sync_cancel 1 0 1 failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	ret = test_sync_cancel(&ring, 0, 1, 1);
+	if (ret) {
+		fprintf(stderr, "test_sync_cancel 0 1 1 failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	ret = test_sync_cancel(&ring, 1, 1, 1);
+	if (ret) {
+		fprintf(stderr, "test_sync_cancel 1 1 1 failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	ret = test_sync_cancel_timeout(&ring, 0);
+	if (ret) {
+		fprintf(stderr, "test_sync_cancel_timeout 0\n");
+		return T_EXIT_FAIL;
+	}
+
+	/* must be last, leaves request */
+	ret = test_sync_cancel_timeout(&ring, 1);
+	if (ret) {
+		fprintf(stderr, "test_sync_cancel_timeout 1\n");
+		return T_EXIT_FAIL;
+	}
+
+	return T_EXIT_PASS;
+}

--- a/vendor/liburing/test/timeout-overflow.c
+++ b/vendor/liburing/test/timeout-overflow.c
@@ -10,6 +10,7 @@
 #include <sys/time.h>
 
 #include "liburing.h"
+#include "helpers.h"
 
 #define TIMEOUT_MSEC	200
 static int not_supported;
@@ -33,14 +34,13 @@ static int check_timeout_support(void)
 	ret = io_uring_queue_init_params(1, &ring, &p);
 	if (ret) {
 		fprintf(stderr, "ring setup failed: %d\n", ret);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	/* not really a match, but same kernel added batched completions */
 	if (p.features & IORING_FEAT_POLL_32BITS) {
-		fprintf(stdout, "Skipping\n");
 		not_supported = 1;
-		return 0;
+		return T_EXIT_SKIP;
 	}
 
 	sqe = io_uring_get_sqe(&ring);
@@ -67,10 +67,10 @@ static int check_timeout_support(void)
 
 	io_uring_cqe_seen(&ring, cqe);
 	io_uring_queue_exit(&ring);
-	return 0;
+	return T_EXIT_PASS;
 err:
 	io_uring_queue_exit(&ring);
-	return 1;
+	return T_EXIT_FAIL;
 }
 
 /*
@@ -183,22 +183,22 @@ int main(int argc, char *argv[])
 	int ret;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_SKIP;
 
 	ret = check_timeout_support();
-	if (ret) {
+	if (ret == T_EXIT_FAIL) {
 		fprintf(stderr, "check_timeout_support failed: %d\n", ret);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	if (not_supported)
-		return 0;
+		return T_EXIT_SKIP;
 
 	ret = test_timeout_overflow();
 	if (ret) {
 		fprintf(stderr, "test_timeout_overflow failed\n");
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
-	return 0;
+	return T_EXIT_PASS;
 }

--- a/vendor/liburing/test/timeout.c
+++ b/vendor/liburing/test/timeout.c
@@ -156,7 +156,7 @@ static int test_single_timeout_nr(struct io_uring *ring, int nr)
 
 		/*
 		 * NOP commands have user_data as 1. Check that we get the
-		 * at least 'nr' NOPs first, then the successfully removed timout.
+		 * at least 'nr' NOPs first, then the successfully removed timeout.
 		 */
 		if (io_uring_cqe_get_data(cqe) == NULL) {
 			if (i < nr) {
@@ -588,7 +588,7 @@ static int test_multi_timeout(struct io_uring *ring)
 		}
 
 		if (cqe->user_data != user_data) {
-			fprintf(stderr, "%s: unexpected timeout req %d sequece\n",
+			fprintf(stderr, "%s: unexpected timeout req %d sequence\n",
 				__FUNCTION__, i+1);
 			goto err;
 		}
@@ -678,7 +678,7 @@ static int test_multi_timeout_nr(struct io_uring *ring)
 		case 1:
 			/* Should be timeout req_2 */
 			if (cqe->user_data != 2) {
-				fprintf(stderr, "%s: unexpected timeout req %d sequece\n",
+				fprintf(stderr, "%s: unexpected timeout req %d sequence\n",
 					__FUNCTION__, i+1);
 				goto err;
 			}
@@ -691,7 +691,7 @@ static int test_multi_timeout_nr(struct io_uring *ring)
 		case 2:
 			/* Should be timeout req_1 */
 			if (cqe->user_data != 1) {
-				fprintf(stderr, "%s: unexpected timeout req %d sequece\n",
+				fprintf(stderr, "%s: unexpected timeout req %d sequence\n",
 					__FUNCTION__, i+1);
 				goto err;
 			}

--- a/vendor/liburing/test/xattr.c
+++ b/vendor/liburing/test/xattr.c
@@ -210,14 +210,14 @@ static int test_fxattr(void)
 
 	/* Test reading attributes. */
 	value_len = io_uring_fgetxattr(&ring, fd, KEY1, value, XATTR_SIZE);
-	if (value_len != strlen(value) || strncmp(value, VALUE1, value_len)) {
+	if (value_len != strlen(VALUE1) || strncmp(value, VALUE1, value_len)) {
 		fprintf(stderr, "Error: fgetxattr expected value: %s, returned value: %s\n", VALUE1, value);
 		rc = -1;
 		goto Exit;
 	}
 
 	value_len = io_uring_fgetxattr(&ring, fd, KEY2, value, XATTR_SIZE);
-	if (value_len != strlen(value)|| strncmp(value, VALUE2, value_len)) {
+	if (value_len != strlen(VALUE2) || strncmp(value, VALUE2, value_len)) {
 		fprintf(stderr, "Error: fgetxattr expected value: %s, returned value: %s\n", VALUE2, value);
 		rc = -1;
 		goto Exit;


### PR DESCRIPTION
This adds support for aarch64/musl and zerocopy transmit.

A potential breaking change is the return value fix to io_uring_submit_and_wait_timeout, but our usecases aren't affected.