### PR TITLE
Add Uring.Res module to handle result values

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,7 @@ The `result` field is the return code,
 with the same meaning as the return code from the corresponding system call (`openat2` in this case).
 
 ```ocaml
-# let fd =
-    if result < 0 then failwith ("Error: " ^ string_of_int result);
-    (Obj.magic result : Unix.file_descr);;
+# let fd = Uring.Res.fd_exn result "openat2" "test.log";;
 val fd : Unix.file_descr = <abstr>
 ```
 
@@ -99,7 +97,7 @@ let rec write_all fd = function
     assert (Uring.submit uring = 1);
     let result, data = wait_with_retry uring in
     assert (data = `Write_all);  (* There aren't any other requests pending *)
-    assert (result > 0);         (* Check for error return *)
+    let result = Uring.Res.int_exn result "writev" "" in
     let bufs = Cstruct.shiftv bufs result in
     write_all fd bufs
 ```
@@ -124,7 +122,7 @@ Some <abstr>
 - : int = 1
 
 # wait_with_retry uring;;
-- : int * ([> `Close_log | `Open_log | `Write_all ] as '_weak3) =
+- : Uring.Res.t * ([> `Close_log | `Open_log | `Write_all ] as '_weak3) =
 (0, `Close_log)
 ```
 

--- a/bench/readv.ml
+++ b/bench/readv.ml
@@ -29,13 +29,10 @@ let run_bechmark ~polling_timeout fd =
   let t0 = Unix.gettimeofday () in
   for _ = 1 to n_iters do
     wait t (fun result bufs ->
-        if result < 0 then (
-          raise (Unix.Unix_error (Uring.error_of_errno result, "readv", ""))
-        ) else (
-          got := !got + result;
-          let _job : _ Uring.job = Uring.readv t fd bufs ~file_offset:Optint.Int63.zero bufs |> Option.get in
-          ()
-        )
+        let result = Uring.Res.int_exn result "readv" "" in
+        got := !got + result;
+        let _job : _ Uring.job = Uring.readv t fd bufs ~file_offset:Optint.Int63.zero bufs |> Option.get in
+        ()
       )
   done;
   (* Get a snapshot of the stats before letting things finish. *)

--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -357,6 +357,109 @@ module Uring = struct
   external register_eventfd : t -> Unix.file_descr -> unit = "ocaml_uring_register_eventfd"
 end
 
+let error_of_errno e =
+  Uring.error_of_errno (abs e)
+
+module Res = struct
+  type t = int
+
+  let int_result t =
+    if t >= 0 then Ok t
+    else Error (error_of_errno t)
+
+  let int_exn t fn arg =
+    if t >= 0 then t
+    else raise (Unix.Unix_error (error_of_errno t, fn, arg))
+
+  let fd_of_int x : Unix.file_descr = Obj.magic (x : int)
+
+  let fd_result t =
+    if t >= 0 then Ok (fd_of_int t)
+    else Error (error_of_errno t)
+
+  let fd_exn t fn arg =
+    if t >= 0 then fd_of_int t
+    else raise (Unix.Unix_error (error_of_errno t, fn, arg))
+
+  let pp f t =
+    if t >= 0 then Fmt.int f t
+    else
+      Fmt.string f @@ match error_of_errno t with
+      | E2BIG -> "E2BIG"
+      | EACCES -> "EACCES"
+      | EAGAIN -> "EAGAIN"
+      | EBADF -> "EBADF"
+      | EBUSY -> "EBUSY"
+      | ECHILD -> "ECHILD"
+      | EDEADLK -> "EDEADLK"
+      | EDOM -> "EDOM"
+      | EEXIST -> "EEXIST"
+      | EFAULT -> "EFAULT"
+      | EFBIG -> "EFBIG"
+      | EINTR -> "EINTR"
+      | EINVAL -> "EINVAL"
+      | EIO -> "EIO"
+      | EISDIR -> "EISDIR"
+      | EMFILE -> "EMFILE"
+      | EMLINK -> "EMLINK"
+      | ENAMETOOLONG -> "ENAMETOOLONG"
+      | ENFILE -> "ENFILE"
+      | ENODEV -> "ENODEV"
+      | ENOENT -> "ENOENT"
+      | ENOEXEC -> "ENOEXEC"
+      | ENOLCK -> "ENOLCK"
+      | ENOMEM -> "ENOMEM"
+      | ENOSPC -> "ENOSPC"
+      | ENOSYS -> "ENOSYS"
+      | ENOTDIR -> "ENOTDIR"
+      | ENOTEMPTY -> "ENOTEMPTY"
+      | ENOTTY -> "ENOTTY"
+      | ENXIO -> "ENXIO"
+      | EPERM -> "EPERM"
+      | EPIPE -> "EPIPE"
+      | ERANGE -> "ERANGE"
+      | EROFS -> "EROFS"
+      | ESPIPE -> "ESPIPE"
+      | ESRCH -> "ESRCH"
+      | EXDEV -> "EXDEV"
+      | EWOULDBLOCK -> "EWOULDBLOCK"
+      | EINPROGRESS -> "EINPROGRESS"
+      | EALREADY -> "EALREADY"
+      | ENOTSOCK -> "ENOTSOCK"
+      | EDESTADDRREQ -> "EDESTADDRREQ"
+      | EMSGSIZE -> "EMSGSIZE"
+      | EPROTOTYPE -> "EPROTOTYPE"
+      | ENOPROTOOPT -> "ENOPROTOOPT"
+      | EPROTONOSUPPORT -> "EPROTONOSUPPORT"
+      | ESOCKTNOSUPPORT -> "ESOCKTNOSUPPORT"
+      | EOPNOTSUPP -> "EOPNOTSUPP"
+      | EPFNOSUPPORT -> "EPFNOSUPPORT"
+      | EAFNOSUPPORT -> "EAFNOSUPPORT"
+      | EADDRINUSE -> "EADDRINUSE"
+      | EADDRNOTAVAIL -> "EADDRNOTAVAIL"
+      | ENETDOWN -> "ENETDOWN"
+      | ENETUNREACH -> "ENETUNREACH"
+      | ENETRESET -> "ENETRESET"
+      | ECONNABORTED -> "ECONNABORTED"
+      | ECONNRESET -> "ECONNRESET"
+      | ENOBUFS -> "ENOBUFS"
+      | EISCONN -> "EISCONN"
+      | ENOTCONN -> "ENOTCONN"
+      | ESHUTDOWN -> "ESHUTDOWN"
+      | ETOOMANYREFS -> "ETOOMANYREFS"
+      | ETIMEDOUT -> "ETIMEDOUT"
+      | ECONNREFUSED -> "ECONNREFUSED"
+      | EHOSTDOWN -> "EHOSTDOWN"
+      | EHOSTUNREACH -> "EHOSTUNREACH"
+      | ELOOP -> "ELOOP"
+      | EOVERFLOW -> "EOVERFLOW"
+      | _ ->
+        match t with
+        | -62 -> "ETIME"
+        | -125 -> "ECANCELED"
+        | _ -> string_of_int t
+end
+
 type 'a t = {
   id : < >;
   uring: Uring.t;
@@ -647,9 +750,6 @@ let wait ?timeout t =
 
 let queue_depth {queue_depth;_} = queue_depth
 let buf {fixed_iobuf;_} = fixed_iobuf
-
-let error_of_errno e =
-  Uring.error_of_errno (abs e)
 
 let get_probe t =
   check t;

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -74,6 +74,27 @@ module Setup_flags : sig
   (** Defer running task work to get events *)
 end
 
+module Res : sig
+  (** The result of a uring operation (typically the same as the return value of the corresponding syscall). *)
+
+  type t = private int
+  (** The return value. If negative, it is the negative errno value giving the error. *)
+
+  val int_result : t -> (int, Unix.error) result
+  (** [int_result t] is [Error _] if [t] is negative, or [Ok t] otherwise. *)
+
+  val int_exn : t -> string -> string -> int
+  (** [int_exn t fn arg] raises {!Unix.Unix_error} if [t] is negative, and returns [t] otherwise. *)
+
+  val fd_result : t -> (Unix.file_descr, Unix.error) result
+  (** [fd_result t] is like [int_result t], but returns [t] as a file descriptor. *)
+
+  val fd_exn : t -> string -> string -> Unix.file_descr
+  (** [fd_exn t] is like [int_exn t], but returns [t] as a file descriptor. *)
+
+  val pp : t Fmt.t [@@ocaml.toplevel_printer]
+end
+
 type 'a t
 (** ['a t] is a reference to an Io_uring structure. *)
 
@@ -842,7 +863,7 @@ val submit : 'a t -> int
 
 type 'a completion_option =
   | None
-  | Some of { result: int; data: 'a } (**)
+  | Some of { result: Res.t; data: 'a } (**)
 (** The type of results of calling {!wait} and {!peek}. [None] denotes that
     either there were no completions in the queue or an interrupt / timeout
     occurred. [Some] contains both the user data attached to the completed

--- a/tests/main.md
+++ b/tests/main.md
@@ -1,5 +1,6 @@
 ```ocaml
 # #require "uring";;
+# #install_printer Uring.Res.pp;;
 ```
 
 # Uring tests
@@ -20,6 +21,14 @@ let rec consume t =
   match Uring.wait ~timeout:1. t with
   | Some { data; result } -> (data, result)
   | None -> consume t
+
+let consume_int ?(fn="consume_int") ?(arg="") t =
+  let data, result = consume t in
+  data, Uring.Res.int_exn result fn arg
+
+let consume_fd ?(fn="consume_fd") ?(arg="") t =
+  let data, result = consume t in
+  data, Uring.Res.fd_exn result fn arg
 
 let traceln fmt =
   Format.printf (fmt ^^ "@.")
@@ -53,9 +62,9 @@ val b : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 1}
 # Uring.submit t;;
 - : int = 1
 # consume t;;
-- : [ `Read ] * int = (`Read, 1)
+- : [ `Read ] * Uring.Res.t = (`Read, 1)
 # consume t;;
-- : [ `Read ] * int = (`Read, 1)
+- : [ `Read ] * Uring.Res.t = (`Read, 1)
 # let fd : unit = Unix.close fd;;
 val fd : unit = ()
 # Uring.exit t;;
@@ -99,7 +108,7 @@ Sketch buffer: 0/0 (plus 0 old buffers)
 
 # for i = 1 to queue_depth do
     let tkn, res = consume t in
-    traceln "%d returned %d" tkn res;
+    traceln "%d returned %a" tkn Uring.Res.pp res;
   done;;
 1 returned 0
 2 returned 0
@@ -134,10 +143,7 @@ val t : [ `Open ] Uring.t = <abstr>
 # Uring.submit t;;;
 - : int = 1
 
-# let token, fd =
-    let token, fd = consume t in
-    assert (fd >= 0);
-    token, (Obj.magic fd : Unix.file_descr);;
+# let token, fd = consume_fd t;;
 val token : [ `Open ] = `Open
 val fd : Unix.file_descr = <abstr>
 
@@ -170,10 +176,7 @@ val t : [ `Create ] Uring.t = <abstr>
 # Uring.submit t;;
 - : int = 1
 
-# let token, fd =
-    let token, fd = consume t in
-    assert (fd >= 0);
-    token, (Obj.magic fd : Unix.file_descr);;
+# let token, fd = consume_fd t;;
 val token : [ `Create ] = `Create
 val fd : Unix.file_descr = <abstr>
 
@@ -190,7 +193,7 @@ val fd : Unix.file_descr = <abstr>
 - : int = 1
 # let v, read = consume t;;
 val v : [ `Create ] = `Create
-val read : int = 0
+val read : Uring.Res.t = 0
 
 # Uring.fdatasync t ~off:1L ~len:5 fd `Create;;
 - : [ `Create ] Uring.job option = Some <abstr>
@@ -198,7 +201,7 @@ val read : int = 0
 - : int = 1
 # let v, read = consume t;;
 val v : [ `Create ] = `Create
-val read : int = 0
+val read : Uring.Res.t = 0
 
 # let fd : unit = Unix.close fd;;
 val fd : unit = ()
@@ -228,7 +231,7 @@ val statx : Uring.Statx.t = <abstr>
 
 # let token, retval = consume t;;
 val token : [ `Open_path | `Statx ] = `Statx
-val retval : int = 0
+val retval : Uring.Res.t = 0
 
 #  Uring.Statx.kind statx, Printf.sprintf "0o%o" (Uring.Statx.perm statx), (Uring.Statx.size statx);;
 - : Uring.Statx.kind * string * int64 = (`Regular_file, "0o600", 9L)
@@ -252,10 +255,7 @@ Now using `~fd`:
 # Uring.submit t;;
 - : int = 1
 
-# let token, fd =
-    let token, fd = consume t in
-    assert (fd >= 0);
-    token, (Obj.magic fd : Unix.file_descr);;
+# let token, fd = consume_fd t;;
 val token : [ `Open_path | `Statx ] = `Open_path
 val fd : Unix.file_descr = <abstr>
 
@@ -275,7 +275,7 @@ val statx : Uring.Statx.t = <abstr>
 
 # let token, retval = consume t;;
 val token : [ `Open_path | `Statx ] = `Statx
-val retval : int = 0
+val retval : Uring.Res.t = 0
 
 # Uring.Statx.kind statx, Printf.sprintf "0o%o" (Uring.Statx.perm statx), (Uring.Statx.size statx);;
 - : Uring.Statx.kind * string * int64 = (`Regular_file, "0o600", 9L)
@@ -301,14 +301,9 @@ val t : [ `Get_path ] Uring.t = <abstr>
                             path
                             `Get_path));
     traceln "Submitted %d" (Uring.submit t);
-    let `Get_path, fd = consume t in
-    if fd >= 0 then (
-      let fd : Unix.file_descr = Obj.magic fd in
-      Unix.close fd;
-      traceln "Opened %S OK" path
-    ) else (
-      raise (Unix.Unix_error (Uring.error_of_errno fd, "openat2", path))
-    );;
+    let `Get_path, fd = consume_fd t ~fn:"openat2" ~arg:path in
+    Unix.close fd;
+    traceln "Opened %S OK" path;;
 val get : resolve:Uring.Resolve.t -> string -> unit = <fun>
 
 # get ~resolve:Uring.Resolve.empty ".";;
@@ -362,7 +357,7 @@ val fd : Unix.file_descr = <abstr>
 # Uring.submit t;;
 - : int = 1
 # consume t;;
-- : [ `Read ] * int = (`Read, 5)
+- : [ `Read ] * Uring.Res.t = (`Read, 5)
 # Cstruct.of_bigarray fbuf ~off ~len |> Cstruct.to_string;;
 - : string = "test "
 
@@ -392,7 +387,7 @@ val b2 : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 7}
 # Uring.submit t;;
 - : int = 1
 # let `Read, read = consume t;;
-val read : int = 3
+val read : Uring.Res.t = 3
 # Cstruct.to_string b1;;
 - : string = "A t"
 
@@ -401,7 +396,7 @@ val read : int = 3
 # Uring.submit t;;
 - : int = 1
 # let `Read, read = consume t;;
-val read : int = 7
+val read : Uring.Res.t = 7
 # Cstruct.to_string b2;;
 - : string = "est fil"
 
@@ -428,7 +423,7 @@ val w : Unix.file_descr = <abstr>
 - : int = 1
 # let v, read = consume t;;
 val v : [ `Read | `Write ] = `Write
-val read : int = 5
+val read : Uring.Res.t = 5
 
 # Uring.read t r rb `Read ~file_offset:Int63.minus_one;;
 - : [ `Read | `Write ] Uring.job option = Some <abstr>
@@ -436,7 +431,7 @@ val read : int = 5
 - : int = 1
 # let v, read = consume t;;
 val v : [ `Read | `Write ] = `Read
-val read : int = 5
+val read : Uring.Res.t = 5
 
 # let rb = Cstruct.sub rb 0 5;;
 val rb : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 5}
@@ -471,7 +466,7 @@ val b2 : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 7}
 - : int = 1
 
 # let `Readv, read = consume t;;
-val read : int = 10
+val read : Uring.Res.t = 10
 # Cstruct.to_string b1;;
 - : string = "A t"
 # Cstruct.to_string b2;;
@@ -495,7 +490,7 @@ val b : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 25}
 # Uring.submit t;;
 - : int = 1
 # consume t;;
-- : [ `Readv ] * int = (`Readv, 7)
+- : [ `Readv ] * Uring.Res.t = (`Readv, 7)
 # Cstruct.to_string b;;
 - : string = "Gathered [A te] and [st ]"
 
@@ -524,7 +519,7 @@ val chunk : Uring.Region.chunk = <abstr>
 val fd : Unix.file_descr = <abstr>
 # Uring.read_chunk t fd chunk `Read ~file_offset:Int63.zero;;
 - : [ `Read ] Uring.job option = Some <abstr>
-# let `Read, read = consume t;;
+# let `Read, read = consume_int t;;
 val read : int = 11
 # Uring.Region.to_string ~len:read chunk;;
 - : string = "A test file"
@@ -552,8 +547,8 @@ val fd : unit = ()
 Ask to read from a pipe (with no data available), then cancel it.
 
 ```ocaml
-# exception Multiple of Unix.error list;;
-exception Multiple of Unix.error list
+# exception Multiple of Uring.Res.t list;;
+exception Multiple of Uring.Res.t list
 
 # let t : [ `Cancel | `Read ] Uring.t = Uring.create ~queue_depth:5 ();;
 val t : [ `Cancel | `Read ] Uring.t = <abstr>
@@ -579,14 +574,14 @@ val read : [ `Cancel | `Read ] Uring.job = <abstr>
     | `Cancel, `Read -> r2, r1
     | _ -> assert false
   in
-  begin match Uring.error_of_errno r_read, Uring.error_of_errno r_cancel with
-    | EINTR, EALREADY
+  begin match Uring.Res.int_result r_read, Uring.Res.int_result r_cancel with
+    | Error EINTR, Error EALREADY
       (* Occasionally, the read is actually busy just as we try to cancel.
          In that case it gets interrupted and the cancel returns EALREADY. *)
-    | EUNKNOWNERR 125 (* ECANCELLED *), EUNKNOWNERR 0 ->
+    | Error (EUNKNOWNERR 125) (* ECANCELLED *), Ok 0 ->
       (* This is the common case. The read is blocked and can just be removed. *)
       ()
-    | e1, e2 -> raise (Multiple [e1; e2])
+    | e1, e2 -> raise (Multiple [r_read; r_cancel])
   end;;
 - : unit = ()
 # let r : unit = Unix.close r;;
@@ -625,17 +620,13 @@ val read : [ `Cancel | `Read ] Uring.job = <abstr>
     | `Cancel, `Read -> r2, r1
     | _ -> assert false
   in
-  if r_read = 1 then (
-    match Uring.error_of_errno r_cancel with
-    | ENOENT -> ()
-    | e -> raise (Unix.Unix_error (e, "cancel", ""))
-  ) else (
-    match Uring.error_of_errno r_read, Uring.error_of_errno r_cancel with
-    | EUNKNOWNERR 125 (* ECANCELLED *), EUNKNOWNERR 0 ->
-      (* This isn't the case we want to test, but it can happen sometimes. *)
-      ()
-    | e1, e2 -> raise (Multiple [e1; e2])
-  );;
+  match Uring.Res.int_result r_read, Uring.Res.int_result r_cancel with
+  | Ok 1, Error ENOENT -> ()
+  | Ok 1, Error e -> raise (Unix.Unix_error (e, "cancel", ""))
+  | Error (EUNKNOWNERR 125 (* ECANCELLED *)), Ok 0 ->
+    (* This isn't the case we want to test, but it can happen sometimes. *)
+    ()
+  | _ -> raise (Multiple [r_read; r_cancel]);;
 - : unit = ()
 # let r : unit = Unix.close r;;
 val r : unit = ()
@@ -658,7 +649,7 @@ val r : Unix.file_descr = <abstr>
 val read : [ `Cancel | `Read ] Uring.job = <abstr>
 # let token, r_read = consume t;;
 val token : [ `Cancel | `Read ] = `Read
-val r_read : int = 1
+val r_read : Uring.Res.t = 1
 # let r : unit = Unix.close r;;
 val r : unit = ()
 ```
@@ -699,7 +690,7 @@ But we can once it's complete:
 # let w : unit = Unix.close w;;
 val w : unit = ()
 # consume t;;
-- : [ `Mkdir | `Read ] * int = (`Read, 0)
+- : [ `Mkdir | `Read ] * Uring.Res.t = (`Read, 0)
 # Uring.exit t;;
 - : unit = ()
 # let r : unit = Unix.close r;;
@@ -752,7 +743,7 @@ val bufs : Cstruct.t list = [{Cstruct.buffer = <abstr>; off = 0; len = 2}]
 # Uring.submit t;;
 - : int = 1
 # consume t;;
-- : [ `Recv | `Send ] * int = (`Send, 2)
+- : [ `Recv | `Send ] * Uring.Res.t = (`Send, 2)
 # let recv_buf = Cstruct.of_string "XX";;
 val recv_buf : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 2}
 # let recv = Uring.Msghdr.create ~n_fds:2 [recv_buf];;
@@ -764,7 +755,7 @@ val recv : Uring.Msghdr.t = <abstr>
 # Uring.submit t;;
 - : int = 1
 # consume t;;
-- : [ `Recv | `Send ] * int = (`Recv, 2)
+- : [ `Recv | `Send ] * Uring.Res.t = (`Recv, 2)
 # Cstruct.to_string recv_buf;;
 - : string = "hi"
 # let r2, w2 =
@@ -885,7 +876,7 @@ val v : [ `Mkdir of int ] Uring.job option = Some <abstr>
 - : int = 1
 # Uring.wait t;;
 - : [ `Mkdir of int ] Uring.completion_option =
-Uring.Some {Uring.result = -17; data = `Mkdir 1}
+Uring.Some {Uring.result = EEXIST; data = `Mkdir 1}
 # Uring.exit t;;
 - : unit = ()
 ```
@@ -906,7 +897,7 @@ val t : [ `Timeout ] Uring.t = <abstr>
 - : int = 1
 
 # let `Timeout, timeout = consume t;;
-val timeout : int = -62
+val timeout : Uring.Res.t = ETIME
 
 # let ns = 
     ((Unix.gettimeofday () +. 0.01) *. 1e9)
@@ -916,14 +907,14 @@ val timeout : int = -62
 - : [ `Timeout ] Uring.job option = Some <abstr>
 
 # let `Timeout, timeout = consume t;;
-val timeout : int = -62
+val timeout : Uring.Res.t = ETIME
 
 # let ns1 = Int64.(mul 10L 1_000_000L) in
   Uring.(timeout ~absolute:true t Boottime ns1 `Timeout);;
 - : [ `Timeout ] Uring.job option = Some <abstr>
 
 # let `Timeout, timeout = consume t;;
-val timeout : int = -62
+val timeout : Uring.Res.t = ETIME
 
 # Uring.exit t;;
 - : unit = ()

--- a/tests/poll_add.ml
+++ b/tests/poll_add.ml
@@ -13,7 +13,7 @@ let () =
   let rec retry () =
     match Uring.wait t with
     | None -> retry ()
-    | Some { result; _ } -> result
+    | Some { result; _ } -> Uring.Res.int_exn result "poll_add" ""
   in
   let res = retry () in
   Printf.eprintf "poll_add: %x\n%!" res;

--- a/tests/sketch.md
+++ b/tests/sketch.md
@@ -29,21 +29,21 @@ val b : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 1}
 - : int = 1
 
 # consume t;;
-- : unit * int = ((), 1)
+- : unit * Uring.Res.t = ((), 1)
 
 # Uring.readv t fd (ldup 7 b) () ~file_offset:Int63.zero;;
 - : unit Uring.job option = Some <abstr>
 # Uring.submit t;;
 - : int = 1
 # consume t;;
-- : unit * int = ((), 7)
+- : unit * Uring.Res.t = ((), 7)
 
 # Uring.readv t fd (ldup 1000 b) () ~file_offset:Int63.zero;;
 - : unit Uring.job option = Some <abstr>
 # Uring.submit t;;
 - : int = 1
 # consume t;;
-- : unit * int = ((), 1000)
+- : unit * Uring.Res.t = ((), 1000)
 
 # let fd : unit = Unix.close fd;;
 val fd : unit = ()

--- a/tests/socket_ops.ml
+++ b/tests/socket_ops.ml
@@ -21,14 +21,13 @@ let () =
         match Uring.wait t with
         | Uring.None -> failwith "No completion for bind"
         | Uring.Some { result; data = _ } ->
-            if result < 0 then begin
-              Uring.close t server_sock () |> ignore;
-              Uring.submit t |> ignore;
-              Uring.exit t;
-              let err = Uring.error_of_errno (-result) in
-              failwith (sprintf "Bind failed: %s" (Unix.error_message err))
-            end else
-              result
+          match Uring.Res.int_result result with
+          | Ok result -> result
+          | Error err ->
+            Uring.close t server_sock () |> ignore;
+            Uring.submit t |> ignore;
+            Uring.exit t;
+            Fmt.failwith "Bind failed: %s" (Unix.error_message err)
   in
   printf "Bind completed with result: %d\n" bind_result;
 
@@ -42,14 +41,13 @@ let () =
         match Uring.wait t with
         | Uring.None -> failwith "No completion for listen"
         | Uring.Some { result; data = _ } ->
-            if result < 0 then begin
-              Uring.close t server_sock () |> ignore;
-              Uring.submit t |> ignore;
-              Uring.exit t;
-              let err = Uring.error_of_errno (-result) in
-              failwith (sprintf "Listen failed: %s" (Unix.error_message err))
-            end else
-              result
+          match Uring.Res.int_result result with
+          | Ok result -> result
+          | Error err ->
+            Uring.close t server_sock () |> ignore;
+            Uring.submit t |> ignore;
+            Uring.exit t;
+            Fmt.failwith "Listen failed: %s" (Unix.error_message err)
   in
   printf "Listen completed with result: %d\n" listen_result;
 
@@ -71,7 +69,7 @@ let () =
 
   (* Use io_uring for connect operation *)
   let connect_addr = Unix.ADDR_INET (Unix.inet_addr_loopback, port) in
-  let connect_result =
+  begin
     match Uring.connect t client_sock connect_addr () with
     | None -> failwith "Failed to submit connect operation"
     | Some _job ->
@@ -79,22 +77,17 @@ let () =
         match Uring.wait t with
         | Uring.None -> failwith "No completion for connect"
         | Uring.Some { result; data = _ } ->
+          match Uring.Res.fd_result result with
+          | Ok _ | Error EINPROGRESS -> 
             (* Connect may return -EINPROGRESS for non-blocking sockets, which is normal *)
-            if result < 0 && result <> (-115) (* -EINPROGRESS *) then begin
-              Uring.close t client_sock () |> ignore;
-              Uring.close t server_sock () |> ignore;
-              Uring.submit t |> ignore;
-              Uring.exit t;
-              let err = Uring.error_of_errno (-result) in
-              failwith (sprintf "Connect failed: %s (errno: %d)" (Unix.error_message err) (-result))
-            end else
-              result
-  in
-
-  if connect_result = 0 || connect_result = (-115) then
-    printf "Connect initiated successfully (result: %d)\n" connect_result
-  else
-    printf "Connect completed with result: %d\n" connect_result;
+            printf "Connect initiated successfully (result: %d)\n" (result :> int)
+          | Error err ->
+            Uring.close t client_sock () |> ignore;
+            Uring.close t server_sock () |> ignore;
+            Uring.submit t |> ignore;
+            Uring.exit t;
+            Fmt.failwith "Connect failed: %s (errno: %d)" (Unix.error_message err) (-(result :> int))
+  end;
 
   (* Get the client socket's local port - Unix.getsockname is necessary for socket introspection *)
   let client_addr = Unix.getsockname client_sock in
@@ -123,8 +116,9 @@ let () =
       match Uring.wait t with
       | Uring.None -> failwith "No completion for close"
       | Uring.Some { result; data = _ } ->
-          if result < 0 then
-            printf "Close warning: %s\n" (Unix.error_message (Uring.error_of_errno (-result)));
+          Uring.Res.int_result result |> Result.iter_error (fun e ->
+            printf "Close warning: %s\n" (Unix.error_message e);
+          );
           wait_closes (pending - 1)
   in
   wait_closes 2;

--- a/tests/urcat.ml
+++ b/tests/urcat.ml
@@ -11,7 +11,7 @@ let get_file_size fd =
 let get_completion_and_print uring =
   let iov, len =
     match Uring.wait uring with
-    | Some { data; result } -> (data, result)
+    | Some { data; result } -> (data, Uring.Res.int_exn result "readv" "")
     | None -> failwith "retry"
   in
   let remaining = ref len in

--- a/tests/urcp_fixed_lib.ml
+++ b/tests/urcp_fixed_lib.ml
@@ -56,9 +56,9 @@ let eintr = -4
 (* Check that a read has completely finished, and if not
  * queue it up for completing the remaining amount *)
 let handle_read_completion uring req res =
-  Logs.debug (fun l -> l "read_completion: res=%d %a" res pp_req req);
+  Logs.debug (fun l -> l "read_completion: res=%a %a" Uring.Res.pp res pp_req req);
   let bytes_to_read = req.len - req.off in
-  match res with
+  match (res :> int) with
   | 0 ->
     Logs.debug (fun l -> l "eof %a" pp_req req);
   | n when n = eagain || n = eintr ->
@@ -86,9 +86,9 @@ let handle_read_completion uring req res =
   | n -> raise (Failure (Printf.sprintf "unexpected read result %d > %d " bytes_to_read n))
 
 let handle_write_completion uring req res =
-  Logs.debug (fun l -> l "write_completion: res=%d %a" res pp_req req);
+  Logs.debug (fun l -> l "write_completion: res=%a %a" Uring.Res.pp res pp_req req);
   let bytes_to_write = req.len - req.off in
-  match res with
+  match (res :> int) with
   | 0 -> raise End_of_file
   | n when n = eagain || n = eintr ->
     (* requeue the request *)

--- a/tests/urcp_lib.ml
+++ b/tests/urcp_lib.ml
@@ -61,9 +61,9 @@ let eintr = -4
 (* Check that a read has completely finished, and if not
  * queue it up for completing the remaining amount *)
 let handle_read_completion uring req res =
-  Logs.debug (fun l -> l "read_completion: res=%d %a" res pp_req req);
+  Logs.debug (fun l -> l "read_completion: res=%a %a" Uring.Res.pp res pp_req req);
   let bytes_to_read = req.len - req.off in
-  match res with
+  match (res :> int) with
   | 0 ->
     Logs.debug (fun l -> l "eof %a" pp_req req);
   | n when n = eagain || n = eintr ->
@@ -93,9 +93,9 @@ let handle_read_completion uring req res =
   | n -> raise (Failure (Printf.sprintf "unexpected readv result %d > %d " bytes_to_read n))
 
 let handle_write_completion uring req res =
-  Logs.debug (fun l -> l "write_completion: res=%d %a" res pp_req req);
+  Logs.debug (fun l -> l "write_completion: res=%a %a" Uring.Res.pp res pp_req req);
   let bytes_to_write = req.len - req.off in
-  match res with
+  match (res :> int) with
   | 0 -> raise End_of_file
   | n when n = eagain || n = eintr ->
     (* requeue the request *)


### PR DESCRIPTION
This is a modified version of @dra27's #129. Instead of returning `int`, uring operations now return values of type `Uring.Res.t = private int`. The `Res` module provides functions for converting to ints or FDs, as results or raising exceptions.

This means:
- You can't forget to handle errors, and handling them is now easier.
- No use of `Obj.magic` in the examples or tests.
- There's a pretty-printer for results, so the tests and top-level no longer show negative numbers for errors.

Unlike #129, there's no overhead of an extra C call and we don't provide a way of turning arbitrary ints into FDs (only the results of uring operations). Though given the design of `Unix` I still don't see why it shouldn't provide a way to do that anyway.

Unlike #130, existing code needs only minor changes (in particular, you can just cast the result to `int` and carry on as before if it's too annoying). It is now possible to get an FD from a result that wasn't supposed to be one (e.g. `read`), but that doesn't seem like a mistake anyone's likely to make.

Annoyingly, OCaml's Unix module doesn't expose a way to turn error codes into enum names, even though it does so itself as part of its exception printer, so I used `Unix.error_message` instead.