### PR TITLE
Use MSG_CMSG_CLOEXEC when receiving file descriptors

### DIFF
--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -838,7 +838,7 @@ ocaml_uring_submit_recv_msg(value v_uring, value v_id, value v_fd, value v_msghd
   msg->msg_iov = Sketch_ptr_val(v_sketch_ptr);
   msg->msg_iovlen = Sketch_ptr_len_val(v_sketch_ptr) / sizeof(struct iovec);
   dprintf("submit_recvmsg:msghdr %p: registering iobuf base %p len %lu\n", msg, msg->msg_iov[0].iov_base, msg->msg_iov[0].iov_len);
-  io_uring_prep_recvmsg(sqe, Int_val(v_fd), msg, 0);
+  io_uring_prep_recvmsg(sqe, Int_val(v_fd), msg, MSG_CMSG_CLOEXEC);
   io_uring_sqe_set_data(sqe, (void *)Long_val(v_id));
   return (Val_true);
 }


### PR DESCRIPTION
In a multi-threaded program all FDs need to be created CLOEXEC as setting it afterwards may be too late.