### PR TITLE
Add Uring.sqe_ready

### DIFF
--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -567,6 +567,8 @@ let cancel t job user_data =
   ignore (Heap.ptr job : Uring.id);  (* Check it's still valid *)
   with_id t (fun id -> Uring.submit_cancel t.uring id (Heap.ptr job)) user_data
 
+let sqe_ready t = Uring.sq_ready t.uring
+
 (* Free stale entries in the sketch buffer, if possible.
    This isn't quite right: a busy system might never have 0 unsubmitted entries.
    We should probably track how many requests need to be submitted before each

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -666,6 +666,9 @@ val active_ops : _ t -> int
 (** [active_ops t] returns the number of operations added to the ring (whether submitted or not)
     for which the completion event has not yet been collected. *)
 
+val sqe_ready : _ t -> int
+(** [sqe_ready t] is the number of unconsumed (if SQPOLL) or unsubmitted entries in the SQ ring. *)
+
 module Stats : sig
   type t = {
     sqe_ready : int;            (** SQEs not yet submitted. *)

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -157,7 +157,11 @@ ocaml_uring_submit_nop(value v_uring, value v_id) {
 value /* noalloc */
 ocaml_uring_sq_ready(value v_uring) {
   struct io_uring *ring = Ring_val(v_uring);
-  return (Val_int(io_uring_sq_ready(ring)));
+  if (ring) {
+    return Val_int(io_uring_sq_ready(ring));
+  } else {
+    return Val_int(0);
+  }
 }
 
 value /* noalloc */


### PR DESCRIPTION
This is useful to know whether we need to call `submit`. Knowing we don't avoids the need to report trace events for it.