### PR TITLE
Restore `FLAGS.t = private int`

### DIFF
--- a/lib/uring/uring.ml
+++ b/lib/uring/uring.ml
@@ -22,7 +22,7 @@ module Region = Region
 module Int63 = Optint.Int63
 
 module type FLAGS = sig
-  type t
+  type t = private int
   val empty : t
   val of_int : int -> t
   val to_int : t -> int

--- a/lib/uring/uring.mli
+++ b/lib/uring/uring.mli
@@ -25,7 +25,7 @@ module Region = Region
 
 (** Type of flags that can be combined. *)
 module type FLAGS = sig
-  type t
+  type t = private int
   (** A set of flags. *)
 
   val empty : t


### PR DESCRIPTION
Avoids breaking Eio (since https://github.com/ocaml-multicore/eio/pull/785). Now we have `to_int` we can remove this later if needed, once users have a chance to upgrade.

This reverts part of c0337991c.