### PR TITLE
regen primops and make lintcstubs-arity a test depopt

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -22,6 +22,5 @@
   (cmdliner (and :with-test (>= 1.1.0)))
   (fmt (>= 0.8.10))
   (optint (>= 0.1.0))
-  (mdx (and (>= 2.1.0) :with-test)))
- (depopts
+  (mdx (and (>= 2.1.0) :with-test))
   (lintcstubs-arity :with-test)))

--- a/dune-project
+++ b/dune-project
@@ -22,4 +22,6 @@
   (cmdliner (and :with-test (>= 1.1.0)))
   (fmt (>= 0.8.10))
   (optint (>= 0.1.0))
-  (mdx (and (>= 2.1.0) :with-test))))
+  (mdx (and (>= 2.1.0) :with-test)))
+ (depopts
+  (lintcstubs-arity :with-test)))

--- a/lib/uring/primitives.h
+++ b/lib/uring/primitives.h
@@ -80,6 +80,8 @@ CAMLprim value ocaml_uring_submit_close(value, value, value);
 CAMLprim value ocaml_uring_submit_statx_native(value, value, value, value, value, value, value);
 CAMLprim value ocaml_uring_submit_statx_byte(value *, int);
 CAMLprim value ocaml_uring_submit_splice(value, value, value, value, value);
+CAMLprim value ocaml_uring_submit_bind(value, value, value, value);
+CAMLprim value ocaml_uring_submit_listen(value, value, value, value);
 CAMLprim value ocaml_uring_submit_connect(value, value, value, value);
 CAMLprim value ocaml_uring_submit_accept(value, value, value, value);
 CAMLprim value ocaml_uring_submit_cancel(value, value, value);

--- a/uring.opam
+++ b/uring.opam
@@ -20,10 +20,8 @@ depends: [
   "fmt" {>= "0.8.10"}
   "optint" {>= "0.1.0"}
   "mdx" {>= "2.1.0" & with-test}
-  "odoc" {with-doc}
-]
-depopts: [
   "lintcstubs-arity" {with-test}
+  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/uring.opam
+++ b/uring.opam
@@ -22,6 +22,9 @@ depends: [
   "mdx" {>= "2.1.0" & with-test}
   "odoc" {with-doc}
 ]
+depopts: [
+  "lintcstubs-arity" {with-test}
+]
 build: [
   ["dune" "subst"] {dev}
   [


### PR DESCRIPTION
I missed this depopt, which in turn didn't regen the primitives.h. I *think* depopts supports with-test, so this should catch future missing regenerations in CI