### PR TITLE
Use `caml_enter_blocking_section` when calling `io_uring_submit`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## dev
 
-- Use `caml_enter_blocking_section` when calling `io_uring_submit`  (@TheLortex #84).
+- Use `caml_enter_blocking_section` when calling `io_uring_submit`  (@TheLortex #86).
 
 ## v0.5
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## dev
+
+- Use `caml_enter_blocking_section` when calling `io_uring_submit`  (@TheLortex #84).
+
 ## v0.5
 
 - Decouple Heap entries from ring size (@haesbaert #81).  

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -220,7 +220,7 @@ module Uring = struct
 
   external unregister_buffers : t -> unit = "ocaml_uring_unregister_buffers"
   external register_bigarray : t ->  Cstruct.buffer -> unit = "ocaml_uring_register_ba"
-  external submit : t -> int = "ocaml_uring_submit" [@@noalloc]
+  external submit : t -> int = "ocaml_uring_submit"
   external sq_ready : t -> int = "ocaml_uring_sq_ready" [@@noalloc]
 
   external get_probe_ring : t -> probe = "ocaml_uring_get_probe_ring"

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -644,14 +644,14 @@ ocaml_uring_submit_cancel(value v_uring, value v_id, value v_target) {
   return (Val_true);
 }
 
-value /* noalloc */
-ocaml_uring_submit(value v_uring)
+value ocaml_uring_submit(value v_uring)
 {
+  CAMLparam1(v_uring);
   struct io_uring *ring = Ring_val(v_uring);
   caml_enter_blocking_section();
   int num = io_uring_submit(ring);
   caml_leave_blocking_section();
-  return (Val_int(num));
+  CAMLreturn (Val_int(num));
 }
 
 #define Val_cqe_none Val_int(0)

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -648,7 +648,9 @@ value /* noalloc */
 ocaml_uring_submit(value v_uring)
 {
   struct io_uring *ring = Ring_val(v_uring);
+  caml_enter_blocking_section();
   int num = io_uring_submit(ring);
+  caml_leave_blocking_section();
   return (Val_int(num));
 }
 


### PR DESCRIPTION
`io_uring_submit` sends asynchronous work to the kernel but it still has to take a copy the data, which may take some time. In my experiments (read operations of 256MB) the system call can take up to 200ms, which is not good when domains need to synchronize.  

Using `caml_enter_blocking_section` notifies the runtime that we're leaving the OCaml world, similarly to https://github.com/ocaml-multicore/ocaml-uring/pull/31.