### PR TITLE
Add Uring.Setup_flags

### DIFF
--- a/lib/uring/heap.mli
+++ b/lib/uring/heap.mli
@@ -28,7 +28,7 @@ type ptr = private int
 
 val ptr : 'a entry -> ptr
 (** [ptr e] is the index of [e].
-    @raise Invalid_arg if [e] has already been freed. *)
+    @raise Invalid_argument if [e] has already been freed. *)
 
 val alloc : 'a t -> 'a -> extra_data:'b -> 'a entry
 (** [alloc t a ~extra_data] adds the value [a] to [t] and returns a

--- a/lib/uring/primitives.h
+++ b/lib/uring/primitives.h
@@ -57,7 +57,7 @@ CAMLprim value ocaml_uring_set_iovec(value, value);
 CAMLprim value ocaml_uring_set_string(value, value);
 CAMLprim value ocaml_uring_make_msghdr(value, value, value);
 CAMLprim value ocaml_uring_get_msghdr_fds(value);
-CAMLprim value ocaml_uring_setup(value, value);
+CAMLprim value ocaml_uring_setup(value, value, value);
 CAMLprim value ocaml_uring_exit(value);
 CAMLprim value ocaml_uring_unregister_buffers(value);
 CAMLprim value ocaml_uring_register_ba(value, value);

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -77,7 +77,7 @@ static struct custom_operations ring_ops = {
   custom_fixed_length_default
 };
 
-value ocaml_uring_setup(value entries, value polling_timeout) {
+value ocaml_uring_setup(value entries, value polling_timeout, value v_flags) {
   CAMLparam1(entries);
   CAMLlocal1(v_uring);
   struct io_uring_params params;
@@ -90,6 +90,7 @@ value ocaml_uring_setup(value entries, value polling_timeout) {
   Ring_val(v_uring) = ring;
 
   memset(&params, 0, sizeof(params));
+  params.flags = Int_val(v_flags);
   if (Is_some(polling_timeout)) {
     params.flags |= IORING_SETUP_SQPOLL;
     params.sq_thread_idle = Int_val(Some_val(polling_timeout));


### PR DESCRIPTION
This allows passing flags to `create`, e.g.
```ocaml
Uring.create ~flags:Uring.Setup_flags.(single_issuer + defer_taskrun)
```
which avoids the issue in https://github.com/ocaml-multicore/eio/issues/788 (see https://github.com/axboe/liburing/discussions/1452).

We should probably enable some of these flags in Eio (e.g. `IORING_SETUP_COOP_TASKRUN` and `IORING_SETUP_SINGLE_ISSUER` at least).