### PR TITLE
Use linux/fcntl.h for 5.x series kernels

### DIFF
--- a/lib/uring/include/discover.ml
+++ b/lib/uring/include/discover.ml
@@ -134,7 +134,7 @@ let () =
 #include <linux/stat.h>
 #endif
 |} ^ new_flag_prelude)
-          ~includes:["fcntl.h" ]
+          ~includes:["linux/fcntl.h" ]
           (C.C_define.Type.[
             "AT_EMPTY_PATH", Int;
             "AT_NO_AUTOMOUNT", Int;


### PR DESCRIPTION
Import `fnctl.h` from `linux/fcntl.h` to retrieve iouring constants that are only defined there in 5.x series kernels