### PR TITLE
[Experiment] Cstruct to Bstruct

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,16 @@ let rec write_all fd = function
     let result, data = wait_with_retry uring in
     assert (data = `Write_all);  (* There aren't any other requests pending *)
     assert (result > 0);         (* Check for error return *)
-    let bufs = Uring.Bytes.shiftv bufs result in
+    let bufs = Uring.Bstruct.shiftv bufs result in
     write_all fd bufs
 ```
 
 ```ocaml
-# write_all fd Bytes.[of_string "INFO: "; of_string "A log message"];;
+# let slab = Uring.Slab.create Uring.major_alloc_byte_size;;
+val slab : Uring.Slab.t = <abstr>
+# let bs = Uring.Slab.slice_strings slab ["INFO: "; "A log message"];;
+val bs : Uring.Bstruct.t list = [<abstr>; <abstr>]
+# write_all fd bs;;
 - : unit = ()
 ```
 

--- a/README.md
+++ b/README.md
@@ -100,12 +100,12 @@ let rec write_all fd = function
     let result, data = wait_with_retry uring in
     assert (data = `Write_all);  (* There aren't any other requests pending *)
     assert (result > 0);         (* Check for error return *)
-    let bufs = Cstruct.shiftv bufs result in
+    let bufs = Uring.Bytes.shiftv bufs result in
     write_all fd bufs
 ```
 
 ```ocaml
-# write_all fd Cstruct.[of_string "INFO: "; of_string "A log message"];;
+# write_all fd Bytes.[of_string "INFO: "; of_string "A log message"];;
 - : unit = ()
 ```
 

--- a/bench/readv.ml
+++ b/bench/readv.ml
@@ -20,7 +20,7 @@ let run_bechmark ~polling_timeout fd =
   let t = Uring.create ?polling_timeout ~queue_depth:(n_concurrent * 2) () in
   (* We start by submitting [n_concurrent] reads. *)
   for _ = 1 to n_concurrent do
-    let buf = Cstruct.create buffer_size in
+    let buf = Bytes.create buffer_size in
     let _job : _ Uring.job = Uring.readv t fd [buf] ~file_offset:Optint.Int63.zero [buf] |> Option.get in
     ()
   done;

--- a/lib/uring/dune
+++ b/lib/uring/dune
@@ -2,7 +2,7 @@
  (name uring)
  (public_name uring)
  (foreign_archives uring)
- (libraries cstruct fmt optint unix)
+ (libraries fmt optint unix)
  (foreign_stubs
   (language c)
   (names uring_stubs)

--- a/lib/uring/dune
+++ b/lib/uring/dune
@@ -2,7 +2,7 @@
  (name uring)
  (public_name uring)
  (foreign_archives uring)
- (libraries fmt optint unix)
+ (libraries fmt optint unix compiler-libs.optcomp)
  (foreign_stubs
   (language c)
   (names uring_stubs)
@@ -11,7 +11,7 @@
   (extra_deps include/liburing/compat.h)))
 
 (rule
- (targets config.ml)
+ (targets uring_config.ml)
  (deps
   include/liburing.h
   include/liburing/io_uring.h

--- a/lib/uring/include/discover.ml
+++ b/lib/uring/include/discover.ml
@@ -189,7 +189,7 @@ let () =
       let at_struct = List.map (fun (name, v) -> Printf.sprintf "  let %s = 0x%x" name v) at_flags in
       let mask_struct = List.map (fun (name, v) -> Printf.sprintf "    let %s = 0x%x" name v) mask_flags in
       let attr_struct = List.map (fun (name, v) -> Printf.sprintf "    let %s = 0x%x" name v) attr_flags in
-      C.Flags.write_lines "config.ml"
+      C.Flags.write_lines "uring_config.ml"
         (defs @
          ["module Op : sig";
           "  type t";

--- a/lib/uring/region.ml
+++ b/lib/uring/region.ml
@@ -3,7 +3,7 @@
 
 (* TODO turn into a variable length slab allocator *)
 type t = {
-  buf: Cstruct.buffer;
+  buf: bytes;
   block_size: int;
   freelist: int Queue.t;
 }
@@ -37,14 +37,10 @@ let length_option t = function
     else
       len
 
-let to_cstruct ?len (t, chunk) =
-  Cstruct.of_bigarray ~off:chunk ~len:(length_option t len) t.buf
+let to_bytes ?len (t, chunk) =
+  Bytes.sub t.buf chunk (length_option t len)
 
-let to_bigstring ?len (t, chunk) =
-  Bigarray.Array1.sub t.buf chunk (length_option t len)
-
-let to_string ?len (t, chunk) =
-  Cstruct.to_string (to_cstruct ?len (t, chunk))
+let to_string ?len (t, chunk) = Bytes.to_string (to_bytes ?len (t, chunk))
 
 let avail {freelist;_} = Queue.length freelist
 

--- a/lib/uring/region.mli
+++ b/lib/uring/region.mli
@@ -17,7 +17,7 @@ type t
   (** [No_space] is raised when an allocation request cannot
       be satisfied. *)
 
-  val init: block_size:int -> Cstruct.buffer -> int -> t
+  val init: block_size:int -> bytes -> int -> t
   (** [init ~block_size buf slots] initialises a region from
       the buffer [buf] with total size of [block_size * slots]. *)
 
@@ -37,16 +37,10 @@ type t
       offset in its associated region.  This can be used in IO calls
       involving that memory. *)
 
-  val to_cstruct : ?len:int -> chunk -> Cstruct.t
+  val to_bytes : ?len:int -> chunk -> bytes
   (** [to_cstruct chunk] is a cstruct of [chunk]'s slice of the region.
       Note that this is a zero-copy view into the underlying region [t]
       and so [chunk] should not be freed until this cstruct is no longer used.
-      @param len Use only the first [len] bytes of [chunk]. *)
-
-  val to_bigstring : ?len:int -> chunk -> Cstruct.buffer
-  (** [to_bigstring] is like {!to_cstruct}, but creates a {!Bigarray}.
-      Note that this is a zero-copy view into the underlying region [t]
-      and so [chunk] should not be freed until this Bigarray reference is no longer used.
       @param len Use only the first [len] bytes of [chunk]. *)
 
   val to_string : ?len:int -> chunk -> string

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -44,7 +44,7 @@ val exit : 'a t -> unit
     for the "fixed buffer" mode of io_uring to avoid data copying between
     userspace and the kernel. *)
 
-val set_fixed_buffer : 'a t -> Cstruct.buffer -> (unit, [> `ENOMEM]) result
+val set_fixed_buffer : 'a t -> bytes -> (unit, [> `ENOMEM]) result
 (** [set_fixed_buffer t buf] sets [buf] as the fixed buffer for [t].
 
     You will normally want to wrap this with {!Region.alloc} or similar
@@ -57,7 +57,7 @@ val set_fixed_buffer : 'a t -> Cstruct.buffer -> (unit, [> `ENOMEM]) result
 
     @raise Invalid_argument if there are any requests in progress *)
 
-val buf : 'a t -> Cstruct.buffer
+val buf : 'a t -> bytes
 (** [buf t] is the fixed internal memory buffer associated with uring [t]
     using {!set_fixed_buffer}, or a zero-length buffer if none is set. *)
 
@@ -169,13 +169,13 @@ type offset := Optint.Int63.t
 (** For files, give the absolute offset, or use [Optint.Int63.minus_one] for the current position.
     For sockets, use an offset of [Optint.Int63.zero] ([minus_one] is not allowed here). *)
 
-val read : 'a t -> file_offset:offset -> Unix.file_descr -> Cstruct.t -> 'a -> 'a job option
+val read : 'a t -> file_offset:offset -> Unix.file_descr -> bytes -> 'a -> 'a job option
 (** [read t ~file_offset fd buf d] will submit a [read(2)] request to uring [t].
     It reads from absolute [file_offset] on the [fd] file descriptor and writes
     the results into the memory pointed to by [buf].  The user data [d] will
     be returned by {!wait} or {!peek} upon completion. *)
 
-val write : 'a t -> file_offset:offset -> Unix.file_descr -> Cstruct.t -> 'a -> 'a job option
+val write : 'a t -> file_offset:offset -> Unix.file_descr -> bytes -> 'a -> 'a job option
 (** [write t ~file_offset fd buf d] will submit a [write(2)] request to uring [t].
     It writes to absolute [file_offset] on the [fd] file descriptor from the
     the memory pointed to by [buf].  The user data [d] will be returned by
@@ -184,7 +184,7 @@ val write : 'a t -> file_offset:offset -> Unix.file_descr -> Cstruct.t -> 'a -> 
 val iov_max : int
 (** The maximum length of the list that can be passed to [readv] and similar. *)
 
-val readv : 'a t -> file_offset:offset -> Unix.file_descr -> Cstruct.t list -> 'a -> 'a job option
+val readv : 'a t -> file_offset:offset -> Unix.file_descr -> bytes list -> 'a -> 'a job option
 (** [readv t ~file_offset fd iov d] will submit a [readv(2)] request to uring [t].
     It reads from absolute [file_offset] on the [fd] file descriptor and writes
     the results into the memory pointed to by [iov].  The user data [d] will
@@ -192,7 +192,7 @@ val readv : 'a t -> file_offset:offset -> Unix.file_descr -> Cstruct.t list -> '
 
     Requires [List.length iov <= Uring.iov_max] *)
 
-val writev : 'a t -> file_offset:offset -> Unix.file_descr -> Cstruct.t list -> 'a -> 'a job option
+val writev : 'a t -> file_offset:offset -> Unix.file_descr -> bytes list -> 'a -> 'a job option
 (** [writev t ~file_offset fd iov d] will submit a [writev(2)] request to uring [t].
     It writes to absolute [file_offset] on the [fd] file descriptor from the
     the memory pointed to by [iov].  The user data [d] will be returned by
@@ -377,7 +377,7 @@ val cancel : 'a t -> 'a job -> 'a -> 'a job option
 module Msghdr : sig
   type t
 
-  val create : ?n_fds:int -> ?addr:Sockaddr.t -> Cstruct.t list -> t
+  val create : ?n_fds:int -> ?addr:Sockaddr.t -> bytes list -> t
   (** [create buffs] makes a new [msghdr] using the [buffs]
       for the underlying [iovec].
 
@@ -390,7 +390,7 @@ module Msghdr : sig
   val get_fds : t -> Unix.file_descr list
 end
 
-val send_msg : ?fds:Unix.file_descr list -> ?dst:Unix.sockaddr -> 'a t -> Unix.file_descr -> Cstruct.t list -> 'a -> 'a job option
+val send_msg : ?fds:Unix.file_descr list -> ?dst:Unix.sockaddr -> 'a t -> Unix.file_descr -> bytes list -> 'a -> 'a job option
 (** [send_msg t fd buffs d] will submit a [sendmsg(2)] request. The [Msghdr] will be constructed
     from the FDs ([fds]), address ([dst]) and buffers ([buffs]).
 
@@ -465,4 +465,8 @@ val get_debug_stats : _ t -> Stats.t
 
 module Private : sig
   module Heap = Heap
+end
+
+module Bytes : sig
+  val shiftv : bytes list -> int -> bytes list
 end

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -59,7 +59,7 @@
 #endif
 
 #define Ring_val(v) *((struct io_uring**)Data_custom_val(v))
-#define Sketch_ptr_val(vsp) (Caml_ba_data_val(Field(vsp, 0)) + Long_val(Field(vsp, 1)))
+#define Sketch_ptr_val(vsp) ((void *)(Bytes_val(Field(vsp, 0)) + Long_val(Field(vsp, 1))))
 #define Sketch_ptr_len_val(vsp) Long_val(Field(vsp, 2))
 
 // Note that this does not free the ring data. You must not allow this to be
@@ -104,12 +104,12 @@ value ocaml_uring_setup(value entries, value polling_timeout) {
 }
 
 // Note that the ring must be idle when calling this.
-value ocaml_uring_register_ba(value v_uring, value v_ba) {
+value ocaml_uring_register_bytes(value v_uring, value v_ba) {
   CAMLparam2(v_uring, v_ba);
   struct io_uring *ring = Ring_val(v_uring);
   struct iovec iov[1];
-  iov[0].iov_base = Caml_ba_data_val(v_ba);
-  iov[0].iov_len = Caml_ba_array_val(v_ba)->dim[0];
+  iov[0].iov_base = Bytes_val(v_ba);
+  iov[0].iov_len = caml_string_length(v_ba);
   dprintf("uring %p: registering iobuf base %p len %lu\n", ring, iov[0].iov_base, iov[0].iov_len);
   int ret = io_uring_register_buffers(ring, iov, 1);
   if (ret)
@@ -280,11 +280,8 @@ ocaml_uring_set_iovec(value v_sketch_ptr, value v_csl)
        v_aux != Val_emptylist;
        v_aux = Field(v_aux, 1), i++) {
     value v_cs = Field(v_aux, 0);
-    value v_ba = Field(v_cs, 0);
-    value v_off = Field(v_cs, 1);
-    value v_len = Field(v_cs, 2);
-    iovs[i].iov_base = Caml_ba_data_val(v_ba) + Long_val(v_off);
-    iovs[i].iov_len = Long_val(v_len);
+    iovs[i].iov_base = Bytes_val(v_cs);
+    iovs[i].iov_len = caml_string_length(v_cs);
   }
 }
 
@@ -295,7 +292,6 @@ ocaml_uring_submit_readv(value v_uring, value v_fd, value v_id, value v_sketch_p
   struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
   struct iovec *iovs = Sketch_ptr_val(v_sketch_ptr);
   size_t len = Sketch_ptr_len_val(v_sketch_ptr) / sizeof(*iovs);
-
   if (sqe == NULL)
     return (Val_false);
   dprintf("submit_readv: %d ents len[0] %lu off %d\n", len, iovs[0].iov_len, Int63_val(v_fileoff));
@@ -325,7 +321,7 @@ value /* noalloc */
 ocaml_uring_submit_readv_fixed_native(value v_uring, value v_fd, value v_id, value v_ba, value v_off, value v_len, value v_fileoff) {
   struct io_uring *ring = Ring_val(v_uring);
   struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
-  void *buf = Caml_ba_data_val(v_ba) + Long_val(v_off);
+  void *buf = Bytes_val(v_ba) + Long_val(v_off);
   if (!sqe) return (Val_false);
   dprintf("submit_readv_fixed: buf %p off %d len %d fileoff %d", buf, Int_val(v_off), Int_val(v_len), Int63_val(v_fileoff));
   io_uring_prep_read_fixed(sqe, Int_val(v_fd), buf, Int_val(v_len), Int63_val(v_fileoff), 0);
@@ -350,7 +346,7 @@ value /* noalloc */
 ocaml_uring_submit_writev_fixed_native(value v_uring, value v_fd, value v_id, value v_ba, value v_off, value v_len, value v_fileoff) {
   struct io_uring *ring = Ring_val(v_uring);
   struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
-  void *buf = Caml_ba_data_val(v_ba) + Long_val(v_off);
+  void *buf = Bytes_val(v_ba) + Long_val(v_off);
   if (!sqe)
     return (Val_false);
   dprintf("submit_writev_fixed: buf %p off %d len %d fileoff %d", buf, Int_val(v_off), Int_val(v_len), Int63_val(v_fileoff));
@@ -372,13 +368,11 @@ ocaml_uring_submit_writev_fixed_byte(value* values, int argc) {
 }
 
 value /* noalloc */
-ocaml_uring_submit_read(value v_uring, value v_fd, value v_id, value v_cstruct, value v_fileoff) {
+ocaml_uring_submit_read(value v_uring, value v_fd, value v_id, value v_bytes, value v_fileoff) {
   struct io_uring *ring = Ring_val(v_uring);
   struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
-  value v_ba = Field(v_cstruct, 0);
-  value v_off = Field(v_cstruct, 1);
-  value v_len = Field(v_cstruct, 2);
-  void *buf = Caml_ba_data_val(v_ba) + Long_val(v_off);
+  value v_len = Val_long(caml_string_length(v_bytes));
+  void *buf = Bytes_val(v_bytes);
   if (!sqe) return (Val_false);
   dprintf("submit_read: fd %d buff %p len %zd fileoff %d\n",
 	  Int_val(v_fd), buf, Long_val(v_len), Int63_val(v_fileoff));
@@ -388,13 +382,11 @@ ocaml_uring_submit_read(value v_uring, value v_fd, value v_id, value v_cstruct, 
 }
 
 value /* noalloc */
-ocaml_uring_submit_write(value v_uring, value v_fd, value v_id, value v_cstruct, value v_fileoff) {
+ocaml_uring_submit_write(value v_uring, value v_fd, value v_id, value v_bytes, value v_fileoff) {
   struct io_uring *ring = Ring_val(v_uring);
   struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
-  value v_ba = Field(v_cstruct, 0);
-  value v_off = Field(v_cstruct, 1);
-  value v_len = Field(v_cstruct, 2);
-  void *buf = Caml_ba_data_val(v_ba) + Long_val(v_off);
+  value v_len = Val_int(caml_string_length(v_bytes));
+  void *buf = Bytes_val(v_bytes);
   if (!sqe) return (Val_false);
   dprintf("submit_write: fd %d buff %p len %zd fileoff %d\n",
 	  Int_val(v_fd), buf, Long_val(v_len), Int63_val(v_fileoff));

--- a/lib/uring/util.ml
+++ b/lib/uring/util.ml
@@ -1,0 +1,106 @@
+module Bstruct = struct
+  type t = {
+    buffer : bytes;
+    off : int;
+    len : int;
+  }
+
+  let empty = { buffer = Bytes.empty; off = 0; len = 0 }
+
+  let length t = t.len
+
+  let copy_to_string src srcoff len =
+    if len < 0 || srcoff < 0 || src.len - srcoff < len then
+      failwith "Error copying to string!"
+    else
+      let b = Bytes.create len in
+      Bytes.blit src.buffer (src.off+srcoff) b 0 len;
+      (* The following call is safe, since b is not visible elsewhere. *)
+      Bytes.unsafe_to_string b
+
+  let blit_from_string src srcoff dst dstoff len =
+    if len < 0 || srcoff < 0 || String.length src - srcoff < len then
+      invalid_arg "Bstruct blit"
+    else if dstoff < 0 || dst.len - dstoff < len then
+      invalid_arg "Bstruct blit"
+    else
+      String.blit src srcoff dst.buffer
+        (dst.off+dstoff) len
+
+  let to_string ?(off=0) ?len t =
+    let len = match len with None -> length t - off | Some l -> l in
+    copy_to_string t off len
+
+  let pp_t ppf t =
+    Format.fprintf ppf "[%d,%d](%d)" t.off t.len (Bytes.length t.buffer)
+  let string_t ppf str =
+    Format.fprintf ppf "[%d]" (String.length str)
+  let bytes_t ppf str =
+    Format.fprintf ppf "[%d]" (Bytes.length str)
+
+  let err fmt =
+    let b = Buffer.create 20 in                         (* for thread safety. *)
+    let ppf = Format.formatter_of_buffer b in
+    let k ppf = Format.pp_print_flush ppf (); invalid_arg (Buffer.contents b) in
+    Format.kfprintf k ppf fmt
+
+  let check_bounds t len =
+    len >= 0 && Bytes.length t.buffer >= len
+
+  let err_shift t = err "Bstruct.shift %a %d" pp_t t
+  let err_shiftv n = err "Bstruct.shiftv short by %d" n
+
+  let shift t amount =
+    let off = t.off + amount in
+    let len = t.len - amount in
+    if amount < 0 || amount > t.len || not (check_bounds t (off+len)) then
+      err_shift t amount
+    else { t with off; len }
+
+  let rec skip_empty = function
+    | t :: ts when t.len = 0 -> skip_empty ts
+    | x -> x
+
+  let rec shiftv ts = function
+    | 0 -> skip_empty ts
+    | n ->
+      match ts with
+      | [] -> err_shiftv n
+      | t :: ts when n >= t.len -> shiftv ts (n - t.len)
+      | t :: ts -> shift t n :: ts
+end
+
+module Slab = struct
+  type t = {
+    size : int;
+    mutable free_ptr : int;
+    mutable bytes : bytes;
+    mutable slices : (int * int) list;
+  }
+
+  let create size = { size; free_ptr = 0; bytes = Bytes.create size; slices = [] }
+
+  (* It would be nice if the bstruct here was just the raw pointer to the byte
+     array instead of probably all the extra header bytes... *)
+  let slice t len =
+    if t.free_ptr + len > t.size then invalid_arg "No space"
+    else begin
+      let b = { 
+        Bstruct.buffer = t.bytes;
+        off = t.free_ptr;
+        len = len;
+      } in
+      t.slices <- (t.free_ptr, len) :: t.slices;
+      t.free_ptr <- t.free_ptr + len;
+      b
+    end
+
+  let slice_string t s =
+    let len = String.length s in
+    let b = slice t len in
+    Bstruct.blit_from_string s 0 b 0 len;
+    b
+
+  let slice_strings t s =
+    List.map (slice_string t) s
+end

--- a/tests/dune
+++ b/tests/dune
@@ -16,7 +16,7 @@
 (executable
  (name urcat)
  (modules urcat)
- (libraries unix uring))
+ (libraries unix compiler-libs.optcomp uring))
 
 (executable
  (name urcp)

--- a/tests/main.md
+++ b/tests/main.md
@@ -25,6 +25,14 @@ let traceln fmt =
   Format.printf (fmt ^^ "@.")
 ```
 
+Setup a new printer for bytes to make things readable.
+
+```ocaml
+# let pp_bytes ppf b = Format.fprintf ppf "Bytes.t <len:%i>" (Bytes.length b);;
+val pp_bytes : Format.formatter -> bytes -> unit = <fun>
+# #install_printer pp_bytes;;
+```
+
 ## Queue depth
 
 ```ocaml
@@ -40,8 +48,8 @@ val t : [ `Read ] Uring.t = <abstr>
 
 # let fd = Unix.openfile "/dev/zero" Unix.[O_RDONLY] 0;;
 val fd : Unix.file_descr = <abstr>
-# let b = Cstruct.create 1;;
-val b : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 1}
+# let b = Bytes.create 1;;
+val b : bytes = Bytes.t <len:1>
 # Uring.read t fd b `Read ~file_offset:Int63.minus_one;;
 - : [ `Read ] Uring.job option = Some <abstr>
 # Uring.submit t;;
@@ -319,7 +327,7 @@ Exception: Unix.Unix_error(Unix.EXDEV, "openat2", "..")
 
 ```ocaml
 let set_fixed_buffer t size =
-  let fbuf = Bigarray.(Array1.create char c_layout size) in
+  let fbuf = Bytes.create Uring.major_alloc_byte_size in
   match Uring.set_fixed_buffer t fbuf with
   | Ok () -> fbuf
   | Error `ENOMEM -> failwith "Resource limit exceeded"
@@ -328,12 +336,11 @@ let () = Test_data.setup ()
 ```
 
 ```ocaml
-# let t : [ `Read ] Uring.t = Uring.create ~queue_depth:1 ();;
-val t : [ `Read ] Uring.t = <abstr>
-# let fbuf = set_fixed_buffer t 1024;;
-val fbuf :
-  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t =
-  <abstr>
+let t : [ `Read ] Uring.t = Uring.create ~queue_depth:1 ()
+let fbuf : Bytes.t = set_fixed_buffer t Uring.major_alloc_byte_size
+```
+
+```ocaml
 # let off = 3;;
 val off : int = 3
 # let len = 5;;
@@ -347,7 +354,7 @@ val fd : Unix.file_descr = <abstr>
 - : int = 1
 # consume t;;
 - : [ `Read ] * int = (`Read, 5)
-# Cstruct.of_bigarray fbuf ~off ~len |> Cstruct.to_string;;
+# Bytes.sub fbuf off len |> Bytes.to_string;;
 - : string = "test "
 
 # let fd : unit = Unix.close fd;;
@@ -367,26 +374,26 @@ val fd : Unix.file_descr = <abstr>
 # let b1_len = 3 and b2_len = 7;;
 val b1_len : int = 3
 val b2_len : int = 7
-# let b1 = Cstruct.create b1_len and b2 = Cstruct.create b2_len;;
-val b1 : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 3}
-val b2 : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 7}
+# let b1 = Bytes.create Uring.major_alloc_byte_size and b2 = Bytes.create Uring.major_alloc_byte_size;;
+val b1 : bytes = Bytes.t <len:16384>
+val b2 : bytes = Bytes.t <len:16384>
 
-# Uring.read t fd b1 `Read ~file_offset:Int63.minus_one;;
+# Uring.read ~len:b1_len t fd b1 `Read ~file_offset:Int63.minus_one;;
 - : [ `Read ] Uring.job option = Some <abstr>
 # Uring.submit t;;
 - : int = 1
 # let `Read, read = consume t;;
 val read : int = 3
-# Cstruct.to_string b1;;
+# Bytes.sub_string b1 0 b1_len;;
 - : string = "A t"
 
-# Uring.read t fd b2 `Read ~file_offset:Int63.minus_one;;
+# Uring.read ~len:b2_len t fd b2 `Read ~file_offset:Int63.minus_one;;
 - : [ `Read ] Uring.job option = Some <abstr>
 # Uring.submit t;;
 - : int = 1
 # let `Read, read = consume t;;
 val read : int = 7
-# Cstruct.to_string b2;;
+# Bytes.sub_string b2 0 b2_len;;
 - : string = "est fil"
 
 # let fd : unit = Unix.close fd;;
@@ -399,14 +406,22 @@ Writing with write:
 # let t : [`Read | `Write] Uring.t =  Uring.create ~queue_depth:2 ();;
 val t : [ `Read | `Write ] Uring.t = <abstr>
 
-# let rb = Cstruct.create 10 and wb = Cstruct.of_string "Hello";;
-val rb : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 10}
-val wb : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 5}
+# let rb_len = 10;;
+val rb_len : int = 10
+
+# let rb = Bytes.create Uring.major_alloc_byte_size;;
+val rb : bytes = Bytes.t <len:16384>
+# let wb = 
+  let b = Bytes.create Uring.major_alloc_byte_size in
+  Bytes.blit_string "Hello" 0 b 0 5;
+  b;;
+val wb : bytes = Bytes.t <len:16384>
+
 # let r, w = Unix.pipe ();;
 val r : Unix.file_descr = <abstr>
 val w : Unix.file_descr = <abstr>
 
-# Uring.write t w wb `Write ~file_offset:Int63.minus_one;;
+# Uring.write ~len:5 t w wb `Write ~file_offset:Int63.minus_one;;
 - : [ `Read | `Write ] Uring.job option = Some <abstr>
 # Uring.submit t;;
 - : int = 1
@@ -414,7 +429,7 @@ val w : Unix.file_descr = <abstr>
 val v : [ `Read | `Write ] = `Write
 val read : int = 5
 
-# Uring.read t r rb `Read ~file_offset:Int63.minus_one;;
+# Uring.read ~len:rb_len t r rb `Read ~file_offset:Int63.minus_one;;
 - : [ `Read | `Write ] Uring.job option = Some <abstr>
 # Uring.submit t;;
 - : int = 1
@@ -422,468 +437,11 @@ val read : int = 5
 val v : [ `Read | `Write ] = `Read
 val read : int = 5
 
-# let rb = Cstruct.sub rb 0 5;;
-val rb : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 5}
-# Cstruct.to_string rb;;
+# Bytes.sub_string rb 0 5;;
 - : string = "Hello"
 
 # let w : unit = Unix.close w;;
 val w : unit = ()
 # let r : unit = Unix.close r;;
 val r : unit = ()
-```
-
-Reading with readv:
-
-```ocaml
-# let t : [ `Readv ] Uring.t = Uring.create ~queue_depth:1 ();;
-val t : [ `Readv ] Uring.t = <abstr>
-
-# let fd = Unix.openfile Test_data.path [ O_RDONLY ] 0;;
-val fd : Unix.file_descr = <abstr>
-# let b1_len = 3 and b2_len = 7;;
-val b1_len : int = 3
-val b2_len : int = 7
-# let b1 = Cstruct.create b1_len and b2 = Cstruct.create b2_len;;
-val b1 : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 3}
-val b2 : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 7}
-# let iov = [b1; b2] in
-  Uring.readv t fd iov `Readv ~file_offset:Int63.zero;;
-- : [ `Readv ] Uring.job option = Some <abstr>
-
-# Uring.submit t;;
-- : int = 1
-
-# let `Readv, read = consume t;;
-val read : int = 10
-# Cstruct.to_string b1;;
-- : string = "A t"
-# Cstruct.to_string b2;;
-- : string = "est fil"
-
-# let fd : unit = Unix.close fd;;
-val fd : unit = ()
-```
-
-Test using cstructs with offsets:
-
-```ocaml
-# let fd = Unix.openfile Test_data.path [ O_RDONLY ] 0;;
-val fd : Unix.file_descr = <abstr>
-# let b = Cstruct.of_string "Gathered [    ] and [   ]";;
-val b : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 25}
-# let b1 = Cstruct.sub b 10 4 and b2 = Cstruct.sub b 21 3 in
-  let iov = [b1; b2] in
-  Uring.readv t fd iov `Readv ~file_offset:Int63.zero;;
-- : [ `Readv ] Uring.job option = Some <abstr>
-# Uring.submit t;;
-- : int = 1
-# consume t;;
-- : [ `Readv ] * int = (`Readv, 7)
-# Cstruct.to_string b;;
-- : string = "Gathered [A te] and [st ]"
-
-# let fd : unit = Unix.close fd;;
-val fd : unit = ()
-# Uring.exit t;;
-- : unit = ()
-```
-
-## Regions
-
-```ocaml
-# let t : [ `Read ] Uring.t = Uring.create ~queue_depth:1 ();;
-val t : [ `Read ] Uring.t = <abstr>
-
-# let fbuf = set_fixed_buffer t 64;;
-val fbuf :
-  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t =
-  <abstr>
-# let region = Uring.Region.init fbuf 4 ~block_size:16;;
-val region : Uring.Region.t = <abstr>
-# let chunk = Uring.Region.alloc region;;
-val chunk : Uring.Region.chunk = <abstr>
-
-# let fd = Unix.openfile Test_data.path [ O_RDONLY ] 0;;
-val fd : Unix.file_descr = <abstr>
-# Uring.read_chunk t fd chunk `Read ~file_offset:Int63.zero;;
-- : [ `Read ] Uring.job option = Some <abstr>
-# let `Read, read = consume t;;
-val read : int = 11
-# Uring.Region.to_string ~len:read chunk;;
-- : string = "A test file"
-# Uring.read_chunk ~len:17 t fd chunk `Read ~file_offset:Int63.zero;;
-Exception:
-Invalid_argument "to_cstruct: requested length 17 > block size 16".
-```
-
-Attempt to use a chunk from one ring with another:
-
-```ocaml
-# let t2 : [`Read] Uring.t = Uring.create ~queue_depth:1 ();;
-val t2 : [ `Read ] Uring.t = <abstr>
-# Uring.read_chunk ~len:16 t2 fd chunk `Read ~file_offset:Int63.zero;;
-Exception: Invalid_argument "Chunk does not belong to ring!".
-
-# let fd = Unix.close fd;;
-val fd : unit = ()
-# Uring.exit t;;
-- : unit = ()
-```
-
-## Cancellation
-
-Ask to read from a pipe (with no data available), then cancel it.
-
-```ocaml
-# exception Multiple of Unix.error list;;
-exception Multiple of Unix.error list
-
-# let t : [ `Cancel | `Read ] Uring.t = Uring.create ~queue_depth:5 ();;
-val t : [ `Cancel | `Read ] Uring.t = <abstr>
-
-# set_fixed_buffer t 1024;;
-- : (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t =
-<abstr>
-# let r, w = Unix.pipe ();;
-val r : Unix.file_descr = <abstr>
-val w : Unix.file_descr = <abstr>
-# let read = Uring.read_fixed t ~file_offset:Int63.zero r ~off:0 ~len:1 `Read |> Option.get;;
-val read : [ `Cancel | `Read ] Uring.job = <abstr>
-
-# Uring.cancel t read `Cancel;;
-- : [ `Cancel | `Read ] Uring.job option = Some <abstr>
-# Uring.submit t;;
-- : int = 2
-# let t1, r1 = consume t in
-  let t2, r2 = consume t in
-  let r_read, r_cancel =
-    match t1, t2 with
-    | `Read, `Cancel -> r1, r2
-    | `Cancel, `Read -> r2, r1
-    | _ -> assert false
-  in
-  begin match Uring.error_of_errno r_read, Uring.error_of_errno r_cancel with
-    | EINTR, EALREADY
-      (* Occasionally, the read is actually busy just as we try to cancel.
-         In that case it gets interrupted and the cancel returns EALREADY. *)
-    | EUNKNOWNERR 125 (* ECANCELLED *), EUNKNOWNERR 0 ->
-      (* This is the common case. The read is blocked and can just be removed. *)
-      ()
-    | e1, e2 -> raise (Multiple [e1; e2])
-  end;;
-- : unit = ()
-# let r : unit = Unix.close r;;
-val r : unit = ()
-# let w : unit = Unix.close w;;
-val w : unit = ()
-# Uring.exit t;;
-- : unit = ()
-```
-
-By the time we cancel, the request has already succeeded (we just didn't process the reply yet):
-
-```ocaml
-# let t : [ `Read | `Cancel ] Uring.t = Uring.create ~queue_depth:5 ();;
-val t : [ `Cancel | `Read ] Uring.t = <abstr>
-# set_fixed_buffer t 102;;
-- : (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t =
-<abstr>
-# let r = Unix.openfile "/dev/zero" Unix.[O_RDONLY] 0;;
-val r : Unix.file_descr = <abstr>
-# let read = Uring.read_fixed t ~file_offset:Int63.zero r ~off:0 ~len:1 `Read |> Option.get;;
-val read : [ `Cancel | `Read ] Uring.job = <abstr>
-# Uring.submit t;;
-- : int = 1
-# Unix.sleepf 0.001;;
-- : unit = ()
-# Uring.cancel t read `Cancel;;
-- : [ `Cancel | `Read ] Uring.job option = Some <abstr>
-# Uring.submit t;;
-- : int = 1
-# let t1, r1 = consume t in
-  let t2, r2 = consume t in
-  let r_read, r_cancel =
-    match t1, t2 with
-    | `Read, `Cancel -> r1, r2
-    | `Cancel, `Read -> r2, r1
-    | _ -> assert false
-  in
-  if r_read = 1 then (
-    match Uring.error_of_errno r_cancel with
-    | ENOENT -> ()
-    | e -> raise (Unix.Unix_error (e, "cancel", ""))
-  ) else (
-    match Uring.error_of_errno r_read, Uring.error_of_errno r_cancel with
-    | EUNKNOWNERR 125 (* ECANCELLED *), EUNKNOWNERR 0 ->
-      (* This isn't the case we want to test, but it can happen sometimes. *)
-      ()
-    | e1, e2 -> raise (Multiple [e1; e2])
-  );;
-- : unit = ()
-# let r : unit = Unix.close r;;
-val r : unit = ()
-
-# Uring.exit t;;
-- : unit = ()
-```
-
-By the time we cancel, we already knew the operation was over:
-
-```ocaml
-# let t : [ `Read | `Cancel ] Uring.t = Uring.create ~queue_depth:5 ();;
-val t : [ `Cancel | `Read ] Uring.t = <abstr>
-# set_fixed_buffer t 1024;;
-- : (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t =
-<abstr>
-# let r = Unix.openfile "/dev/zero" Unix.[O_RDONLY] 0;;
-val r : Unix.file_descr = <abstr>
-# let read = Uring.read_fixed t ~file_offset:Int63.zero r ~off:0 ~len:1 `Read |> Option.get;;
-val read : [ `Cancel | `Read ] Uring.job = <abstr>
-# let token, r_read = consume t;;
-val token : [ `Cancel | `Read ] = `Read
-val r_read : int = 1
-# let r : unit = Unix.close r;;
-val r : unit = ()
-```
-
-Try to cancel after we may have reused the index:
-```ocaml
-# Uring.cancel t read `Cancel;;
-Exception: Invalid_argument "Entry has already been freed!".
-
-# Uring.exit t;;
-- : unit = ()
-```
-
-## Freeing the ring
-
-We can't exit the ring while an operation is still pending:
-
-```ocaml
-# let t : [ `Read | `Mkdir ] Uring.t = Uring.create ~queue_depth:1 ();;
-val t : [ `Mkdir | `Read ] Uring.t = <abstr>
-# set_fixed_buffer t 1024;;
-- : (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t =
-<abstr>
-# let r, w = Unix.pipe ();;
-val r : Unix.file_descr = <abstr>
-val w : Unix.file_descr = <abstr>
-# Uring.read_fixed t ~file_offset:Int63.minus_one r ~off:0 ~len:1 `Read;;
-- : [ `Mkdir | `Read ] Uring.job option = Some <abstr>
-# Uring.submit t;;
-- : int = 1
-# Uring.exit t;;
-Exception: Invalid_argument "exit: 1 request(s) still active!".
-```
-
-But we can once it's complete:
-
-```ocaml
-# let w : unit = Unix.close w;;
-val w : unit = ()
-# consume t;;
-- : [ `Mkdir | `Read ] * int = (`Read, 0)
-# Uring.exit t;;
-- : unit = ()
-# let r : unit = Unix.close r;;
-val r : unit = ()
-```
-
-We can't free the ring a second time, or use it after freeing it:
-
-```ocaml
-# Uring.unlink t ~dir:false "/doesntexist" `Mkdir;;
-Exception:
-Invalid_argument "Can't use ring after Uring.exit has been called".
-
-# Uring.submit t;;
-Exception:
-Invalid_argument "Can't use ring after Uring.exit has been called".
-
-# Uring.wait t;;
-Exception:
-Invalid_argument "Can't use ring after Uring.exit has been called".
-
-# Uring.get_cqe_nonblocking t;;
-Exception:
-Invalid_argument "Can't use ring after Uring.exit has been called".
-
-# Uring.get_probe t;;
-Exception:
-Invalid_argument "Can't use ring after Uring.exit has been called".
-
-# Uring.exit t;;
-Exception:
-Invalid_argument "Can't use ring after Uring.exit has been called".
-```
-
-## Send_msg
-
-```ocaml
-# let r, w = Unix.pipe ();;
-val r : Unix.file_descr = <abstr>
-val w : Unix.file_descr = <abstr>
-# let t : [ `Recv | `Send ] Uring.t= Uring.create ~queue_depth:2 ();;
-val t : [ `Recv | `Send ] Uring.t = <abstr>
-# let a, b = Unix.(socketpair PF_UNIX SOCK_STREAM 0);;
-val a : Unix.file_descr = <abstr>
-val b : Unix.file_descr = <abstr>
-# let bufs = [Cstruct.of_string "hi"];;
-val bufs : Cstruct.t list = [{Cstruct.buffer = <abstr>; off = 0; len = 2}]
-# Uring.send_msg t a ~fds:[r; w] bufs `Send;;
-- : [ `Recv | `Send ] Uring.job option = Some <abstr>
-# Uring.submit t;;
-- : int = 1
-# consume t;;
-- : [ `Recv | `Send ] * int = (`Send, 2)
-# let recv_buf = Cstruct.of_string "XX";;
-val recv_buf : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 2}
-# let recv = Uring.Msghdr.create ~n_fds:2 [recv_buf];;
-val recv : Uring.Msghdr.t = <abstr>
-# List.length (Uring.Msghdr.get_fds recv);;
-- : int = 0
-# Uring.recv_msg t b recv `Recv;;
-- : [ `Recv | `Send ] Uring.job option = Some <abstr>
-# Uring.submit t;;
-- : int = 1
-# consume t;;
-- : [ `Recv | `Send ] * int = (`Recv, 2)
-# Cstruct.to_string recv_buf;;
-- : string = "hi"
-# let r2, w2 =
-    match Uring.Msghdr.get_fds recv with
-    | [r2; w2] -> r2, w2
-    | _ -> failwith "Expected two FDs!";;
-val r2 : Unix.file_descr = <abstr>
-val w2 : Unix.file_descr = <abstr>
-# Unix.write_substring w2 "to-w2" 0 5;;
-- : int = 5
-# really_input_string (Unix.in_channel_of_descr r) 5;;
-- : string = "to-w2"
-# Unix.write_substring w "to-w" 0 4;;
-- : int = 4
-# really_input_string (Unix.in_channel_of_descr r2) 4;;
-- : string = "to-w"
-# let r : unit = Unix.close r;;
-val r : unit = ()
-# let r2 : unit = Unix.close r2;;
-val r2 : unit = ()
-# let w2 : unit = Unix.close w2;;
-val w2 : unit = ()
-# let w : unit = Unix.close w;;
-val w : unit = ()
-# Uring.exit t;;
-- : unit = ()
-```
-
-## Unlink and rmdir
-
-```ocaml
-# let t : unit Uring.t = Uring.create ~queue_depth:2 ();;
-val t : unit Uring.t = <abstr>
-
-# close_out (open_out "test-file"); Unix.mkdir "test-dir" 0o700;;
-- : unit = ()
-
-# let check () = Sys.file_exists "test-file", Sys.file_exists "test-dir";;
-val check : unit -> bool * bool = <fun>
-# check ();;
-- : bool * bool = (true, true)
-
-# Uring.unlink t ~dir:false "test-file" ();;
-- : unit Uring.job option = Some <abstr>
-
-# Uring.unlink t ~dir:true "test-dir" ();;
-- : unit Uring.job option = Some <abstr>
-
-# Uring.wait t;;
-- : unit Uring.completion_option = Uring.Some {Uring.result = 0; data = ()}
-
-# Uring.wait t;;
-- : unit Uring.completion_option = Uring.Some {Uring.result = 0; data = ()}
-
-# check ();;
-- : bool * bool = (false, false)
-
-# Uring.exit t;;
-- : unit = ()
-```
-
-## Timeout
-
-Timeout should return (-ETIME). This is defined in https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/errno.h#L45
-
-```ocaml
-# let t : [`Timeout] Uring.t = Uring.create ~queue_depth:1 ();;
-val t : [ `Timeout ] Uring.t = <abstr>
-
-# let ns1 = Int64.(mul 10L 1_000_000L) in
-  Uring.(timeout t Boottime ns1 `Timeout);;
-- : [ `Timeout ] Uring.job option = Some <abstr>
-
-# Uring.submit t;;
-- : int = 1
-
-# let `Timeout, timeout = consume t;;
-val timeout : int = -62
-
-# let ns = 
-    ((Unix.gettimeofday () +. 0.01) *. 1e9)
-    |> Int64.of_float
-  in
-  Uring.(timeout ~absolute:true t Realtime ns `Timeout);;
-- : [ `Timeout ] Uring.job option = Some <abstr>
-
-# let `Timeout, timeout = consume t;;
-val timeout : int = -62
-
-# let ns1 = Int64.(mul 10L 1_000_000L) in
-  Uring.(timeout ~absolute:true t Boottime ns1 `Timeout);;
-- : [ `Timeout ] Uring.job option = Some <abstr>
-
-# let `Timeout, timeout = consume t;;
-val timeout : int = -62
-
-# Uring.exit t;;
-- : unit = ()
-```
-
-If there is a timeout but we did submit something, `io_uring_submit_and_wait_timeout` returns success instead:
-
-```ocaml
-# let t : [`Timeout | `Cancel] Uring.t = Uring.create ~queue_depth:1 ();;
-val t : [ `Cancel | `Timeout ] Uring.t = <abstr>
-
-# let job =
-    let ns = Int64.(mul 10L 1_000_000_000L) in
-    Uring.(timeout t Boottime ns `Timeout);;
-val job : [ `Cancel | `Timeout ] Uring.job option = Some <abstr>
-
-# Uring.wait ~timeout:0.01 t;;Uring.wait ~timeout:0.01 t;;
-- : [ `Cancel | `Timeout ] Uring.completion_option = Uring.None
-
-# Uring.cancel t (Option.get job) `Cancel;;
-- : [ `Cancel | `Timeout ] Uring.job option = Some <abstr>
-
-# ignore (Uring.wait ~timeout:10.0 t, Uring.wait ~timeout:10.0 t);;
-- : unit = ()
-
-# Uring.exit t;;
-- : unit = ()
-```
-
-
-## Probing
-
-```ocaml
-# let t : unit Uring.t = Uring.create ~queue_depth:1 ();;
-val t : unit Uring.t = <abstr>
-
-# let probe = Uring.get_probe t in
-  Uring.op_supported probe Uring.Op.nop;;
-- : bool = true
-
-# Uring.exit t;;
-- : unit = ()
 ```

--- a/tests/sketch.md
+++ b/tests/sketch.md
@@ -20,8 +20,10 @@ let rec consume t =
 val t : unit Uring.t = <abstr>
 # let fd = Unix.openfile "/dev/zero" [ O_RDONLY ] 0;;
 val fd : Unix.file_descr = <abstr>
-# let b = Bytes.create 1;;
-val b : bytes = Bytes.of_string "\000"
+# let b = 
+  let slab = Uring.Slab.create Uring.major_alloc_byte_size in
+  Uring.Slab.slice slab 1;;
+val b : Uring.Bstruct.t = <abstr>
 
 # Uring.readv t fd (ldup 1 b) () ~file_offset:Int63.zero;;
 - : unit Uring.job option = Some <abstr>

--- a/tests/sketch.md
+++ b/tests/sketch.md
@@ -20,8 +20,8 @@ let rec consume t =
 val t : unit Uring.t = <abstr>
 # let fd = Unix.openfile "/dev/zero" [ O_RDONLY ] 0;;
 val fd : Unix.file_descr = <abstr>
-# let b = Cstruct.create 1;;
-val b : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 1}
+# let b = Bytes.create 1;;
+val b : bytes = Bytes.of_string "\000"
 
 # Uring.readv t fd (ldup 1 b) () ~file_offset:Int63.zero;;
 - : unit Uring.job option = Some <abstr>

--- a/tests/urcat.ml
+++ b/tests/urcat.ml
@@ -1,7 +1,7 @@
 (* cat(1) built with liburing.
    OCaml version of https://unixism.net/loti/tutorial/cat_liburing.html *)
 
-let block_size = 1024
+let block_size = Config.max_young_wosize * Sys.word_size
 
 let get_file_size fd =
   Unix.handle_unix_error Unix.fstat fd |>
@@ -17,13 +17,13 @@ let get_completion_and_print uring =
   let remaining = ref len in
   Printf.eprintf "%d bytes read\n%!" len;
   List.iter (fun buf ->
-    let buflen = Cstruct.length buf in
+    let buflen = Bytes.length buf in
     if !remaining > 0 then begin
       if buflen <= !remaining then begin
-        print_string (Cstruct.to_string buf);
+        print_string (Bytes.to_string buf);
         remaining := !remaining - buflen;
       end else begin
-        print_string (Cstruct.to_string ~off:0 ~len:!remaining buf);
+        print_string (Bytes.sub_string buf 0 !remaining);
         remaining := 0;
       end
     end
@@ -33,8 +33,9 @@ let submit_read_request fname uring =
   let fd = Unix.(handle_unix_error (openfile fname [O_RDONLY]) 0) in
   let file_sz = get_file_size fd in
   let blocks = if file_sz mod block_size <> 0 then (file_sz / block_size)+1 else file_sz/block_size in
-  let iov = List.init blocks (fun _ -> Cstruct.create block_size) in
+  let iov = List.init blocks (fun _ -> Bytes.create block_size) in
   let _ = Uring.readv uring fd iov iov ~file_offset:Optint.Int63.zero in
+  Gc.full_major (); (* <--- KABOOM! ... well not really, just the bytes are empty... did something move? *)
   let numreq = Uring.submit uring in
   assert(numreq=1);
   ()

--- a/tests/urcp_fixed_lib.ml
+++ b/tests/urcp_fixed_lib.ml
@@ -159,7 +159,7 @@ let run_cp block_size queue_depth infile outfile () =
    Logs.debug (fun l -> l "starting: %a bs=%d qd=%d" pp t block_size queue_depth);
    let fixed_buf_len = queue_depth * block_size in
    let uring = Uring.create ~queue_depth () in
-   let fbuf = Bigarray.(Array1.create char c_layout fixed_buf_len) in
+   let fbuf = Bytes.create fixed_buf_len in
    Fun.protect
      (fun () ->
         match Uring.set_fixed_buffer uring fbuf with


### PR DESCRIPTION
This is an experiment to switch away from Cstruct to Bstruct (bytes-backed Cstruct). The main issue is that the bytes are in the OCaml heap but we have to ensure they don't move. I started playing around with an allocator (`Uring.Slab`) which allocates a big bytes area upfront and the carves it up as the user requests slices (returned as `Bstruct.t`). For this to work properly the `Uring.Slab` implementation needs a few more tricky features:

 - The bytes array probably needs to be more dynamic so it can create other big bytes areas when there's a lot of requests for slices.
 - Slices that are finished with, should be garbage-collected which probably means having some reference counting.

Opening this PR in case other people want to have a play around. Note this will only work with OCaml 5+ and is related to https://github.com/ocaml-multicore/eio/issues/140