### PR TITLE
add filesystem attributes display to urstat

### DIFF
--- a/tests/urstat.ml
+++ b/tests/urstat.ml
@@ -9,7 +9,7 @@ let pp_time f (sec, nsec) =
     (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
     tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
     nsec
-  
+
 let get_completion_and_print uring =
   let (fname, buf), _ =
     match Uring.wait uring with
@@ -17,10 +17,21 @@ let get_completion_and_print uring =
     | None -> failwith "retry"
   in
   let kind = S.kind buf in
+  let amask = S.attributes_mask buf in
+  let attrs = S.attributes buf in
+  let pp_attr f (a,s) =
+    try
+      if S.Attr.check ~mask:amask attrs a then
+        Format.fprintf f "%s:on " s
+      else
+        Format.fprintf f "%s:off " s
+    with Invalid_argument _ ->
+      Format.fprintf f "%s:unsup " s
+  in
   let opt_symlink = match kind with
       `Symbolic_link -> Printf.sprintf " -> %s" (Unix.readlink fname) (* TODO no readlink in io_uring? *)
     | _ -> "" in
-  Format.printf "  File: %s%s\n  Size: %Lu\t\tBlocks: %Lu\tIO Block: %Lu\t %a\nDevice: %Lu\tInode: %Lu\tLinks: %Lu\nAccess: (%04o/TODO)\tUid: (%Lu/TODO)\tGid: (%Lu/TODO)\nAccess: %a\nModify: %a\nChange: %a\n Birth: %a\n%!"
+  Format.printf "  File: %s%s\n  Size: %Lu\t\tBlocks: %Lu\tIO Block: %Lu\t %a\nDevice: %Lu\tInode: %Lu\tLinks: %Lu\nAccess: (%04o/TODO)\tUid: (%Lu/TODO)\tGid: (%Lu/TODO)\nAccess: %a\nModify: %a\nChange: %a\n Birth: %a\nAttrs : %a %a %a %a %a %a %a\n%!"
     fname opt_symlink
     (S.size buf)
     (S.blocks buf)
@@ -32,6 +43,13 @@ let get_completion_and_print uring =
     pp_time (S.mtime_sec buf, S.mtime_nsec buf)
     pp_time (S.ctime_sec buf, S.ctime_nsec buf)
     pp_time (S.btime_sec buf, S.btime_nsec buf)
+    pp_attr (S.Attr.compressed, "compressed")
+    pp_attr (S.Attr.immutable, "immutable")
+    pp_attr (S.Attr.append, "append")
+    pp_attr (S.Attr.nodump, "nodump")
+    pp_attr (S.Attr.encrypted, "encrypted")
+    pp_attr (S.Attr.verity, "verity")
+    pp_attr (S.Attr.dax, "dax")
 
 let submit_stat_request fname buf uring =
   let mask = S.Mask.(basic_stats + btime) in


### PR DESCRIPTION
e.g.
```
./_build/default/tests/urstat.exe /proc
  File: /proc                         
  Size: 0               Blocks: 0       IO Block: 1024   directory
Device: 21      Inode: 1        Links: 297
Access: (0555/TODO)     Uid: (0/TODO)   Gid: (0/TODO)
Access: 2023-05-27 18:52:33.927999992 +0000
Modify: 2023-05-27 18:52:33.927999992 +0000
Change: 2023-05-27 18:52:33.927999992 +0000
 Birth: 1970-01-01 00:00:00.000000000 +0000
Attrs : compressed:off  immutable:off  append:off  nodump:off  encrypted:off  verity:off  dax:unsup 
```