### PR TITLE
TESTING: add fork test

### DIFF
--- a/tests/dune
+++ b/tests/dune
@@ -34,10 +34,24 @@
  (modules poll_add)
  (libraries unix uring logs logs.fmt))
 
+(executable
+ (name fork)
+ (modules fork)
+ (libraries uring)
+ (foreign_stubs
+   (language c)
+   (flags :standard)
+   (names stubs)))
+
 (rule
  (alias runtest)
  (package uring)
  (action (run ./poll_add.exe)))
+
+(rule
+ (alias runtest)
+ (package uring)
+ (action (run ./fork.exe)))
 
 (rule
  (alias runbenchmark)

--- a/tests/fork.ml
+++ b/tests/fork.ml
@@ -1,0 +1,18 @@
+external set_signal : unit -> unit = "test_set_signal"
+
+let main () =
+  set_signal ();
+  for _ = 1 to 10000 do
+    match Unix.fork () with
+    | 0 -> Unix._exit 1
+    | _child -> ()
+  done
+
+let () =
+  let uring = Uring.create ~queue_depth:64 () in
+  Effect.Deep.match_with main ()
+    { retc = ignore;
+      exnc = raise;
+      effc = (fun _ -> None);
+    };
+  Uring.exit uring

--- a/tests/stubs.c
+++ b/tests/stubs.c
@@ -1,0 +1,14 @@
+#include <caml/mlvalues.h>
+#include <signal.h>
+
+static void handle_signal(int signum) {}
+
+CAMLprim value test_set_signal(value v_unit) {
+  struct sigaction sa;
+
+  sa.sa_handler = handle_signal;
+  sa.sa_flags = 0;
+  sigemptyset(&sa.sa_mask);
+  sigaction(SIGCHLD, &sa, NULL);
+  return Val_unit;
+}


### PR DESCRIPTION
Trying to simplify the error from https://github.com/ocaml-multicore/lwt_eio/issues/15.

I get:
```
$ dune exec -- ./tests/fork.exe
free(): invalid pointer
fish: “dune exec -- ./tests/fork.exe” terminated by signal SIGABRT (Abort)
```