### PR TITLE
Fix mkdir test

### DIFF
--- a/tests/main.md
+++ b/tests/main.md
@@ -877,8 +877,8 @@ val t : [ `Mkdir of int ] Uring.t = <abstr>
 # Uring.wait t;;
 - : [ `Mkdir of int ] Uring.completion_option =
 Uring.Some {Uring.result = 0; data = `Mkdir 0}
-# (Unix.stat "mkdir").st_perm;;
-- : int = 448
+# Printf.sprintf "0o%o" ((Unix.stat "mkdir").st_perm land 0o777);;
+- : string = "0o700"
 # let v = Uring.mkdirat t ~mode:0o755 "mkdir" (`Mkdir 1);;
 val v : [ `Mkdir of int ] Uring.job option = Some <abstr>
 # Uring.submit t;;


### PR DESCRIPTION
According to `man 7 inode`:
> POSIX refers to the stat.st_mode bits corresponding to the mask S_IFMT
> (see below) as the file type, the 12 bits  corresponding to the mask
> 07777 as the file mode bits and the least significant 9 bits (0777) as
> the file permission bits.

OCaml defines `st_perm` as:
> The type of file access rights, e.g. 0o640 is read and write for user,
> read for group, none for others

However, OCaml uses `buf->st_mode & 07777` and so includes three other bits. We need to mask them out for the test (see failure in https://github.com/ocaml/opam-repository/pull/28604).

/cc @patricoferris