### PR TITLE
Add eventfd support

### DIFF
--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -343,6 +343,7 @@ module Uring = struct
   external peek_cqe : t -> cqe_option = "ocaml_uring_peek_cqe"
 
   external error_of_errno : int -> Unix.error = "ocaml_uring_error_of_errno"
+  external register_eventfd : t -> Unix.file_descr -> unit = "ocaml_uring_register_eventfd"
 end
 
 type 'a t = {
@@ -582,6 +583,10 @@ let get_cqe_nonblocking t =
   fn_on_ring Uring.peek_cqe t
 
 let peek = get_cqe_nonblocking
+
+let register_eventfd t fd =
+  check t;
+  Uring.register_eventfd t.uring fd
 
 let wait ?timeout t =
   check t;

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -441,6 +441,10 @@ val get_cqe_nonblocking : 'a t -> 'a completion_option
 val peek : 'a t -> 'a completion_option
 [@@deprecated "Renamed to Uring.get_cqe_nonblocking"]
 
+val register_eventfd : 'a t -> Unix.file_descr -> unit
+(** [register_eventfd t fd] will register an eventfd to the the uring [t].
+    See documentation for io_uring_register_eventfd *)
+
 val error_of_errno : int -> Unix.error
 (** [error_of_errno e] converts the error code [abs e] to a Unix error type. *)
 

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -998,3 +998,15 @@ ocaml_uring_opcode_supported(value v_probe, value v_op)
   else
     return Val_false;
 }
+
+value
+ocaml_uring_register_eventfd(value v_uring, value v_fd) {
+  struct io_uring *ring = Ring_val(v_uring);
+  int fd = Int_val(v_fd);
+
+  int ret = io_uring_register_eventfd(ring, fd);
+  if (ret)
+    unix_error(-ret, "io_uring_register_eventfd", Nothing);
+
+  return Val_unit;
+}


### PR DESCRIPTION
Registering an eventfd to the io_uring is useful for interfacing with systems that already use polling.