### PR TITLE
Statx opt

### DIFF
--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -144,6 +144,7 @@ module Statx = struct
   external uid : t -> (int64 [@unboxed]) = "ocaml_uring_statx_uid_bytes" "ocaml_uring_statx_uid_native" [@@noalloc]
   external gid : t -> (int64 [@unboxed]) = "ocaml_uring_statx_gid_bytes" "ocaml_uring_statx_gid_native" [@@noalloc]
   external ino : t -> (int64 [@unboxed]) = "ocaml_uring_statx_ino_bytes" "ocaml_uring_statx_ino_native" [@@noalloc]
+  external size : t -> (int64 [@unboxed]) = "ocaml_uring_statx_size_bytes" "ocaml_uring_statx_size_native" [@@noalloc]
   external blocks : t -> (int64 [@unboxed]) = "ocaml_uring_statx_blocks_bytes" "ocaml_uring_statx_blocks_native" [@@noalloc]
   external attributes_mask : t -> (int64 [@unboxed]) = "ocaml_uring_statx_attributes_mask_bytes" "ocaml_uring_statx_attributes_mask_native" [@@noalloc]
   external rdev : t -> (int64 [@unboxed]) = "ocaml_uring_statx_rdev_bytes" "ocaml_uring_statx_rdev_native" [@@noalloc]
@@ -167,7 +168,6 @@ module Statx = struct
   external perm : t -> (int [@untagged]) = "ocaml_uring_statx_perm_bytes" "ocaml_uring_statx_perm_native" [@@noalloc]
 
   external kind : t -> kind = "ocaml_uring_statx_kind"
-  external size : t -> Optint.Int63.t = "ocaml_uring_statx_size"
 end
 
 module Sockaddr = struct

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -100,6 +100,18 @@ module Statx = struct
     | `Socket
   ]
 
+  let pp_kind f k =
+    Fmt.pf f "%s"
+      (match k with
+       |`Unknown -> "unknown"
+       |`Fifo -> "fifo"
+       |`Character_special -> "character special file"
+       |`Directory -> "directory"
+       |`Block_device -> "block device"
+       |`Regular_file -> "regular file"
+       |`Symbolic_link -> "symbolic link"
+       |`Socket -> "socket")
+
   external create : unit -> t = "ocaml_uring_make_statx"
 
   module Flags = struct

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -153,10 +153,15 @@ module Statx = struct
   external dio_mem_align : t -> (int64 [@unboxed]) = "ocaml_uring_statx_dio_mem_align_bytes" "ocaml_uring_statx_dio_mem_align_native" [@@noalloc]
   external dio_offset_align : t -> (int64 [@unboxed]) = "ocaml_uring_statx_dio_offset_align_bytes" "ocaml_uring_statx_dio_offset_align_native" [@@noalloc]
 
-  external atime : t -> (float [@unboxed]) = "ocaml_uring_statx_atime_bytes" "ocaml_uring_statx_atime_native" [@@noalloc]
-  external btime : t -> (float [@unboxed]) = "ocaml_uring_statx_btime_bytes" "ocaml_uring_statx_btime_native" [@@noalloc]
-  external ctime : t -> (float [@unboxed]) = "ocaml_uring_statx_ctime_bytes" "ocaml_uring_statx_ctime_native" [@@noalloc]
-  external mtime : t -> (float [@unboxed]) = "ocaml_uring_statx_mtime_bytes" "ocaml_uring_statx_mtime_native" [@@noalloc]
+  external atime_sec : t -> (int64 [@unboxed]) = "ocaml_uring_statx_atime_sec_bytes" "ocaml_uring_statx_atime_sec_native" [@@noalloc]
+  external btime_sec : t -> (int64 [@unboxed]) = "ocaml_uring_statx_btime_sec_bytes" "ocaml_uring_statx_btime_sec_native" [@@noalloc]
+  external ctime_sec : t -> (int64 [@unboxed]) = "ocaml_uring_statx_ctime_sec_bytes" "ocaml_uring_statx_ctime_sec_native" [@@noalloc]
+  external mtime_sec : t -> (int64 [@unboxed]) = "ocaml_uring_statx_mtime_sec_bytes" "ocaml_uring_statx_mtime_sec_native" [@@noalloc]
+
+  external atime_nsec : t -> int = "ocaml_uring_statx_atime_nsec" [@@noalloc]
+  external btime_nsec : t -> int = "ocaml_uring_statx_btime_nsec" [@@noalloc]
+  external ctime_nsec : t -> int = "ocaml_uring_statx_ctime_nsec" [@@noalloc]
+  external mtime_nsec : t -> int = "ocaml_uring_statx_mtime_nsec" [@@noalloc]
 
   external mode : t -> (int [@untagged]) = "ocaml_uring_statx_mode_bytes" "ocaml_uring_statx_mode_native" [@@noalloc]
   external perm : t -> (int [@untagged]) = "ocaml_uring_statx_perm_bytes" "ocaml_uring_statx_perm_native" [@@noalloc]

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -240,6 +240,8 @@ module Statx : sig
     | `Socket
   ]
 
+  val pp_kind : kind Fmt.t
+
   val create : unit -> t
   (** Use [create] to make a statx result buffer to pass to {! statx}. *)
 

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -226,8 +226,8 @@ val splice : 'a t -> src:Unix.file_descr -> dst:Unix.file_descr -> len:int -> 'a
     The result is [EINVAL] if the file descriptors don't support splicing. *)
 
 module Statx : sig
-  type internal
-  (** An internal type used to pass into {! statx}. *)
+  type t
+  (** A statx struct. *)
 
   type kind = [
     | `Unknown
@@ -240,34 +240,8 @@ module Statx : sig
     | `Socket
   ]
 
-  type t = {
-    blksize : Int64.t;
-    attributes : Int64.t;
-    nlink : Int64.t;
-    uid : Int64.t;
-    gid : Int64.t;
-    mode : int;
-    ino : Int64.t;
-    size : Optint.Int63.t;
-    blocks : Int64.t;
-    attributes_mask : Int64.t;
-    atime : float;
-    btime : float;
-    ctime : float;
-    mtime : float;
-    rdev : Int64.t;
-    dev : Int64.t;
-    perm : int;
-    kind : kind;
-    mask : Int64.t;
-  } (** See statx(2). *)
-
-  val create : unit -> internal
-  (** Use [create] to make an {! internal} statx struct to pass to {! statx}. *)
-
-  val internal_to_t : internal -> t
-  (** Convert an internal statx struct to an OCaml value. This should only be called
-      after a successful completition of a {! statx} call. *)
+  val create : unit -> t
+  (** Use [create] to make a statx result buffer to pass to {! statx}. *)
 
   module Flags : sig
     include FLAGS
@@ -279,6 +253,26 @@ module Statx : sig
     val statx_sync_as_stat : t
     val statx_force_sync : t
     val statx_dont_sync : t
+  end
+
+  module Attr : sig
+    include FLAGS
+
+    val compressed : t
+    val immutable : t
+    val append : t
+    val nodump : t
+    val encrypted : t
+    val verity : t
+
+    val dax : t
+    (** Since Linux 5.8 *)
+
+    val check : ?mask:Int64.t -> Int64.t -> t -> bool
+    (** [check ?mask attr t] will check if [t] is set in [attr].
+
+        If [mask] is not [None] then it will first check the mask to see
+        if the file attribute is supported and if not raise [Invalid_argument]. *)
   end
 
   module Mask : sig
@@ -299,17 +293,55 @@ module Statx : sig
 
     val btime : t
 
+    val mnt_id : t
+    (** As of Linux 5.8 *)
+
+    val dioalign : t
+    (** As of Linux 6.1 *)
+
     val check : Int64.t -> t -> bool
     (** [check mask t] checks if [t] is set in [mask]. *)
   end
+
+  (** You may wish to use {! Mask.check} to verify the field has actually
+      been returned with a sensible value first. *)
+
+  val blksize : t -> Int64.t
+  val attributes : t -> Int64.t
+  val nlink : t -> Int64.t
+  val uid : t -> Int64.t
+  val gid : t -> Int64.t
+  val ino : t -> Int64.t
+  val blocks : t -> Int64.t
+  val attributes_mask : t -> Int64.t
+  val rdev : t -> Int64.t
+  val dev : t -> Int64.t
+  val mask : t -> Int64.t
+  
+  val mnt_id : t -> Int64.t
+  (** See {! Mask.mnt_id}. *)
+
+  val dio_mem_align : t -> Int64.t
+  (** See {! Mask.dioalign}. *)
+
+  val dio_offset_align : t -> Int64.t
+  (** See {! Mask.dioalign}. *)
+
+  val atime : t -> float
+  val btime : t -> float
+  val ctime : t -> float
+  val mtime : t -> float
+  
+  val mode : t -> int
+  val perm : t -> int
+
+  val size : t -> Optint.Int63.t
+  val kind : t -> kind
 end
 
-val statx : 'a t -> ?fd:Unix.file_descr -> mask:Statx.Mask.t -> string -> Statx.internal -> Statx.Flags.t -> 'a -> 'a job option
+val statx : 'a t -> ?fd:Unix.file_descr -> mask:Statx.Mask.t -> string -> Statx.t -> Statx.Flags.t -> 'a -> 'a job option
 (** [statx t ?fd ~mask path stat flags] stats [path], which is resolved relative to [fd]
-    (or the current directory if [fd] is not given).
-        
-    Create a {! Statx.internal} using {! Statx.create} and after successful completion
-    of the job, convert it to {! Statx.t} using {! Statx.internal_to_t}. *)
+    (or the current directory if [fd] is not given). *)
 
 val connect : 'a t -> Unix.file_descr -> Unix.sockaddr -> 'a -> 'a job option
 (** [connect t fd addr d] will submit a request to connect [fd] to [addr]. *)

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -314,6 +314,7 @@ module Statx : sig
   val uid : t -> Int64.t
   val gid : t -> Int64.t
   val ino : t -> Int64.t
+  val size : t -> Int64.t
   val blocks : t -> Int64.t
   val attributes_mask : t -> Int64.t
   val rdev : t -> Int64.t
@@ -342,7 +343,6 @@ module Statx : sig
   val mode : t -> int
   val perm : t -> int
 
-  val size : t -> Optint.Int63.t
   val kind : t -> kind
 end
 

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -329,10 +329,15 @@ module Statx : sig
   val dio_offset_align : t -> Int64.t
   (** See {! Mask.dioalign}. *)
 
-  val atime : t -> float
-  val btime : t -> float
-  val ctime : t -> float
-  val mtime : t -> float
+  val atime_sec : t -> int64
+  val btime_sec : t -> int64
+  val ctime_sec : t -> int64
+  val mtime_sec : t -> int64
+  
+  val atime_nsec : t -> int
+  val btime_nsec : t -> int
+  val ctime_nsec : t -> int
+  val mtime_nsec : t -> int
   
   val mode : t -> int
   val perm : t -> int

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -54,10 +54,8 @@
 // TODO: this belongs in Optint
 #ifdef ARCH_SIXTYFOUR
 #define Int63_val(v) Long_val(v)
-#define caml_copy_int63(v) Val_long(v)
 #else
 #define Int63_val(v) (Int64_val(v) >> 1)
-#define caml_copy_int63(v) caml_copy_int64(v << 1)
 #endif
 
 #define Ring_val(v) *((struct io_uring**)Data_custom_val(v))
@@ -510,6 +508,7 @@ STATX_GETTER(nlink, int64_t, caml_copy_int64);
 STATX_GETTER(uid, int64_t, caml_copy_int64);
 STATX_GETTER(gid, int64_t, caml_copy_int64);
 STATX_GETTER(ino, int64_t, caml_copy_int64);
+STATX_GETTER(size, int64_t, caml_copy_int64);
 STATX_GETTER(blocks, int64_t, caml_copy_int64);
 STATX_GETTER(attributes_mask, int64_t, caml_copy_int64);
 STATX_GETTER(mask, int64_t, caml_copy_int64);
@@ -619,12 +618,6 @@ value
 ocaml_uring_statx_kind(value v_statx) {
   struct statx *s = Statx_val(v_statx);
   return get_file_type_variant(s);
-}
-
-value
-ocaml_uring_statx_size(value v_statx) {
-  struct statx *s = Statx_val(v_statx);
-  return caml_copy_int63(s->stx_size);
 }
 
 struct sock_addr_data {

--- a/tests/dune
+++ b/tests/dune
@@ -30,6 +30,11 @@
  (libraries cmdliner logs.cli logs.fmt fmt.tty fmt.cli lwtcp_lib))
 
 (executable
+ (name urstat)
+ (modules urstat)
+ (libraries uring fmt))
+
+(executable
  (name poll_add)
  (modules poll_add)
  (libraries unix uring logs logs.fmt))

--- a/tests/main.md
+++ b/tests/main.md
@@ -214,8 +214,8 @@ val statx : Uring.Statx.t = <abstr>
 val token : [ `Open_path | `Statx ] = `Statx
 val retval : int = 0
 
-#  Uring.Statx.kind statx, Printf.sprintf "0o%o" (Uring.Statx.perm statx), Int63.to_int (Uring.Statx.size statx);;
-- : Uring.Statx.kind * string * int = (`Regular_file, "0o600", 9)
+#  Uring.Statx.kind statx, Printf.sprintf "0o%o" (Uring.Statx.perm statx), (Uring.Statx.size statx);;
+- : Uring.Statx.kind * string * int64 = (`Regular_file, "0o600", 9L)
 
 # if not (Uring.Statx.(Mask.check (mask statx) Mask.dioalign)) then assert (Uring.Statx.dio_mem_align statx = 0L);;
 - : unit = ()
@@ -261,8 +261,8 @@ val statx : Uring.Statx.t = <abstr>
 val token : [ `Open_path | `Statx ] = `Statx
 val retval : int = 0
 
-# Uring.Statx.kind statx, Printf.sprintf "0o%o" (Uring.Statx.perm statx), Int63.to_int (Uring.Statx.size statx);;
-- : Uring.Statx.kind * string * int = (`Regular_file, "0o600", 9)
+# Uring.Statx.kind statx, Printf.sprintf "0o%o" (Uring.Statx.perm statx), (Uring.Statx.size statx);;
+- : Uring.Statx.kind * string * int64 = (`Regular_file, "0o600", 9L)
 
 # let fd : unit = Unix.close fd;;
 val fd : unit = ()

--- a/tests/main.md
+++ b/tests/main.md
@@ -198,7 +198,7 @@ val fd : unit = ()
 val t : [ `Open_path | `Statx ] Uring.t = <abstr>
 
 # let statx = Uring.Statx.create ();;
-val statx : Uring.Statx.internal = <abstr>
+val statx : Uring.Statx.t = <abstr>
 # Uring.statx t
     ~mask:Uring.Statx.Mask.basic_stats
     "test-openat"
@@ -214,9 +214,11 @@ val statx : Uring.Statx.internal = <abstr>
 val token : [ `Open_path | `Statx ] = `Statx
 val retval : int = 0
 
-# let x = Uring.Statx.internal_to_t statx in
-  x.kind, Printf.sprintf "0o%o" x.perm, Int63.to_int x.size;;
+#  Uring.Statx.kind statx, Printf.sprintf "0o%o" (Uring.Statx.perm statx), Int63.to_int (Uring.Statx.size statx);;
 - : Uring.Statx.kind * string * int = (`Regular_file, "0o600", 9)
+
+# if not (Uring.Statx.(Mask.check (mask statx) Mask.dioalign)) then assert (Uring.Statx.dio_mem_align statx = 0L);;
+- : unit = ()
 ```
 
 Now using `~fd`:
@@ -242,7 +244,7 @@ val token : [ `Open_path | `Statx ] = `Open_path
 val fd : Unix.file_descr = <abstr>
 
 # let statx = Uring.Statx.create ();;
-val statx : Uring.Statx.internal = <abstr>
+val statx : Uring.Statx.t = <abstr>
 # Uring.statx t
     ~fd
     ~mask:Uring.Statx.Mask.(type' + mode + size)
@@ -259,8 +261,7 @@ val statx : Uring.Statx.internal = <abstr>
 val token : [ `Open_path | `Statx ] = `Statx
 val retval : int = 0
 
-# let x = Uring.Statx.internal_to_t statx in
-  x.kind, Printf.sprintf "0o%o" x.perm, Int63.to_int x.size;;
+# Uring.Statx.kind statx, Printf.sprintf "0o%o" (Uring.Statx.perm statx), Int63.to_int (Uring.Statx.size statx);;
 - : Uring.Statx.kind * string * int = (`Regular_file, "0o600", 9)
 
 # let fd : unit = Unix.close fd;;

--- a/tests/urstat.ml
+++ b/tests/urstat.ml
@@ -1,0 +1,50 @@
+(* stat(1) built with liburing. *)
+
+module S = Uring.Statx
+
+(* TODO move into Uring.Statx? *)
+let pp_time f t =
+  let nsec, sec = modf t in
+  let tm = Unix.localtime sec in
+  Format.fprintf f "%04d-%02d-%02d %02d:%02d:%02d.%9.0f +0000"
+    (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
+    tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+    (nsec *. 1e9)
+  
+let get_completion_and_print uring =
+  let (fname, buf), _ =
+    match Uring.wait uring with
+    | Some { data; result } -> (data, result)
+    | None -> failwith "retry"
+  in
+  let kind = S.kind buf in
+  let opt_symlink = match kind with
+      `Symbolic_link -> Printf.sprintf " -> %s" (Unix.readlink fname) (* TODO no readlink in io_uring? *)
+    | _ -> "" in
+  Format.printf "  File: %s%s\n  Size: %Lu\t\tBlocks: %Lu\tIO Block: %Lu\t %a\nDevice: %Lu\tInode: %Lu\tLinks: %Lu\nAccess: (%04o/TODO)\tUid: (%Lu/TODO)\tGid: (%Lu/TODO)\nAccess: %a\nModify: %a\nChange: %a\n Birth: %a\n%!"
+    fname opt_symlink
+    (Optint.Int63.to_int64 (S.size buf))
+    (S.blocks buf)
+    (S.blksize buf)
+    S.pp_kind (S.kind buf)
+    (S.dev buf) (* TODO expose makedev/major/minor *) (S.ino buf) (S.nlink buf)
+    (S.perm buf) (S.uid buf) (S.gid buf)
+    pp_time (S.atime buf)
+    pp_time (S.mtime buf)
+    pp_time (S.ctime buf)
+    pp_time (S.btime buf)
+
+let submit_stat_request fname buf uring =
+  let mask = S.Mask.(basic_stats + btime) in
+  let flags = S.Flags.(symlink_nofollow + statx_dont_sync) in
+  let _ = Uring.statx uring ~mask fname buf flags (fname,buf) in
+  let numreq = Uring.submit uring in
+  assert(numreq=1);
+  ()
+
+let () =
+   let fname = Sys.argv.(1) in
+   let buf = S.create () in
+   let uring = Uring.create ~queue_depth:1 () in
+   submit_stat_request fname buf uring;
+   get_completion_and_print uring

--- a/tests/urstat.ml
+++ b/tests/urstat.ml
@@ -22,7 +22,7 @@ let get_completion_and_print uring =
     | _ -> "" in
   Format.printf "  File: %s%s\n  Size: %Lu\t\tBlocks: %Lu\tIO Block: %Lu\t %a\nDevice: %Lu\tInode: %Lu\tLinks: %Lu\nAccess: (%04o/TODO)\tUid: (%Lu/TODO)\tGid: (%Lu/TODO)\nAccess: %a\nModify: %a\nChange: %a\n Birth: %a\n%!"
     fname opt_symlink
-    (Optint.Int63.to_int64 (S.size buf))
+    (S.size buf)
     (S.blocks buf)
     (S.blksize buf)
     S.pp_kind (S.kind buf)

--- a/tests/urstat.ml
+++ b/tests/urstat.ml
@@ -3,13 +3,12 @@
 module S = Uring.Statx
 
 (* TODO move into Uring.Statx? *)
-let pp_time f t =
-  let nsec, sec = modf t in
-  let tm = Unix.localtime sec in
-  Format.fprintf f "%04d-%02d-%02d %02d:%02d:%02d.%9.0f +0000"
+let pp_time f (sec, nsec) =
+  let tm = Unix.localtime (Int64.to_float sec) in
+  Format.fprintf f "%04d-%02d-%02d %02d:%02d:%02d.%09d +0000"
     (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
     tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
-    (nsec *. 1e9)
+    nsec
   
 let get_completion_and_print uring =
   let (fname, buf), _ =
@@ -29,10 +28,10 @@ let get_completion_and_print uring =
     S.pp_kind (S.kind buf)
     (S.dev buf) (* TODO expose makedev/major/minor *) (S.ino buf) (S.nlink buf)
     (S.perm buf) (S.uid buf) (S.gid buf)
-    pp_time (S.atime buf)
-    pp_time (S.mtime buf)
-    pp_time (S.ctime buf)
-    pp_time (S.btime buf)
+    pp_time (S.atime_sec buf, S.atime_nsec buf)
+    pp_time (S.mtime_sec buf, S.mtime_nsec buf)
+    pp_time (S.ctime_sec buf, S.ctime_nsec buf)
+    pp_time (S.btime_sec buf, S.btime_nsec buf)
 
 let submit_stat_request fname buf uring =
   let mask = S.Mask.(basic_stats + btime) in


### PR DESCRIPTION
A follow on PR to #95 after @avsm's review. Thought I'd open the PR early to get some eyes on it but I would like to double-check I didn't make (more) copy-paste mistakes, mess up the noalloc functions etc. 

Instead of having individual C functions we could perhaps have an "int64_field" function and choose the right field based on a flag we send in from OCaml which might reduce the amount of code... but then internally there's a big switch statement so I wasn't sure if that was any better. 

Also I haven't added the `STATX_DIOALIGN` flag as it is Linux 6.1 ? 