### PR TITLE
Fix liburing build bug

### DIFF
--- a/vendor/liburing/src/Makefile
+++ b/vendor/liburing/src/Makefile
@@ -81,7 +81,7 @@ liburing-ffi.a: $(liburing_objs) $(liburing_ffi_objs)
 $(libname): $(liburing_sobjs) liburing.map
 	$(QUIET_CC)$(CC) $(SO_CFLAGS) -shared -Wl,--version-script=liburing.map -Wl,-soname=$(soname) -o $@ $(liburing_sobjs) $(LINK_FLAGS)
 
-$(ffi_libname): $(liburing_ffi_objs) $(liburing_ffi_sobjs) liburing-ffi.map
+$(ffi_libname): $(liburing_ffi_objs) $(liburing_ffi_sobjs) $(liburing_sobjs) liburing-ffi.map
 	$(QUIET_CC)$(CC) $(SO_CFLAGS) -shared -Wl,--version-script=liburing-ffi.map -Wl,-soname=$(ffi_soname) -o $@ $(liburing_sobjs) $(liburing_ffi_sobjs) $(LINK_FLAGS)
 
 install: $(all_targets)


### PR DESCRIPTION
Was failing sometimes with e.g.

    /usr/bin/ld: cannot find queue.os: No such file or directory
    /usr/bin/ld: cannot find register.os: No such file or directory

Looks like it's already fixed upstream: https://github.com/axboe/liburing/pull/891

(I had the s390x build fail twice in a row, but the third bulild was OK)