### PR TITLE
fix debug messages in ocaml_uring_unregister_buffers

### DIFF
--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -124,10 +124,10 @@ value ocaml_uring_register_ba(value v_uring, value v_ba) {
 value ocaml_uring_unregister_buffers(value v_uring) {
   CAMLparam1(v_uring);
   struct io_uring *ring = Ring_val(v_uring);
-  dprintf("uring %p: unregistering buffers");
+  dprintf("uring %p: unregistering buffers\n", ring);
   int ret = io_uring_unregister_buffers(ring);
   if (ret)
-    unix_error(-ret, "io_uring_register_buffers", Nothing);
+    unix_error(-ret, "io_uring_unregister_buffers", Nothing);
   CAMLreturn(Val_unit);
 }
 

--- a/lib/uring/uring_stubs.c
+++ b/lib/uring/uring_stubs.c
@@ -315,7 +315,7 @@ ocaml_uring_submit_readv(value v_uring, value v_fd, value v_id, value v_sketch_p
 
   if (sqe == NULL)
     return (Val_false);
-  dprintf("submit_readv: %d ents len[0] %lu off %d\n", len, iovs[0].iov_len, Int63_val(v_fileoff));
+  dprintf("submit_readv: %zu ents len[0] %lu off %ld\n", len, iovs[0].iov_len, Int63_val(v_fileoff));
   io_uring_prep_readv(sqe, Int_val(v_fd), iovs, len, Int63_val(v_fileoff));
   io_uring_sqe_set_data(sqe, (void *)Long_val(v_id));
   return (Val_true);
@@ -331,7 +331,7 @@ ocaml_uring_submit_writev(value v_uring, value v_fd, value v_id, value v_sketch_
 
   if (sqe == NULL)
     return (Val_false);
-  dprintf("submit_writev: %d ents len[0] %lu off %d\n", len, iovs[0].iov_len, Int63_val(v_fileoff));
+  dprintf("submit_writev: %zu ents len[0] %lu off %ld\n", len, iovs[0].iov_len, Int63_val(v_fileoff));
   io_uring_prep_writev(sqe, Int_val(v_fd), iovs, len, Int63_val(v_fileoff));
   io_uring_sqe_set_data(sqe, (void *)Long_val(v_id));
   return (Val_true);
@@ -344,7 +344,7 @@ ocaml_uring_submit_readv_fixed_native(value v_uring, value v_fd, value v_id, val
   struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
   void *buf = Caml_ba_data_val(v_ba) + Long_val(v_off);
   if (!sqe) return (Val_false);
-  dprintf("submit_readv_fixed: buf %p off %d len %d fileoff %d", buf, Int_val(v_off), Int_val(v_len), Int63_val(v_fileoff));
+  dprintf("submit_readv_fixed: buf %p off %d len %d fileoff %ld\n", buf, Int_val(v_off), Int_val(v_len), Int63_val(v_fileoff));
   io_uring_prep_read_fixed(sqe, Int_val(v_fd), buf, Int_val(v_len), Int63_val(v_fileoff), 0);
   io_uring_sqe_set_data(sqe, (void *)Long_val(v_id));
   return (Val_true);
@@ -370,7 +370,7 @@ ocaml_uring_submit_writev_fixed_native(value v_uring, value v_fd, value v_id, va
   void *buf = Caml_ba_data_val(v_ba) + Long_val(v_off);
   if (!sqe)
     return (Val_false);
-  dprintf("submit_writev_fixed: buf %p off %d len %d fileoff %d", buf, Int_val(v_off), Int_val(v_len), Int63_val(v_fileoff));
+  dprintf("submit_writev_fixed: buf %p off %d len %d fileoff %ld\n", buf, Int_val(v_off), Int_val(v_len), Int63_val(v_fileoff));
   io_uring_prep_write_fixed(sqe, Int_val(v_fd), buf, Int_val(v_len), Int63_val(v_fileoff), 0);
   io_uring_sqe_set_data(sqe, (void *)Long_val(v_id));
   return (Val_true);
@@ -397,7 +397,7 @@ ocaml_uring_submit_read(value v_uring, value v_fd, value v_id, value v_cstruct, 
   value v_len = Field(v_cstruct, 2);
   void *buf = Caml_ba_data_val(v_ba) + Long_val(v_off);
   if (!sqe) return (Val_false);
-  dprintf("submit_read: fd %d buff %p len %zd fileoff %d\n",
+  dprintf("submit_read: fd %d buff %p len %zd fileoff %ld\n",
 	  Int_val(v_fd), buf, Long_val(v_len), Int63_val(v_fileoff));
   io_uring_prep_read(sqe, Int_val(v_fd), buf, Long_val(v_len), Int63_val(v_fileoff));
   io_uring_sqe_set_data(sqe, (void *)Long_val(v_id));
@@ -413,7 +413,7 @@ ocaml_uring_submit_write(value v_uring, value v_fd, value v_id, value v_cstruct,
   value v_len = Field(v_cstruct, 2);
   void *buf = Caml_ba_data_val(v_ba) + Long_val(v_off);
   if (!sqe) return (Val_false);
-  dprintf("submit_write: fd %d buff %p len %zd fileoff %d\n",
+  dprintf("submit_write: fd %d buff %p len %zd fileoff %ld\n",
 	  Int_val(v_fd), buf, Long_val(v_len), Int63_val(v_fileoff));
   io_uring_prep_write(sqe, Int_val(v_fd), buf, Long_val(v_len), Int63_val(v_fileoff));
   io_uring_sqe_set_data(sqe, (void *)Long_val(v_id));


### PR DESCRIPTION
Missing `%p` args and wrong signage for the errno